### PR TITLE
Use current macOS Intel runner for binary build

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - runner: ubuntu-latest
             target: linux-x64
-          - runner: macos-13
+          - runner: macos-15-intel
             target: darwin-x64
           - runner: macos-14
             target: darwin-arm64


### PR DESCRIPTION
## Summary
- Replace the stale darwin-x64 runner label macos-13 with GitHub's current Intel macOS runner label macos-15-intel
- This unblocks the uild darwin-x64 job that was stuck queued after PR #23 merged

## Verification
- GitHub hosted runner reference lists Intel macOS standard labels as macos-15-intel / macos-26-intel
- CI and build-binaries will validate this PR