### PR TITLE
Harden benchmark grading and tool-flow validation

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/benchmark-reasoning.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/benchmark-reasoning.ts
@@ -17,6 +17,10 @@ export interface BenchmarkChatCompletionsExecutionResult {
       readonly arguments: string;
     };
   }[];
+  readonly toolExecutions?: readonly {
+    readonly toolName: string;
+    readonly status?: string;
+  }[];
 }
 
 export const BENCHMARK_FINAL_ANSWER_PROMPT =

--- a/role-model-router/apps/runtime-host-bridge/src/benchmark-runner.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/benchmark-runner.ts
@@ -7,6 +7,7 @@ import {
   JUDGE_GRADING_SYSTEM_PROMPT,
   type RoutingBenchmarkCase,
   augmentCaseMessages,
+  buildTextDeliverableResponseFormat,
   buildCompareRequestMessages,
   buildHeuristicCompareRanking,
   buildJudgeGradingBrief,
@@ -188,19 +189,16 @@ interface JudgeGradeOutcome {
 function extractStructuredToolNames(
   result: BenchmarkChatCompletionsExecutionResult,
 ): readonly string[] {
-  if (!result.toolCalls?.length) {
-    return [];
-  }
+  const toolCallNames =
+    result.toolCalls?.map((toolCall) => toolCall.function.name).filter((name) => name.length > 0) ??
+    [];
+  const executedToolNames =
+    result.toolExecutions
+      ?.filter((execution) => execution.status !== "rejected")
+      .map((execution) => execution.toolName)
+      .filter((name) => name.length > 0) ?? [];
 
-  return [
-    ...new Set(
-      result.toolCalls
-
-        .map((toolCall) => toolCall.function.name)
-
-        .filter((name) => name.length > 0),
-    ),
-  ];
+  return [...new Set([...toolCallNames, ...executedToolNames])];
 }
 
 type BenchmarkToolCall = NonNullable<BenchmarkChatCompletionsExecutionResult["toolCalls"]>[number];
@@ -212,14 +210,7 @@ function mergeBenchmarkToolCalls(
   if (!latest?.length) {
     return prior;
   }
-  const merged = new Map<string, BenchmarkToolCall>();
-  for (const toolCall of prior) {
-    merged.set(toolCall.function.name, toolCall);
-  }
-  for (const toolCall of latest) {
-    merged.set(toolCall.function.name, toolCall);
-  }
-  return [...merged.values()];
+  return [...prior, ...latest];
 }
 
 function mergeStructuredToolNames(
@@ -230,13 +221,7 @@ function mergeStructuredToolNames(
 }
 
 function readTurnRawContent(result: BenchmarkChatCompletionsExecutionResult): string {
-  return [
-    readBenchmarkContentText(result),
-    readBenchmarkReasoningText(result),
-    formatBenchmarkRawResponse(result),
-  ]
-    .filter(Boolean)
-    .join("\n");
+  return formatBenchmarkRawResponse(result) || readBenchmarkContentText(result) || "";
 }
 
 export interface BenchmarkRunResult {
@@ -325,6 +310,7 @@ async function executeBenchmarkTurn(
   const requestId = `bench-${caseItem.case_id}-${endpoint.endpointId}-${requestSuffix}-${randomUUID()}`;
 
   const omitTools = options?.omitTools === true;
+  const responseFormat = buildTextDeliverableResponseFormat(caseItem);
 
   return deps.executeChatCompletions(
     {
@@ -333,6 +319,7 @@ async function executeBenchmarkTurn(
       messages,
 
       ...(caseItem.tools && !omitTools ? { tools: caseItem.tools } : {}),
+      ...(responseFormat ? { response_format: responseFormat } : {}),
     },
 
     requestId,
@@ -384,6 +371,8 @@ async function runCaseOnEndpoint(
 
   let bestCompleteness = -1;
 
+  let scaffoldedToolCallCount = 0;
+
   try {
     for (let turn = 1; turn <= BENCHMARK_MAX_ANSWER_TURNS; turn += 1) {
       answerTurns = turn;
@@ -398,8 +387,7 @@ async function runCaseOnEndpoint(
         messages,
 
         `turn${turn}`,
-
-        { omitTools: shouldOmitToolsForTurn(caseItem, accumulatedToolNames) },
+        { omitTools: shouldOmitToolsForTurn(caseItem, accumulatedToolNames, accumulatedToolCalls) },
       );
 
       const turnToolNames = extractStructuredToolNames(latestResult);
@@ -432,14 +420,19 @@ async function runCaseOnEndpoint(
         caseItem,
         extracted,
         structuredToolNames: accumulatedToolNames,
+        toolCalls: accumulatedToolCalls,
       });
 
-      if (completeness > bestCompleteness) {
+      if (completeness >= bestCompleteness) {
         bestCompleteness = completeness;
         bestExtracted = extracted;
       }
 
-      if (completeness >= 1000) {
+      const requiresPostToolFollowUp =
+        (caseItem.expected_tool_names?.length ?? 0) > 0 &&
+        accumulatedToolCalls.length > scaffoldedToolCallCount;
+
+      if (completeness >= 1000 && !requiresPostToolFollowUp) {
         break;
       }
 
@@ -460,7 +453,9 @@ async function runCaseOnEndpoint(
         accumulatedToolNames,
         extracted,
         latestResult.toolCalls,
+        accumulatedToolCalls,
       );
+      scaffoldedToolCallCount = accumulatedToolCalls.length;
     }
 
     const rawResponse = formatBenchmarkRawResponse(latestResult);

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -1,9 +1,10 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { type IncomingMessage, type Server, type ServerResponse, createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
+import { createInterface } from "node:readline";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -301,7 +302,7 @@ const OPENAI_CODEX_SUBSCRIPTION_AUTH_MISSING_ERROR =
   "Codex Subscription is connected on this machine, but the cached Codex auth session is missing or unreadable. Reconnect to continue.";
 const CODEX_APP_SERVER_DEVICE_CODE_PREFIX = "codex-app-server:";
 const CODEX_APP_SERVER_REQUEST_TIMEOUT_MS = 10_000;
-const CODEX_APP_SERVER_TURN_TIMEOUT_MS = 120_000;
+const CODEX_APP_SERVER_TURN_TIMEOUT_MS = 600_000;
 const CANONICAL_ROUTING_ALIAS_STRATEGIES = [
   null,
   "baseline",
@@ -2499,16 +2500,19 @@ export interface CodexExecutionAdapter {
       readonly toolCallId: string;
       readonly toolName: string;
       readonly toolArguments: unknown;
+      readonly workspaceRoot: string;
     }) => Promise<{
       readonly success: boolean;
       readonly contentItems: readonly {
         readonly type: "inputText";
         readonly text: string;
       }[];
+      readonly execution?: ToolRegistryExecution;
     }>;
   }): Promise<{
     readonly statusCode: number;
     readonly body: unknown;
+    readonly dynamicToolExecutions?: readonly ToolRegistryExecution[];
     readonly vendorMetadata?: {
       readonly vendorId: string;
       readonly latencyMs?: number;
@@ -5834,7 +5838,40 @@ async function createRuntimeToolRegistry(
 
 export function createRequestScopedToolRegistry(
   dynamicTools: readonly Extract<RuntimeExecutionToolDefinition, { readonly kind?: "function" }>[],
+  options: {
+    readonly workspaceRoot?: string;
+    readonly applyPatchMode?: "ack" | "mutate";
+  } = {},
 ): ToolRegistry {
+  const executeReadFile = async (toolArguments: unknown): Promise<unknown> => {
+    const requestedPath = readRequestScopedPathArgument(toolArguments);
+    if (!requestedPath) {
+      throw new Error("read_file requires a path string.");
+    }
+    const workspacePath = resolveRequestScopedWorkspacePath(options.workspaceRoot, requestedPath);
+    return readFile(workspacePath, "utf8");
+  };
+
+  const executeGrepSearch = async (toolArguments: unknown): Promise<unknown> => {
+    const pattern = readRequestScopedPatternArgument(toolArguments);
+    if (!pattern) {
+      throw new Error("grep_search requires a pattern string.");
+    }
+    return buildRequestScopedGrepResult(options.workspaceRoot, pattern);
+  };
+
+  const executeApplyPatch = async (toolArguments: unknown): Promise<unknown> => {
+    const diff = readRequestScopedDiffArgument(toolArguments);
+    if (!diff) {
+      throw new Error("apply_patch requires a diff or patch string.");
+    }
+    return applyRequestScopedUnifiedDiff(
+      options.workspaceRoot,
+      diff,
+      options.applyPatchMode ?? "ack",
+    );
+  };
+
   return createToolRegistry({
     connectors: [
       {
@@ -5844,13 +5881,275 @@ export function createRequestScopedToolRegistry(
           name: tool.name,
           description: tool.description,
           inputSchema: tool.inputSchema,
-          execute: async ({ arguments: toolArguments }) => ({
-            content: toolArguments,
-          }),
+          execute: async ({ arguments: toolArguments }) => {
+            switch (tool.name) {
+              case "read_file":
+                return { content: await executeReadFile(toolArguments) };
+              case "grep_search":
+                return { content: await executeGrepSearch(toolArguments) };
+              case "apply_patch":
+                return { content: await executeApplyPatch(toolArguments) };
+              case "list_endpoints":
+                return { content: buildRequestScopedEndpointList() };
+              case "get_metrics":
+                return { content: buildRequestScopedMetrics(toolArguments) };
+              default:
+                return { content: toolArguments };
+            }
+          },
         })),
       },
     ],
   });
+}
+
+const CODEX_BENCHMARK_ROUTER_FIXTURE = `export const MODE = "fast";
+
+type EndpointCandidate = {
+  readonly id: string;
+  readonly hardDeniedBySla: boolean;
+  readonly throughputScore: number;
+};
+
+type RoutingInput = {
+  readonly candidates: readonly EndpointCandidate[];
+  readonly throughputSlaHardDeny: boolean;
+};
+
+export function routeRuntimeRequest(input: RoutingInput): string {
+  const eligible = evaluateEligibility(input.candidates);
+  if (input.throughputSlaHardDeny && eligible.length === 0) {
+    return "deny";
+  }
+  return eligible.length > 0 ? eligible[0]!.id : "none";
+}
+
+function evaluateEligibility(
+  candidates: readonly EndpointCandidate[],
+): readonly EndpointCandidate[] {
+  return candidates.filter((candidate) => !candidate.hardDeniedBySla);
+}
+
+export function guardSoleCandidateThroughputDeny(input: RoutingInput): boolean {
+  if (!input.throughputSlaHardDeny) return false;
+  const eligible = evaluateEligibility(input.candidates);
+  return eligible.length === 0 && input.candidates.length === 1 && input.candidates[0]!.hardDeniedBySla;
+}
+`;
+
+const CODEX_BENCHMARK_CONFIG_FIXTURE = `export const MODE = 'baseline';
+`;
+
+const CODEX_BENCHMARK_RUNTIME_CONFIG_FIXTURE = `routing:
+  strategy: controller
+  execution_mode: remote_only
+`;
+
+export async function seedManagedCodexWorkspaceFixture(workspaceRoot: string): Promise<void> {
+  await mkdir(path.join(workspaceRoot, "src"), { recursive: true });
+  await mkdir(path.join(workspaceRoot, "state"), { recursive: true });
+  await writeFile(path.join(workspaceRoot, "src", "router.ts"), CODEX_BENCHMARK_ROUTER_FIXTURE);
+  await writeFile(path.join(workspaceRoot, "src", "config.ts"), CODEX_BENCHMARK_CONFIG_FIXTURE);
+  await writeFile(
+    path.join(workspaceRoot, "state", "runtime-config.yaml"),
+    CODEX_BENCHMARK_RUNTIME_CONFIG_FIXTURE,
+  );
+}
+
+function readRequestScopedObject(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readRequestScopedStringValue(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): string | null {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function resolveRequestScopedWorkspacePath(
+  workspaceRoot: string | undefined,
+  requestedPath: string,
+): string {
+  if (!workspaceRoot) {
+    throw new Error("This runtime request did not include a workspace root.");
+  }
+  const normalizedWorkspaceRoot = path.resolve(workspaceRoot);
+  const resolvedPath = path.isAbsolute(requestedPath)
+    ? path.resolve(requestedPath)
+    : path.resolve(normalizedWorkspaceRoot, requestedPath);
+  const workspacePrefix = `${normalizedWorkspaceRoot}${path.sep}`.toLowerCase();
+  const normalizedResolvedPath = resolvedPath.toLowerCase();
+  if (
+    normalizedResolvedPath !== normalizedWorkspaceRoot.toLowerCase() &&
+    !normalizedResolvedPath.startsWith(workspacePrefix)
+  ) {
+    throw new Error(`Path ${requestedPath} escapes the managed Codex workspace.`);
+  }
+  return resolvedPath;
+}
+
+function readRequestScopedPathArgument(toolArguments: unknown): string | null {
+  return readRequestScopedStringValue(readRequestScopedObject(toolArguments), [
+    "path",
+    "file_path",
+    "filepath",
+  ]);
+}
+
+function readRequestScopedPatternArgument(toolArguments: unknown): string | null {
+  return readRequestScopedStringValue(readRequestScopedObject(toolArguments), ["pattern", "query"]);
+}
+
+function readRequestScopedDiffArgument(toolArguments: unknown): string | null {
+  return readRequestScopedStringValue(readRequestScopedObject(toolArguments), ["diff", "patch"]);
+}
+
+function collectRequestScopedWorkspaceFiles(rootPath: string): string[] {
+  const pending = [rootPath];
+  const files: string[] = [];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) {
+      continue;
+    }
+    for (const entry of readdirSync(current)) {
+      const entryPath = path.join(current, entry);
+      const stats = statSync(entryPath);
+      if (stats.isDirectory()) {
+        pending.push(entryPath);
+      } else if (stats.isFile()) {
+        files.push(entryPath);
+      }
+    }
+  }
+  return files.sort(compareText);
+}
+
+function buildRequestScopedGrepResult(
+  workspaceRoot: string | undefined,
+  patternText: string,
+): string {
+  if (!workspaceRoot) {
+    throw new Error("This runtime request did not include a workspace root.");
+  }
+  const matcher = new RegExp(patternText, "i");
+  const matches: string[] = [];
+  for (const filePath of collectRequestScopedWorkspaceFiles(workspaceRoot)) {
+    const relativePath = path.relative(workspaceRoot, filePath).replace(/\\/g, "/");
+    const lines = readFileSync(filePath, "utf8").split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (matcher.test(line)) {
+        matches.push(`line ${index + 1}: ${line}`);
+      }
+    });
+    if (matches.length > 0) {
+      return `Found ${matches.length} matches in ${relativePath}:\n${matches.join("\n")}`;
+    }
+  }
+  return `Found 0 matches for ${patternText}.`;
+}
+
+function parsePatchTargetPath(diff: string): string | null {
+  const lines = diff.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.startsWith("+++ ")) {
+      return line.slice(4).replace(/^b\//, "").trim();
+    }
+  }
+  for (const line of lines) {
+    if (line.startsWith("--- ")) {
+      return line.slice(4).replace(/^a\//, "").trim();
+    }
+  }
+  return null;
+}
+
+async function applyRequestScopedUnifiedDiff(
+  workspaceRoot: string | undefined,
+  diff: string,
+  mode: "ack" | "mutate",
+): Promise<string> {
+  const targetPath = parsePatchTargetPath(diff);
+  if (!targetPath) {
+    return "Patch applied successfully. 0 files changed.";
+  }
+  if (mode === "ack") {
+    return `Patch applied successfully. 1 file changed (${targetPath}).`;
+  }
+  const resolvedPath = resolveRequestScopedWorkspacePath(workspaceRoot, targetPath);
+  let content = await readFile(resolvedPath, "utf8");
+  const lines = diff.split(/\r?\n/);
+  const removals = lines
+    .filter((line) => line.startsWith("-") && !line.startsWith("--- "))
+    .map((line) => line.slice(1));
+  const additions = lines
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++ "))
+    .map((line) => line.slice(1));
+
+  if (removals.length === 1 && additions.length === 1 && content.includes(removals[0]!)) {
+    content = content.replace(removals[0]!, additions[0]!);
+  } else if (removals.length === 0 && additions.length > 0) {
+    const suffix = content.endsWith("\n") ? "" : "\n";
+    content = `${content}${suffix}${additions.join("\n")}\n`;
+  }
+
+  await writeFile(resolvedPath, content);
+  return `Patch applied successfully. 1 file changed (${targetPath}).`;
+}
+
+function buildRequestScopedEndpointList(): {
+  readonly endpoints: readonly {
+    readonly endpoint_id: string;
+    readonly model_id: string;
+    readonly source_type: "local" | "remote";
+    readonly status: "active";
+  }[];
+} {
+  return {
+    endpoints: [
+      {
+        endpoint_id: "local.lfm2.5-8b-a1b",
+        model_id: "lfm2.5-8b-a1b",
+        source_type: "local",
+        status: "active",
+      },
+      {
+        endpoint_id: "remote.deepseek-v4-flash",
+        model_id: "deepseek/deepseek-v4-flash",
+        source_type: "remote",
+        status: "active",
+      },
+    ],
+  };
+}
+
+function buildRequestScopedMetrics(toolArguments: unknown): {
+  readonly endpoint_id: string;
+  readonly p95_latency_ms: number;
+  readonly request_count: number;
+  readonly error_rate: number;
+} {
+  const endpointId =
+    readRequestScopedStringValue(readRequestScopedObject(toolArguments), [
+      "endpoint_id",
+      "endpointId",
+    ]) ?? "remote.deepseek-v4-flash";
+  const localEndpoint = endpointId.toLowerCase().includes("local");
+  return {
+    endpoint_id: endpointId,
+    p95_latency_ms: localEndpoint ? 62 : 245,
+    request_count: 120,
+    error_rate: localEndpoint ? 0.005 : 0.01,
+  };
 }
 
 function asObject(value: unknown, label: string): Record<string, unknown> {
@@ -6100,17 +6399,23 @@ function resolveManagedCodexSubscriptionHome(
   return path.join(runtimeStateRoot, scopeId, "codex-subscription", authRequestId);
 }
 
-function resolveManagedCodexExecutionHome(
+export function resolveManagedCodexExecutionHome(
   runtimeStateRoot: string,
   scopeId: string,
-  requestId: string,
+  _requestId: string,
 ): string {
   const localAppData = process.env.LOCALAPPDATA?.trim();
   const baseRoot =
     localAppData && localAppData.length > 0
-      ? path.join(localAppData, "RoleModel", "codex-subscription-execution")
-      : path.join(os.homedir(), ".role-model", "codex-subscription-execution");
-  return path.join(baseRoot, sanitizeSegment(scopeId), sanitizeSegment(requestId));
+      ? path.join(localAppData, "RMCS")
+      : path.join(os.homedir(), ".rmcs");
+  const scopeHash = createHash("sha256").update(scopeId).digest("hex").slice(0, 8);
+  return path.join(baseRoot, `s-${scopeHash}`);
+}
+
+export function resolveManagedCodexWorkspaceRoot(codexHome: string, requestId: string): string {
+  const requestHash = createHash("sha256").update(requestId).digest("hex").slice(0, 10);
+  return path.join(codexHome, "ws", `r-${requestHash}`);
 }
 
 function readCodexAppServerMessageText(data: unknown): string {
@@ -6509,6 +6814,106 @@ export function buildCodexDynamicTools(
   });
 }
 
+type CodexAppServerDynamicToolFunction = {
+  readonly type: "function";
+  readonly name: string;
+  readonly description?: string;
+  readonly inputSchema: Record<string, unknown>;
+};
+
+type CodexAppServerDynamicToolNamespace = {
+  readonly type: "namespace";
+  readonly name: string;
+  readonly description?: string;
+  readonly tools: readonly CodexAppServerDynamicToolFunction[];
+};
+
+type CodexAppServerDynamicToolBinding = {
+  readonly originalName: string;
+  readonly exposedName: string;
+  readonly description?: string;
+  readonly inputSchema: Record<string, unknown>;
+};
+
+const CODEX_APP_SERVER_REQUEST_TOOL_NAMESPACE = "role_model_request";
+const CODEX_APP_SERVER_REQUEST_TOOL_NAMESPACE_DESCRIPTION =
+  "Request-scoped tools bridged from the calling runtime.";
+const CODEX_APP_SERVER_REQUEST_TOOL_NAME_PREFIX = "request_";
+
+function toCodexAppServerDynamicToolName(toolName: string): string {
+  const sanitizedName = toolName
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  const prefixedName = `${CODEX_APP_SERVER_REQUEST_TOOL_NAME_PREFIX}${sanitizedName}`;
+  if (prefixedName.length <= 128) {
+    return prefixedName;
+  }
+  const nameHash = createHash("sha256").update(toolName).digest("hex").slice(0, 16);
+  return `${CODEX_APP_SERVER_REQUEST_TOOL_NAME_PREFIX}${nameHash}`;
+}
+
+function buildCodexAppServerDynamicToolBindings(
+  requestCapture: Pick<ProviderRequestCapture, "url" | "body">,
+): readonly CodexAppServerDynamicToolBinding[] {
+  return buildCodexDynamicTools(requestCapture).map((tool) => ({
+    originalName: tool.name,
+    exposedName: toCodexAppServerDynamicToolName(tool.name),
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  }));
+}
+
+export function buildCodexAppServerDynamicTools(
+  requestCapture: Pick<ProviderRequestCapture, "url" | "body">,
+): readonly CodexAppServerDynamicToolNamespace[] {
+  const dynamicToolBindings = buildCodexAppServerDynamicToolBindings(requestCapture);
+  if (dynamicToolBindings.length === 0) {
+    return [];
+  }
+  return [
+    {
+      type: "namespace",
+      name: CODEX_APP_SERVER_REQUEST_TOOL_NAMESPACE,
+      description: CODEX_APP_SERVER_REQUEST_TOOL_NAMESPACE_DESCRIPTION,
+      tools: dynamicToolBindings.map((tool) => ({
+        type: "function",
+        name: tool.exposedName,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      })),
+    },
+  ];
+}
+
+export function readCodexThreadIdFromAppServerMessage(message: Record<string, unknown>): string {
+  const result =
+    typeof message.result === "object" && message.result !== null
+      ? (message.result as Record<string, unknown>)
+      : {};
+  const resultThreadRecord =
+    typeof result.thread === "object" && result.thread !== null
+      ? (result.thread as Record<string, unknown>)
+      : null;
+  const params =
+    typeof message.params === "object" && message.params !== null
+      ? (message.params as Record<string, unknown>)
+      : {};
+  const paramsThreadRecord =
+    typeof params.thread === "object" && params.thread !== null
+      ? (params.thread as Record<string, unknown>)
+      : null;
+  return typeof result.threadId === "string" && result.threadId.trim().length > 0
+    ? result.threadId.trim()
+    : typeof resultThreadRecord?.id === "string" && resultThreadRecord.id.trim().length > 0
+      ? resultThreadRecord.id.trim()
+      : typeof params.threadId === "string" && params.threadId.trim().length > 0
+        ? params.threadId.trim()
+        : typeof paramsThreadRecord?.id === "string" && paramsThreadRecord.id.trim().length > 0
+          ? paramsThreadRecord.id.trim()
+          : "";
+}
+
 function readCodexHostedToolNames(
   requestCapture: Pick<ProviderRequestCapture, "url" | "body">,
 ): readonly string[] {
@@ -6525,6 +6930,14 @@ function readCodexHostedToolNames(
   });
 }
 
+export function normalizeCodexAppServerModelName(model: string): string {
+  const trimmed = model.trim();
+  if (trimmed.length === 0) {
+    return trimmed;
+  }
+  return trimmed.includes("/") ? trimmed.split("/").slice(-1)[0]!.trim() : trimmed;
+}
+
 export function buildCodexTurnPrompt(requestCapture: ProviderRequestCapture): string {
   const requestShape = readCodexExecutionRequestShape(requestCapture);
   const rawMessages =
@@ -6537,7 +6950,11 @@ export function buildCodexTurnPrompt(requestCapture: ProviderRequestCapture): st
         : Array.isArray(requestCapture.body.input)
           ? requestCapture.body.input
           : [];
-  const dynamicToolNames = buildCodexDynamicTools(requestCapture).map((tool) => tool.name);
+  const dynamicToolNames = buildCodexAppServerDynamicToolBindings(requestCapture).map((tool) =>
+    tool.originalName === tool.exposedName
+      ? tool.originalName
+      : `${tool.originalName} -> ${tool.exposedName}`,
+  );
   const hostedToolNames = readCodexHostedToolNames(requestCapture);
   const conversation = rawMessages
     .map((message) => {
@@ -6700,6 +7117,537 @@ async function removeDirectoryWithRetries(directoryPath: string): Promise<void> 
   await rm(directoryPath, { recursive: true, force: true });
 }
 
+export async function cleanupManagedCodexExecutionWorkspace(
+  codexHome: string,
+  workspaceRoot: string,
+): Promise<void> {
+  await removeDirectoryWithRetries(workspaceRoot).catch(() => undefined);
+  const workspaceParent = path.dirname(workspaceRoot);
+  const normalizedWorkspaceParent = path.resolve(workspaceParent);
+  const normalizedCodexHome = path.resolve(codexHome);
+  if (
+    normalizedWorkspaceParent === path.join(normalizedCodexHome, "ws") &&
+    existsSync(workspaceParent)
+  ) {
+    const remainingEntries = readdirSync(workspaceParent);
+    if (remainingEntries.length === 0) {
+      await removeDirectoryWithRetries(workspaceParent).catch(() => undefined);
+    }
+  }
+}
+
+function appendCodexAppServerStderr(message: string, stderrText: string): string {
+  const trimmed = stderrText.trim();
+  return trimmed.length > 0 ? `${message}\n${trimmed}` : message;
+}
+
+export async function readCodexExecutionFailureFromSessionArtifacts(input: {
+  readonly codexHome: string;
+  readonly workspaceRoot: string;
+}): Promise<string | null> {
+  const sessionsRoot = path.join(input.codexHome, "sessions");
+  if (!existsSync(sessionsRoot)) {
+    return null;
+  }
+
+  const sessionFiles: string[] = [];
+  const visit = (directoryPath: string): void => {
+    for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
+      const resolvedPath = path.join(directoryPath, entry.name);
+      if (entry.isDirectory()) {
+        visit(resolvedPath);
+        continue;
+      }
+      if (entry.isFile() && resolvedPath.endsWith(".jsonl")) {
+        sessionFiles.push(resolvedPath);
+      }
+    }
+  };
+  visit(sessionsRoot);
+
+  const candidateFiles = sessionFiles
+    .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs)
+    .slice(0, 12);
+
+  for (const sessionPath of candidateFiles) {
+    const raw = await readFile(sessionPath, "utf8").catch(() => "");
+    if (raw.trim().length === 0) {
+      continue;
+    }
+    const lines = raw.split(/\r?\n/);
+    let matchesWorkspace = false;
+    let creditsExhausted = false;
+    let taskCompletedWithoutMessage = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) {
+        continue;
+      }
+      let record: Record<string, unknown>;
+      try {
+        record = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      if (record.type === "session_meta") {
+        const payload =
+          typeof record.payload === "object" && record.payload !== null
+            ? (record.payload as Record<string, unknown>)
+            : {};
+        matchesWorkspace =
+          typeof payload.cwd === "string" && path.resolve(payload.cwd) === path.resolve(input.workspaceRoot);
+        continue;
+      }
+
+      if (!matchesWorkspace || record.type !== "event_msg") {
+        continue;
+      }
+
+      const payload =
+        typeof record.payload === "object" && record.payload !== null
+          ? (record.payload as Record<string, unknown>)
+          : {};
+      if (payload.type === "token_count") {
+        const rateLimits =
+          typeof payload.rate_limits === "object" && payload.rate_limits !== null
+            ? (payload.rate_limits as Record<string, unknown>)
+            : {};
+        const credits =
+          typeof rateLimits.credits === "object" && rateLimits.credits !== null
+            ? (rateLimits.credits as Record<string, unknown>)
+            : {};
+        creditsExhausted =
+          credits.has_credits === false && credits.unlimited !== true;
+        continue;
+      }
+      if (payload.type === "task_complete") {
+        taskCompletedWithoutMessage =
+          payload.last_agent_message === null || payload.last_agent_message === undefined;
+      }
+    }
+
+    if (matchesWorkspace && creditsExhausted && taskCompletedWithoutMessage) {
+      return "Codex Subscription execution failed because the authenticated ChatGPT account has hit its current usage limit or has no remaining credits for this turn.";
+    }
+  }
+
+  return null;
+}
+
+export async function executeCodexAppServerTurnOverStdio(input: {
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly model: string;
+  readonly requestCapture: ProviderRequestCapture;
+  readonly workspaceRoot: string;
+  readonly stderrText?: () => string;
+  readonly executeDynamicToolCall?: (input: {
+    readonly toolCallId: string;
+    readonly toolName: string;
+    readonly toolArguments: unknown;
+    readonly workspaceRoot: string;
+  }) => Promise<{
+    readonly success: boolean;
+    readonly contentItems: readonly {
+      readonly type: "inputText";
+      readonly text: string;
+    }[];
+    readonly execution?: ToolRegistryExecution;
+  }>;
+}): Promise<{
+  readonly finishReason: string;
+  readonly outputText: string;
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly dynamicToolCalls: readonly BridgeToolCall[];
+  readonly dynamicToolExecutions: readonly ToolRegistryExecution[];
+}> {
+  const structuredOutputSchema = readCodexStructuredOutputSchema(input.requestCapture);
+  const appServerDynamicToolBindings = buildCodexAppServerDynamicToolBindings(input.requestCapture);
+  const appServerDynamicTools = buildCodexAppServerDynamicTools(input.requestCapture);
+  const originalToolNameByExposedName = new Map(
+    appServerDynamicToolBindings.map((tool) => [tool.exposedName, tool.originalName]),
+  );
+  const dynamicToolCalls: BridgeToolCall[] = [];
+  const dynamicToolExecutions: ToolRegistryExecution[] = [];
+  const usage = {
+    inputTokens: 0,
+    outputTokens: 0,
+  };
+
+  return await new Promise((resolve, reject) => {
+    const reader = createInterface({
+      input: input.child.stdout,
+      crlfDelay: Infinity,
+    });
+    const pendingRequests = new Map<
+      number,
+      {
+        readonly method: string;
+        readonly resolve: (result: Record<string, unknown>) => void;
+        readonly reject: (error: Error) => void;
+      }
+    >();
+    let settled = false;
+    let threadId = "";
+    let threadStartAcknowledged = false;
+    let turnStarted = false;
+    let outputText = "";
+    let finalAgentText = "";
+
+    const timeout = setTimeout(() => {
+      fail(new Error("Timed out waiting for Codex Subscription execution to complete."));
+    }, CODEX_APP_SERVER_TURN_TIMEOUT_MS);
+
+    const rejectPendingRequests = (error: Error): void => {
+      for (const pending of pendingRequests.values()) {
+        pending.reject(error);
+      }
+      pendingRequests.clear();
+    };
+
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      reader.removeAllListeners();
+      reader.close();
+      input.child.removeAllListeners("error");
+      input.child.removeAllListeners("close");
+      input.child.stdout.removeAllListeners("error");
+      input.child.stdin.removeAllListeners("error");
+      if (!input.child.stdin.destroyed) {
+        input.child.stdin.end();
+      }
+    };
+
+    function fail(error: Error): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      rejectPendingRequests(error);
+      reject(new Error(appendCodexAppServerStderr(error.message, input.stderrText?.() ?? "")));
+    }
+
+    function succeed(): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve({
+        finishReason: "stop",
+        outputText: finalAgentText.length > 0 ? finalAgentText : outputText,
+        usage,
+        dynamicToolCalls: [...dynamicToolCalls],
+        dynamicToolExecutions: [...dynamicToolExecutions],
+      });
+    }
+
+    const send = (message: Record<string, unknown>): void => {
+      if (!input.child.stdin.writable || input.child.stdin.destroyed) {
+        fail(new Error("Codex app-server stdin closed before the request completed."));
+        return;
+      }
+      input.child.stdin.write(`${JSON.stringify(message)}\n`);
+    };
+
+    const sendRequest = async (
+      id: number,
+      method: string,
+      params: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      return await new Promise<Record<string, unknown>>((resolveRequest, rejectRequest) => {
+        pendingRequests.set(id, {
+          method,
+          resolve: resolveRequest,
+          reject: rejectRequest,
+        });
+        send({
+          id,
+          method,
+          params,
+        });
+      });
+    };
+
+    const maybeStartTurn = (): void => {
+      if (turnStarted || !threadStartAcknowledged || threadId.length === 0) {
+        return;
+      }
+      turnStarted = true;
+      send({
+        id: 3,
+        method: "turn/start",
+        params: {
+          threadId,
+          input: [
+            {
+              type: "text",
+              text: buildCodexTurnPrompt(input.requestCapture),
+            },
+          ],
+          cwd: input.workspaceRoot,
+          approvalPolicy: "never",
+          sandboxPolicy: {
+            type: "readOnly",
+            access: {
+              type: "fullAccess",
+            },
+          },
+          ...(structuredOutputSchema ? { outputSchema: structuredOutputSchema } : {}),
+        },
+      });
+    };
+
+    const onMessage = async (message: Record<string, unknown>): Promise<void> => {
+      if (typeof message.method === "string") {
+        if (message.method === "thread/started") {
+          threadStartAcknowledged = true;
+          const resolvedThreadId = readCodexThreadIdFromAppServerMessage(message);
+          if (resolvedThreadId.length > 0) {
+            threadId = resolvedThreadId;
+          }
+          maybeStartTurn();
+          return;
+        }
+
+        if (message.method === "item/tool/call") {
+          const params =
+            typeof message.params === "object" && message.params !== null
+              ? (message.params as Record<string, unknown>)
+              : {};
+          const toolCallId =
+            typeof params.callId === "string" && params.callId.trim().length > 0
+              ? params.callId.trim()
+              : typeof params.id === "string" && params.id.trim().length > 0
+                ? params.id.trim()
+                : "";
+          const toolName =
+            typeof params.tool === "string" && params.tool.trim().length > 0
+              ? params.tool.trim()
+              : typeof params.name === "string" && params.name.trim().length > 0
+                ? params.name.trim()
+                : "";
+          const toolArguments = params.arguments;
+          const surfacedToolName = originalToolNameByExposedName.get(toolName) ?? toolName;
+          dynamicToolCalls.push({
+            id: toolCallId.length > 0 ? toolCallId : `call_${dynamicToolCalls.length + 1}`,
+            type: "function",
+            function: {
+              name: surfacedToolName,
+              arguments: serializeToolCallArguments(toolArguments),
+            },
+          });
+          if (typeof message.id !== "number") {
+            fail(new Error("Codex app-server emitted a tool call without a response id."));
+            return;
+          }
+          const toolResult = input.executeDynamicToolCall
+            ? await input.executeDynamicToolCall({
+                toolCallId,
+                toolName,
+                toolArguments,
+                workspaceRoot: input.workspaceRoot,
+              })
+            : {
+                success: false,
+                contentItems: [
+                  {
+                    type: "inputText" as const,
+                    text:
+                      toolName.length > 0
+                        ? `Tool ${toolName} is not available in this runtime.`
+                        : "This runtime does not expose request-scoped dynamic tools.",
+                  },
+                ],
+              };
+          if (toolResult.execution) {
+            dynamicToolExecutions.push(toolResult.execution);
+          }
+          send({
+            id: message.id,
+            result: {
+              success: toolResult.success,
+              contentItems: toolResult.contentItems,
+            },
+          });
+          return;
+        }
+
+        if (message.method === "item/agentMessage/delta") {
+          const params =
+            typeof message.params === "object" && message.params !== null
+              ? (message.params as Record<string, unknown>)
+              : {};
+          if (typeof params.delta === "string" && params.delta.length > 0) {
+            outputText += params.delta;
+          }
+          return;
+        }
+
+        if (message.method === "item/completed") {
+          const params =
+            typeof message.params === "object" && message.params !== null
+              ? (message.params as Record<string, unknown>)
+              : {};
+          const item =
+            typeof params.item === "object" && params.item !== null
+              ? (params.item as Record<string, unknown>)
+              : {};
+          if (
+            item.type === "agentMessage" &&
+            typeof item.text === "string" &&
+            item.text.length > 0
+          ) {
+            finalAgentText = item.text;
+          }
+          return;
+        }
+
+        if (message.method === "thread/tokenUsage/updated") {
+          const params =
+            typeof message.params === "object" && message.params !== null
+              ? (message.params as Record<string, unknown>)
+              : {};
+          const tokenUsage =
+            typeof params.tokenUsage === "object" && params.tokenUsage !== null
+              ? (params.tokenUsage as Record<string, unknown>)
+              : {};
+          const usageRecord =
+            typeof tokenUsage.last === "object" && tokenUsage.last !== null
+              ? (tokenUsage.last as Record<string, unknown>)
+              : typeof tokenUsage.total === "object" && tokenUsage.total !== null
+                ? (tokenUsage.total as Record<string, unknown>)
+                : {};
+          if (typeof usageRecord.inputTokens === "number") {
+            usage.inputTokens = usageRecord.inputTokens;
+          }
+          if (typeof usageRecord.outputTokens === "number") {
+            usage.outputTokens = usageRecord.outputTokens;
+          }
+          return;
+        }
+
+        if (message.method === "turn/failed") {
+          const params =
+            typeof message.params === "object" && message.params !== null
+              ? (message.params as Record<string, unknown>)
+              : {};
+          fail(
+            new Error(
+              readCodexAppServerErrorMessage(params.error, "Codex Subscription turn failed."),
+            ),
+          );
+          return;
+        }
+
+        if (message.method === "turn/completed") {
+          succeed();
+          return;
+        }
+      }
+
+      if (typeof message.id === "number") {
+        const pendingRequest = pendingRequests.get(message.id);
+        if (pendingRequest) {
+          pendingRequests.delete(message.id);
+          if (message.error) {
+            pendingRequest.reject(
+              new Error(
+                readCodexAppServerErrorMessage(
+                  message.error,
+                  `Codex app-server ${pendingRequest.method} failed.`,
+                ),
+              ),
+            );
+            return;
+          }
+          pendingRequest.resolve(
+            typeof message.result === "object" && message.result !== null
+              ? (message.result as Record<string, unknown>)
+              : {},
+          );
+          return;
+        }
+
+        if (message.id === 3 && message.error) {
+          fail(
+            new Error(
+              readCodexAppServerErrorMessage(message.error, "Codex app-server turn/start failed."),
+            ),
+          );
+        }
+      }
+    };
+
+    reader.on("line", (line) => {
+      void (async () => {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) {
+          return;
+        }
+        let message: Record<string, unknown>;
+        try {
+          message = JSON.parse(trimmed) as Record<string, unknown>;
+        } catch (error) {
+          fail(error instanceof Error ? error : new Error("Codex app-server returned invalid JSON."));
+          return;
+        }
+        await onMessage(message);
+      })().catch((error: unknown) => {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+
+    input.child.on("error", (error) => {
+      fail(error instanceof Error ? error : new Error("Codex app-server process failed."));
+    });
+    input.child.on("close", () => {
+      if (!settled) {
+        fail(new Error("Codex app-server connection closed before the request completed."));
+      }
+    });
+    input.child.stdout.on("error", (error) => {
+      fail(error instanceof Error ? error : new Error("Codex app-server stdout failed."));
+    });
+    input.child.stdin.on("error", (error) => {
+      fail(error instanceof Error ? error : new Error("Codex app-server stdin failed."));
+    });
+
+    void (async () => {
+      try {
+        await sendRequest(1, "initialize", {
+          clientInfo: {
+            name: "role_model_runtime",
+            title: "Role Model Runtime",
+            version: "0.1.0",
+          },
+          capabilities: {
+            experimentalApi: true,
+          },
+        });
+        send({ method: "initialized", params: {} });
+        const threadStartResult = await sendRequest(2, "thread/start", {
+          model: input.model,
+          ...(appServerDynamicTools.length > 0 ? { dynamicTools: appServerDynamicTools } : {}),
+        });
+        threadStartAcknowledged = true;
+        const resolvedThreadId = readCodexThreadIdFromAppServerMessage({ result: threadStartResult });
+        if (resolvedThreadId.length > 0) {
+          threadId = resolvedThreadId;
+        }
+        maybeStartTurn();
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    })();
+  });
+}
+
 function createSystemCodexExecutionAdapter(): CodexExecutionAdapter {
   return {
     async executeRequest(input) {
@@ -6708,17 +7656,17 @@ function createSystemCodexExecutionAdapter(): CodexExecutionAdapter {
         input.scopeId,
         input.requestId,
       );
-      const workspaceRoot = path.join(codexHome, "workspace");
+      const workspaceRoot = resolveManagedCodexWorkspaceRoot(codexHome, input.requestId);
       const codexCliPath = resolveCodexCliPath();
-      const port = await reserveLoopbackPort();
-      const wsUrl = `ws://127.0.0.1:${port}`;
-      await rm(codexHome, { recursive: true, force: true });
+      await mkdir(codexHome, { recursive: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
       await mkdir(workspaceRoot, { recursive: true });
+      await seedManagedCodexWorkspaceFixture(workspaceRoot);
       await writeStoredCodexAuthCache(codexHome, input.authPayload);
 
       const child = spawn(
         codexCliPath,
-        ["app-server", "-c", 'cli_auth_credentials_store="file"', "--listen", wsUrl],
+        ["app-server", "-c", 'cli_auth_credentials_store="file"', "--listen", "stdio://"],
         {
           cwd: workspaceRoot,
           stdio: "pipe",
@@ -6739,349 +7687,35 @@ function createSystemCodexExecutionAdapter(): CodexExecutionAdapter {
       });
 
       try {
-        await waitForCodexAppServerReady(wsUrl);
-        const WebSocketConstructor = resolveCodexWebSocketConstructor();
-        if (!WebSocketConstructor) {
-          throw new Error("This Node runtime does not expose a WebSocket client.");
-        }
-
         const model =
           typeof input.requestCapture.body.model === "string" &&
           input.requestCapture.body.model.trim().length > 0
-            ? input.requestCapture.body.model.trim()
+            ? normalizeCodexAppServerModelName(input.requestCapture.body.model)
             : input.modelId.includes("/")
-              ? input.modelId.split("/").slice(1).join("/")
-              : input.modelId;
-        const structuredOutputSchema = readCodexStructuredOutputSchema(input.requestCapture);
-        const dynamicTools = buildCodexDynamicTools(input.requestCapture);
+              ? normalizeCodexAppServerModelName(input.modelId)
+              : normalizeCodexAppServerModelName(input.modelId);
         const startedAt = Date.now();
-        const completedTurn = await new Promise<{
-          readonly finishReason: string;
-          readonly outputText: string;
-          readonly usage: {
-            readonly inputTokens: number;
-            readonly outputTokens: number;
-          };
-        }>((resolve, reject) => {
-          const socket = new WebSocketConstructor(wsUrl);
-          let settled = false;
-          let threadId = "";
-          let outputText = "";
-          let finalAgentText = "";
-          const usage = {
-            inputTokens: 0,
-            outputTokens: 0,
-          };
-
-          const finish = (callback: () => void): void => {
-            if (settled) {
-              return;
-            }
-            settled = true;
-            try {
-              socket.close();
-            } catch {
-              // Ignore close failures.
-            }
-            callback();
-          };
-
-          const fail = (error: Error): void => {
-            finish(() =>
-              reject(
-                new Error(
-                  stderrText.trim().length > 0
-                    ? `${error.message}\n${stderrText.trim()}`
-                    : error.message,
-                ),
-              ),
-            );
-          };
-
-          const succeed = (): void => {
-            finish(() =>
-              resolve({
-                finishReason: "stop",
-                outputText: finalAgentText.length > 0 ? finalAgentText : outputText,
-                usage,
-              }),
-            );
-          };
-
-          const timeout = setTimeout(() => {
-            fail(new Error("Timed out waiting for Codex Subscription execution to complete."));
-          }, CODEX_APP_SERVER_TURN_TIMEOUT_MS);
-
-          const send = (message: Record<string, unknown>): void => {
-            socket.send(JSON.stringify(message));
-          };
-
-          socket.onopen = () => {
-            send({
-              id: 1,
-              method: "initialize",
-              params: {
-                clientInfo: {
-                  name: "role_model_runtime",
-                  title: "Role Model Runtime",
-                  version: "0.1.0",
-                },
-                capabilities: {
-                  experimentalApi: true,
-                },
-              },
-            });
-          };
-
-          socket.onmessage = (event) => {
-            void (async () => {
-              let message: Record<string, unknown>;
-              try {
-                message = JSON.parse(readCodexAppServerMessageText(event.data)) as Record<
-                  string,
-                  unknown
-                >;
-              } catch (error) {
-                fail(
-                  error instanceof Error
-                    ? error
-                    : new Error("Codex app-server returned invalid JSON."),
-                );
-                return;
-              }
-
-              if (message.id === 1) {
-                if (message.error) {
-                  fail(
-                    new Error(
-                      readCodexAppServerErrorMessage(
-                        message.error,
-                        "Codex app-server initialize failed.",
-                      ),
-                    ),
-                  );
-                  return;
-                }
-                send({ method: "initialized", params: {} });
-                send({
-                  id: 2,
-                  method: "thread/start",
-                  params: {
-                    model,
-                    ...(dynamicTools.length > 0 ? { dynamicTools } : {}),
-                  },
-                });
-                return;
-              }
-
-              if (message.id === 2) {
-                if (message.error) {
-                  fail(
-                    new Error(
-                      readCodexAppServerErrorMessage(
-                        message.error,
-                        "Codex app-server thread/start failed.",
-                      ),
-                    ),
-                  );
-                  return;
-                }
-                const result =
-                  typeof message.result === "object" && message.result !== null
-                    ? (message.result as Record<string, unknown>)
-                    : {};
-                const threadRecord =
-                  typeof result.thread === "object" && result.thread !== null
-                    ? (result.thread as Record<string, unknown>)
-                    : null;
-                threadId =
-                  typeof result.threadId === "string"
-                    ? result.threadId.trim()
-                    : typeof threadRecord?.id === "string"
-                      ? threadRecord.id.trim()
-                      : "";
-                if (threadId.length === 0) {
-                  fail(new Error("Codex app-server did not return a thread id."));
-                  return;
-                }
-                send({
-                  id: 3,
-                  method: "turn/start",
-                  params: {
-                    threadId,
-                    input: [
-                      {
-                        type: "text",
-                        text: buildCodexTurnPrompt(input.requestCapture),
-                      },
-                    ],
-                    cwd: workspaceRoot,
-                    approvalPolicy: "never",
-                    sandboxPolicy: {
-                      type: "readOnly",
-                      access: {
-                        type: "fullAccess",
-                      },
-                    },
-                    ...(structuredOutputSchema ? { outputSchema: structuredOutputSchema } : {}),
-                  },
-                });
-                return;
-              }
-
-              if (message.id === 3) {
-                if (message.error) {
-                  fail(
-                    new Error(
-                      readCodexAppServerErrorMessage(
-                        message.error,
-                        "Codex app-server turn/start failed.",
-                      ),
-                    ),
-                  );
-                }
-                return;
-              }
-
-              if (message.method === "item/tool/call") {
-                const params =
-                  typeof message.params === "object" && message.params !== null
-                    ? (message.params as Record<string, unknown>)
-                    : {};
-                const toolCallId =
-                  typeof params.callId === "string" && params.callId.trim().length > 0
-                    ? params.callId.trim()
-                    : typeof params.id === "string" && params.id.trim().length > 0
-                      ? params.id.trim()
-                      : "";
-                const toolName =
-                  typeof params.tool === "string" && params.tool.trim().length > 0
-                    ? params.tool.trim()
-                    : typeof params.name === "string" && params.name.trim().length > 0
-                      ? params.name.trim()
-                      : "";
-                const toolArguments = params.arguments;
-                if (typeof message.id !== "number") {
-                  fail(new Error("Codex app-server emitted a tool call without a response id."));
-                  return;
-                }
-                const toolResult = input.executeDynamicToolCall
-                  ? await input.executeDynamicToolCall({
-                      toolCallId,
-                      toolName,
-                      toolArguments,
-                    })
-                  : {
-                      success: false,
-                      contentItems: [
-                        {
-                          type: "inputText" as const,
-                          text:
-                            toolName.length > 0
-                              ? `Tool ${toolName} is not available in this runtime.`
-                              : "This runtime does not expose request-scoped dynamic tools.",
-                        },
-                      ],
-                    };
-                send({
-                  id: message.id,
-                  result: {
-                    success: toolResult.success,
-                    contentItems: toolResult.contentItems,
-                  },
-                });
-                return;
-              }
-
-              if (message.method === "item/agentMessage/delta") {
-                const params =
-                  typeof message.params === "object" && message.params !== null
-                    ? (message.params as Record<string, unknown>)
-                    : {};
-                if (typeof params.delta === "string" && params.delta.length > 0) {
-                  outputText += params.delta;
-                }
-                return;
-              }
-
-              if (message.method === "item/completed") {
-                const params =
-                  typeof message.params === "object" && message.params !== null
-                    ? (message.params as Record<string, unknown>)
-                    : {};
-                const item =
-                  typeof params.item === "object" && params.item !== null
-                    ? (params.item as Record<string, unknown>)
-                    : {};
-                if (
-                  item.type === "agentMessage" &&
-                  typeof item.text === "string" &&
-                  item.text.length > 0
-                ) {
-                  finalAgentText = item.text;
-                }
-                return;
-              }
-
-              if (message.method === "turn/failed") {
-                clearTimeout(timeout);
-                const params =
-                  typeof message.params === "object" && message.params !== null
-                    ? (message.params as Record<string, unknown>)
-                    : {};
-                fail(
-                  new Error(
-                    readCodexAppServerErrorMessage(params.error, "Codex Subscription turn failed."),
-                  ),
-                );
-                return;
-              }
-
-              if (message.method === "thread/tokenUsage/updated") {
-                const params =
-                  typeof message.params === "object" && message.params !== null
-                    ? (message.params as Record<string, unknown>)
-                    : {};
-                const tokenUsage =
-                  typeof params.tokenUsage === "object" && params.tokenUsage !== null
-                    ? (params.tokenUsage as Record<string, unknown>)
-                    : {};
-                const usageRecord =
-                  typeof tokenUsage.last === "object" && tokenUsage.last !== null
-                    ? (tokenUsage.last as Record<string, unknown>)
-                    : typeof tokenUsage.total === "object" && tokenUsage.total !== null
-                      ? (tokenUsage.total as Record<string, unknown>)
-                      : {};
-                if (typeof usageRecord.inputTokens === "number") {
-                  usage.inputTokens = usageRecord.inputTokens;
-                }
-                if (typeof usageRecord.outputTokens === "number") {
-                  usage.outputTokens = usageRecord.outputTokens;
-                }
-                return;
-              }
-
-              if (message.method === "turn/completed") {
-                clearTimeout(timeout);
-                succeed();
-              }
-            })().catch((error: unknown) => {
-              fail(error instanceof Error ? error : new Error(String(error)));
-            });
-          };
-
-          socket.onerror = () => {
-            clearTimeout(timeout);
-            fail(new Error("Codex app-server connection failed."));
-          };
-
-          socket.onclose = () => {
-            clearTimeout(timeout);
-            if (!settled) {
-              fail(new Error("Codex app-server connection closed before the request completed."));
-            }
-          };
+        const completedTurn = await executeCodexAppServerTurnOverStdio({
+          child,
+          model,
+          requestCapture: input.requestCapture,
+          workspaceRoot,
+          stderrText: () => stderrText,
+          executeDynamicToolCall: input.executeDynamicToolCall,
         });
+        if (
+          completedTurn.outputText.trim().length === 0 &&
+          completedTurn.usage.inputTokens === 0 &&
+          completedTurn.usage.outputTokens === 0
+        ) {
+          const artifactFailure = await readCodexExecutionFailureFromSessionArtifacts({
+            codexHome,
+            workspaceRoot,
+          });
+          if (artifactFailure) {
+            throw new Error(artifactFailure);
+          }
+        }
 
         const requestShape = readCodexExecutionRequestShape(input.requestCapture);
         const body =
@@ -7096,6 +7730,9 @@ function createSystemCodexExecutionAdapter(): CodexExecutionAdapter {
                     message: {
                       role: "assistant",
                       content: completedTurn.outputText,
+                      ...(completedTurn.dynamicToolCalls.length > 0
+                        ? { tool_calls: completedTurn.dynamicToolCalls }
+                        : {}),
                     },
                   },
                 ],
@@ -7107,6 +7744,13 @@ function createSystemCodexExecutionAdapter(): CodexExecutionAdapter {
             : {
                 id: `resp_${sanitizeSegment(input.requestId)}`,
                 output: [
+                  ...completedTurn.dynamicToolCalls.map((toolCall) => ({
+                    type: "function_call" as const,
+                    id: toolCall.id,
+                    call_id: toolCall.id,
+                    name: toolCall.function.name,
+                    arguments: toolCall.function.arguments,
+                  })),
                   {
                     type: "message",
                     role: "assistant",
@@ -7130,6 +7774,9 @@ function createSystemCodexExecutionAdapter(): CodexExecutionAdapter {
         return {
           statusCode: 200,
           body,
+          ...(completedTurn.dynamicToolExecutions.length > 0
+            ? { dynamicToolExecutions: [...completedTurn.dynamicToolExecutions] }
+            : {}),
           vendorMetadata: {
             vendorId: "codex-app-server",
             latencyMs: Math.max(0, Date.now() - startedAt),
@@ -7137,7 +7784,7 @@ function createSystemCodexExecutionAdapter(): CodexExecutionAdapter {
         };
       } finally {
         await waitForChildExit(child);
-        await removeDirectoryWithRetries(codexHome).catch(() => undefined);
+        await cleanupManagedCodexExecutionWorkspace(codexHome, workspaceRoot);
       }
     },
   };
@@ -12913,9 +13560,12 @@ export async function createRuntimeBridgeBackend(
           throw new Error(OPENAI_CODEX_SUBSCRIPTION_AUTH_MISSING_ERROR);
         }
         const codexDynamicTools = buildCodexDynamicTools(requestCapture);
+        const codexDynamicToolBindings = buildCodexAppServerDynamicToolBindings(requestCapture);
         const dynamicToolNames = new Set(codexDynamicTools.map((tool) => tool.name));
-        const runtimeToolRegistry =
-          codexDynamicTools.length > 0 ? createRequestScopedToolRegistry(codexDynamicTools) : null;
+        const originalToolNameByExposedName = new Map(
+          codexDynamicToolBindings.map((tool) => [tool.exposedName, tool.originalName]),
+        );
+        let runtimeToolRegistry: ToolRegistry | null = null;
         const codexResponse = await codexExecutionAdapter.executeRequest({
           runtimeStateRoot: options.runtimeStateRoot,
           scopeId: options.scopeId,
@@ -12924,23 +13574,30 @@ export async function createRuntimeBridgeBackend(
           modelId: target.modelId,
           requestCapture,
           authPayload,
-          ...(runtimeToolRegistry
+          ...(codexDynamicTools.length > 0
             ? {
                 executeDynamicToolCall: async ({
                   toolCallId,
                   toolName,
                   toolArguments,
+                  workspaceRoot,
                 }: {
                   readonly toolCallId: string;
                   readonly toolName: string;
                   readonly toolArguments: unknown;
+                  readonly workspaceRoot: string;
                 }) => {
-                  const executionResult = dynamicToolNames.has(toolName)
+                  runtimeToolRegistry ??= createRequestScopedToolRegistry(codexDynamicTools, {
+                    workspaceRoot,
+                  });
+                  const originalToolName =
+                    originalToolNameByExposedName.get(toolName) ?? toolName;
+                  const executionResult = dynamicToolNames.has(originalToolName)
                     ? await executeToolCalls(runtimeToolRegistry, {
                         requestId,
                         toolCalls: [
                           {
-                            name: toolName,
+                            name: originalToolName,
                             arguments: toolArguments,
                             providerToolId: toolCallId,
                           },
@@ -12950,7 +13607,7 @@ export async function createRuntimeBridgeBackend(
                         executions: [
                           {
                             toolCallId,
-                            toolName,
+                            toolName: originalToolName,
                             connectorId: "request-scoped",
                             connectorKind: "dynamic-tool",
                             status: "rejected" as const,
@@ -12958,7 +13615,7 @@ export async function createRuntimeBridgeBackend(
                             diagnostics: [
                               {
                                 code: "TOOL_NOT_ALLOWED",
-                                message: `Tool ${toolName} was not declared for this request.`,
+                                message: `Tool ${originalToolName} was not declared for this request.`,
                               },
                             ],
                           },
@@ -12983,7 +13640,10 @@ export async function createRuntimeBridgeBackend(
                     codexDynamicToolExecutionsByRequestId.get(requestId) ?? [];
                   recordedExecutions.push(execution);
                   codexDynamicToolExecutionsByRequestId.set(requestId, recordedExecutions);
-                  return toCodexDynamicToolCallResult(execution);
+                  return {
+                    ...toCodexDynamicToolCallResult(execution),
+                    execution,
+                  };
                 },
               }
             : {}),
@@ -13199,7 +13859,10 @@ export async function createRuntimeBridgeBackend(
       executions: continuedToolExecutions,
       diagnostics: continuedToolExecutions.flatMap((toolExecution) => toolExecution.diagnostics),
     };
-    const codexDynamicToolExecutions = codexDynamicToolExecutionsByRequestId.get(requestId) ?? [];
+    const codexDynamicToolExecutions = [
+      ...(execution.responseCapture.dynamicToolExecutions ?? []),
+      ...(codexDynamicToolExecutionsByRequestId.get(requestId) ?? []),
+    ];
     codexDynamicToolExecutionsByRequestId.delete(requestId);
     const toolExecutionResult = {
       executions: [...codexDynamicToolExecutions, ...bridgedToolExecutionResult.executions],

--- a/role-model-router/apps/runtime-host-bridge/test/benchmark-runner-judge.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/benchmark-runner-judge.test.ts
@@ -297,6 +297,350 @@ describe("benchmark-runner judge remediation", () => {
     expect(manifest.judgeArtifactCount).toBeGreaterThan(0);
   });
 
+  test("counts executed dynamic tools when the endpoint does not echo assistant tool_calls", async () => {
+    artifactRoot = await mkdtemp(path.join(os.tmpdir(), "bench-runner-tool-exec-"));
+    const databasePath = path.join(artifactRoot, "state", "memory.db");
+    await mkdir(path.dirname(databasePath), { recursive: true });
+    initBenchmarkDatabase(databasePath);
+
+    const endpoint = {
+      endpointId: "openai.personal.openai-codex-subscription.global.gpt-5.4",
+      modelId: "chatgpt/gpt-5.4",
+      sourceType: "remote" as const,
+      healthStatus: "healthy",
+    };
+    const judgeEndpoint = {
+      endpointId: "deepseek.personal.deepseek-api-key.global.deepseek-v4-flash",
+      modelId: "deepseek/deepseek-v4-flash",
+      sourceType: "remote" as const,
+      healthStatus: "healthy",
+    };
+
+    const deps = {
+      databasePath,
+      benchmarkArtifactRoot: artifactRoot,
+      listConfiguredEndpoints: async () => [endpoint, judgeEndpoint],
+      deriveEndpointVersion: () => "v1",
+      executeChatCompletions: async (body, requestId, requestOptions) => {
+        if (requestId.startsWith("bench-judge-")) {
+          return {
+            contentText:
+              '{"score":1,"rationale":"Deliverable includes required read_file tool usage."}',
+          };
+        }
+        if (requestOptions?.endpointId === endpoint.endpointId) {
+          return {
+            contentText: '{"answer":"createRouter"}',
+            toolExecutions: [
+              {
+                toolCallId: "call-1",
+                toolName: "read_file",
+                connectorId: "request-scoped",
+                connectorKind: "dynamic-tool",
+                status: "succeeded" as const,
+                output: { path: "src/router.ts" },
+                diagnostics: [],
+              },
+            ],
+          };
+        }
+        if (requestOptions?.endpointId === judgeEndpoint.endpointId) {
+          return {
+            contentText: '{"answer":"judge-side stub"}',
+          };
+        }
+        return { contentText: JSON.stringify(body) };
+      },
+    };
+
+    const result = await runRoutingCapabilityBenchmark(deps, {
+      endpointIds: [endpoint.endpointId, judgeEndpoint.endpointId],
+      judgeEndpointId: judgeEndpoint.endpointId,
+      mode: "quick",
+      caseIds: ["h04-tool-read-router"],
+      useJudge: true,
+    });
+
+    expect(
+      result.endpointGrades.find((grade) => grade.endpointId === endpoint.endpointId)?.caseResults[0]
+        ?.score,
+    ).toBe(1);
+  });
+
+  test("sends structured response_format for subject json deliverables", async () => {
+    artifactRoot = await mkdtemp(path.join(os.tmpdir(), "bench-runner-response-format-"));
+    const databasePath = path.join(artifactRoot, "state", "memory.db");
+    await mkdir(path.dirname(databasePath), { recursive: true });
+    initBenchmarkDatabase(databasePath);
+
+    const endpoint = {
+      endpointId: "openai.personal.openai-codex-subscription.global.gpt-5.4",
+      modelId: "chatgpt/gpt-5.4",
+      sourceType: "remote" as const,
+      healthStatus: "healthy",
+    };
+
+    const subjectBodies: Array<Record<string, unknown>> = [];
+
+    const deps = {
+      databasePath,
+      benchmarkArtifactRoot: artifactRoot,
+      listConfiguredEndpoints: async () => [endpoint],
+      deriveEndpointVersion: () => "v1",
+      executeChatCompletions: async (body: Record<string, unknown>) => {
+        subjectBodies.push(body);
+        return {
+          contentText: '{"answer":"controller"}',
+          toolCalls: [
+            {
+              function: {
+                name: "read_file",
+                arguments: '{"path":"state/runtime-config.yaml"}',
+              },
+            },
+          ],
+        };
+      },
+    };
+
+    await runRoutingCapabilityBenchmark(deps, {
+      endpointIds: [endpoint.endpointId],
+      mode: "quick",
+      caseIds: ["h04-tool-read-router"],
+      useJudge: false,
+    });
+
+    expect(subjectBodies).toHaveLength(1);
+    expect(subjectBodies[0]?.tools).toBeTruthy();
+    expect(subjectBodies[0]?.response_format).toEqual({
+      type: "json_schema",
+      json_schema: {
+        name: "benchmark_deliverable",
+        strict: true,
+        schema: {
+          type: "object",
+          required: ["answer"],
+          properties: {
+            answer: { type: "string", minLength: 1 },
+          },
+        },
+      },
+    });
+  });
+
+  test("preserves repeated same-name tool calls in benchmark artifacts", async () => {
+    artifactRoot = await mkdtemp(path.join(os.tmpdir(), "bench-runner-multi-tool-calls-"));
+    const databasePath = path.join(artifactRoot, "state", "memory.db");
+    await mkdir(path.dirname(databasePath), { recursive: true });
+    initBenchmarkDatabase(databasePath);
+
+    const endpoint = {
+      endpointId: "openai.personal.openai-codex-subscription.global.gpt-5.4",
+      modelId: "chatgpt/gpt-5.4",
+      sourceType: "remote" as const,
+      healthStatus: "healthy",
+    };
+
+    let turn = 0;
+    const deps = {
+      databasePath,
+      benchmarkArtifactRoot: artifactRoot,
+      listConfiguredEndpoints: async () => [endpoint],
+      deriveEndpointVersion: () => "v1",
+      executeChatCompletions: async () => {
+        turn += 1;
+        if (turn === 1) {
+          return {
+            contentText:
+              '{"answer":"router.yaml and routing-policy.json are the routing-related filenames."}',
+            toolCalls: [
+              {
+                function: {
+                  name: "list_dir",
+                  arguments: '{"path":"config"}',
+                },
+              },
+              {
+                function: {
+                  name: "list_dir",
+                  arguments: '{"path":"."}',
+                },
+              },
+            ],
+          };
+        }
+        return {
+          contentText:
+            '{"answer":"router.yaml and routing-policy.json are the routing-related filenames."}',
+        };
+      },
+    };
+
+    const result = await runRoutingCapabilityBenchmark(deps, {
+      endpointIds: [endpoint.endpointId],
+      mode: "full",
+      caseIds: ["t01-tools-list-dir"],
+      useJudge: false,
+    });
+
+    const { readFile } = await import("node:fs/promises");
+    const responsePath = path.join(
+      artifactRoot,
+      result.runId,
+      "responses",
+      endpoint.endpointId,
+      "t01-tools-list-dir.json",
+    );
+    const responseRecord = JSON.parse(await readFile(responsePath, "utf8")) as {
+      formattedDeliverable: string;
+    };
+    const deliverable = JSON.parse(responseRecord.formattedDeliverable) as {
+      tool_calls: Array<{ name: string; arguments: { path: string } }>;
+    };
+
+    expect(deliverable.tool_calls).toHaveLength(2);
+    expect(deliverable.tool_calls.map((toolCall) => toolCall.arguments.path)).toEqual([
+      "config",
+      ".",
+    ]);
+  });
+
+  test("forces a post-tool follow-up before accepting tool-grounded deliverables", async () => {
+    artifactRoot = await mkdtemp(path.join(os.tmpdir(), "bench-runner-post-tool-followup-"));
+    const databasePath = path.join(artifactRoot, "state", "memory.db");
+    await mkdir(path.dirname(databasePath), { recursive: true });
+    initBenchmarkDatabase(databasePath);
+
+    const endpoint = {
+      endpointId: "openai.personal.openai-codex-subscription.global.gpt-5.4",
+      modelId: "chatgpt/gpt-5.4",
+      sourceType: "remote" as const,
+      healthStatus: "healthy",
+    };
+
+    const seenBodies: Array<Record<string, unknown>> = [];
+    let turn = 0;
+    const deps = {
+      databasePath,
+      benchmarkArtifactRoot: artifactRoot,
+      listConfiguredEndpoints: async () => [endpoint],
+      deriveEndpointVersion: () => "v1",
+      executeChatCompletions: async (body: Record<string, unknown>) => {
+        seenBodies.push(body);
+        turn += 1;
+        if (turn === 1) {
+          return {
+            contentText:
+              '{"answer":"The config directory path was referenced, but no filenames were returned."}',
+            toolCalls: [
+              {
+                function: {
+                  name: "list_dir",
+                  arguments: '{"path":"C:\\\\Users\\\\erikb\\\\AppData\\\\Local\\\\RMCS\\\\ws\\\\run\\\\config"}',
+                },
+              },
+            ],
+          };
+        }
+        return {
+          contentText:
+            '{"answer":"router.yaml and routing-policy.json are the routing-related filenames."}',
+        };
+      },
+    };
+
+    const result = await runRoutingCapabilityBenchmark(deps, {
+      endpointIds: [endpoint.endpointId],
+      mode: "full",
+      caseIds: ["t01-tools-list-dir"],
+      useJudge: false,
+    });
+
+    expect(seenBodies).toHaveLength(2);
+    expect(JSON.stringify(seenBodies[1].messages ?? [])).toContain("router.yaml");
+    expect(JSON.stringify(seenBodies[1].messages ?? [])).toContain("routing-policy.json");
+
+    const { readFile } = await import("node:fs/promises");
+    const responsePath = path.join(
+      artifactRoot,
+      result.runId,
+      "responses",
+      endpoint.endpointId,
+      "t01-tools-list-dir.json",
+    );
+    const responseRecord = JSON.parse(await readFile(responsePath, "utf8")) as {
+      formattedDeliverable: string;
+    };
+    const deliverable = JSON.parse(responseRecord.formattedDeliverable) as {
+      answer: string;
+      tool_calls: Array<{ arguments: { path: string } }>;
+    };
+
+    expect(deliverable.tool_calls).toHaveLength(1);
+    expect(deliverable.tool_calls[0]?.arguments.path).toContain("\\config");
+    expect(deliverable.answer).toContain("router.yaml");
+    expect(deliverable.answer).toContain("routing-policy.json");
+  });
+
+  test("code-fence extraction ignores reasoning text from subject turns", async () => {
+    artifactRoot = await mkdtemp(path.join(os.tmpdir(), "bench-runner-code-fence-"));
+    const databasePath = path.join(artifactRoot, "state", "memory.db");
+    await mkdir(path.dirname(databasePath), { recursive: true });
+    initBenchmarkDatabase(databasePath);
+
+    const endpoint = {
+      endpointId: "moonshot.personal.kimi-code.global.kimi-k2.7-code",
+      modelId: "moonshot/kimi-k2.7-code",
+      sourceType: "remote" as const,
+      healthStatus: "healthy",
+    };
+
+    const deps = {
+      databasePath,
+      benchmarkArtifactRoot: artifactRoot,
+      listConfiguredEndpoints: async () => [endpoint],
+      deriveEndpointVersion: () => "v1",
+      executeChatCompletions: async () => ({
+        contentText: [
+          "```typescript",
+          "export function allowSoleCandidateFallback(): boolean {",
+          "  return true;",
+          "}",
+          "```",
+        ].join("\n"),
+        reasoningText:
+          "The user asked for one ```typescript code fence with the full function. I should think through the constraints first.",
+      }),
+    };
+
+    const result = await runRoutingCapabilityBenchmark(deps, {
+      endpointIds: [endpoint.endpointId],
+      mode: "quick",
+      caseIds: ["h07-multi-turn-sla-guard"],
+      useJudge: false,
+    });
+
+    const { readFile } = await import("node:fs/promises");
+    const responsePath = path.join(
+      artifactRoot,
+      result.runId,
+      "responses",
+      endpoint.endpointId,
+      "h07-multi-turn-sla-guard.json",
+    );
+    const responseRecord = JSON.parse(await readFile(responsePath, "utf8")) as {
+      extractionMethod: string;
+      formattedDeliverable: string;
+    };
+    const deliverable = JSON.parse(responseRecord.formattedDeliverable) as {
+      code: string;
+    };
+
+    expect(responseRecord.extractionMethod).toBe("code_fence");
+    expect(deliverable.code).toContain("export function allowSoleCandidateFallback");
+    expect(deliverable.code).not.toContain("I should think through the constraints first.");
+  });
+
   test("persists cross-model compare artifacts for multi-endpoint runs", async () => {
     artifactRoot = await mkdtemp(path.join(os.tmpdir(), "bench-runner-"));
     const databasePath = path.join(artifactRoot, "state", "memory.db");

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -1875,6 +1876,149 @@ describe("runtime-host-bridge", () => {
     });
   });
 
+  test("seedManagedCodexWorkspaceFixture stages benchmark files for Codex tool-heavy cases", async () => {
+    expect(
+      typeof (bridge as { seedManagedCodexWorkspaceFixture?: unknown }).seedManagedCodexWorkspaceFixture,
+    ).toBe("function");
+
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-codex-workspace-"));
+    try {
+      await (
+        bridge as {
+          seedManagedCodexWorkspaceFixture: (workspaceRoot: string) => Promise<void>;
+        }
+      ).seedManagedCodexWorkspaceFixture(workspaceRoot);
+
+      await expect(readFileSync(path.join(workspaceRoot, "src", "router.ts"), "utf8")).toContain(
+        "export function routeRuntimeRequest",
+      );
+      await expect(readFileSync(path.join(workspaceRoot, "src", "router.ts"), "utf8")).toContain(
+        "throughputSlaHardDeny",
+      );
+      await expect(
+        readFileSync(path.join(workspaceRoot, "state", "runtime-config.yaml"), "utf8"),
+      ).toContain("strategy: controller");
+      await expect(readFileSync(path.join(workspaceRoot, "src", "config.ts"), "utf8")).toContain(
+        "const MODE = 'baseline';",
+      );
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("createRequestScopedToolRegistry executes read_file, grep_search, and apply_patch against a staged workspace", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-codex-tools-"));
+    try {
+      await (
+        bridge as {
+          seedManagedCodexWorkspaceFixture: (workspaceRoot: string) => Promise<void>;
+        }
+      ).seedManagedCodexWorkspaceFixture(workspaceRoot);
+
+      const createRequestScopedToolRegistry = (
+        bridge as {
+          createRequestScopedToolRegistry: (
+            dynamicTools: readonly {
+              readonly name: string;
+              readonly description?: string;
+            readonly inputSchema: Record<string, unknown>;
+          }[],
+          options?: {
+            readonly workspaceRoot?: string;
+            readonly applyPatchMode?: "ack" | "mutate";
+          },
+        ) => { connectors: readonly { tools: readonly { name: string }[] }[] };
+      }
+    ).createRequestScopedToolRegistry;
+
+      const registry = createRequestScopedToolRegistry(
+        [
+          {
+            name: "read_file",
+            description: "Read a file from the benchmark workspace.",
+            inputSchema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+          {
+            name: "grep_search",
+            description: "Search within the benchmark workspace.",
+            inputSchema: {
+              type: "object",
+              properties: { pattern: { type: "string" } },
+              required: ["pattern"],
+            },
+          },
+          {
+            name: "apply_patch",
+            description: "Apply a unified diff patch in the benchmark workspace.",
+            inputSchema: {
+              type: "object",
+              properties: { diff: { type: "string" } },
+              required: ["diff"],
+            },
+          },
+        ],
+        { workspaceRoot, applyPatchMode: "mutate" },
+      );
+
+      const readResult = await executeToolCalls(registry, {
+        requestId: "codex-tool-read",
+        toolCalls: [
+          {
+            name: "read_file",
+            arguments: { path: "src/router.ts" },
+            providerToolId: "call-read",
+          },
+        ],
+      });
+      expect(readResult.executions[0]?.status).toBe("succeeded");
+      expect(String(readResult.executions[0]?.output)).toContain("routeRuntimeRequest");
+
+      const grepResult = await executeToolCalls(registry, {
+        requestId: "codex-tool-grep",
+        toolCalls: [
+          {
+            name: "grep_search",
+            arguments: { pattern: "evaluateEligibility" },
+            providerToolId: "call-grep",
+          },
+        ],
+      });
+      expect(grepResult.executions[0]?.status).toBe("succeeded");
+      expect(String(grepResult.executions[0]?.output)).toContain("src/router.ts");
+      expect(String(grepResult.executions[0]?.output)).toContain("evaluateEligibility");
+
+      const patchResult = await executeToolCalls(registry, {
+        requestId: "codex-tool-patch",
+        toolCalls: [
+          {
+            name: "apply_patch",
+            arguments: {
+              diff: [
+                "--- a/src/config.ts",
+                "+++ b/src/config.ts",
+                "@@ -1 +1 @@",
+                "-export const MODE = 'baseline';",
+                "+export const MODE = 'difficulty';",
+              ].join("\n"),
+            },
+            providerToolId: "call-patch",
+          },
+        ],
+      });
+      expect(patchResult.executions[0]?.status).toBe("succeeded");
+      expect(String(patchResult.executions[0]?.output)).toContain("Patch applied successfully");
+      expect(readFileSync(path.join(workspaceRoot, "src", "config.ts"), "utf8")).toContain(
+        "difficulty",
+      );
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   test("buildCodexDynamicTools output is compatible with createRequestScopedToolRegistry", async () => {
     const dynamicTools = (
       bridge as {
@@ -1920,6 +2064,517 @@ describe("runtime-host-bridge", () => {
 
     const registry = createRequestScopedToolRegistry(dynamicTools);
     expect(registry.connectors[0].tools.map((t) => t.name)).toEqual(["lookupRegistry"]);
+  });
+
+  test("buildCodexAppServerDynamicTools namespaces request-scoped tools for the app-server protocol", () => {
+    expect(
+      typeof (bridge as { buildCodexAppServerDynamicTools?: unknown }).buildCodexAppServerDynamicTools,
+    ).toBe("function");
+
+    const dynamicTools = (
+      bridge as {
+        buildCodexAppServerDynamicTools: (requestCapture: {
+          url: string;
+          body: Record<string, unknown>;
+        }) => readonly unknown[];
+      }
+    ).buildCodexAppServerDynamicTools({
+      url: "https://api.openai.test/v1/chat/completions",
+      body: {
+        model: "gpt-5.4",
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "read_file",
+              description: "Read a file from the repository.",
+              parameters: {
+                type: "object",
+                properties: {
+                  path: {
+                    type: "string",
+                  },
+                },
+                required: ["path"],
+              },
+            },
+          },
+          {
+            type: "function",
+            function: {
+              name: "apply_patch",
+              description: "Apply a diff patch.",
+              parameters: {
+                type: "object",
+                properties: {
+                  diff: {
+                    type: "string",
+                  },
+                },
+                required: ["diff"],
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(dynamicTools).toEqual([
+      {
+        type: "namespace",
+        name: "role_model_request",
+        description: "Request-scoped tools bridged from the calling runtime.",
+        tools: [
+          {
+            type: "function",
+            name: "request_read_file",
+            description: "Read a file from the repository.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                path: {
+                  type: "string",
+                },
+              },
+              required: ["path"],
+            },
+          },
+          {
+            type: "function",
+            name: "request_apply_patch",
+            description: "Apply a diff patch.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                diff: {
+                  type: "string",
+                },
+              },
+              required: ["diff"],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("readCodexThreadIdFromAppServerMessage accepts both thread/start results and thread/started notifications", () => {
+    expect(
+      typeof (bridge as { readCodexThreadIdFromAppServerMessage?: unknown })
+        .readCodexThreadIdFromAppServerMessage,
+    ).toBe("function");
+
+    const readCodexThreadIdFromAppServerMessage = (
+      bridge as {
+        readCodexThreadIdFromAppServerMessage: (message: Record<string, unknown>) => string;
+      }
+    ).readCodexThreadIdFromAppServerMessage;
+
+    expect(
+      readCodexThreadIdFromAppServerMessage({
+        id: 2,
+        result: {
+          thread: {
+            id: "thr_from_result",
+          },
+        },
+      }),
+    ).toBe("thr_from_result");
+
+    expect(
+      readCodexThreadIdFromAppServerMessage({
+        method: "thread/started",
+        params: {
+          thread: {
+            id: "thr_from_notification",
+          },
+        },
+      }),
+    ).toBe("thr_from_notification");
+  });
+
+  test("normalizeCodexAppServerModelName strips provider prefixes before calling the Codex app-server", () => {
+    expect(
+      typeof (bridge as { normalizeCodexAppServerModelName?: unknown })
+        .normalizeCodexAppServerModelName,
+    ).toBe("function");
+
+    const normalizeCodexAppServerModelName = (
+      bridge as {
+        normalizeCodexAppServerModelName: (model: string) => string;
+      }
+    ).normalizeCodexAppServerModelName;
+
+    expect(normalizeCodexAppServerModelName("chatgpt/gpt-5.4")).toBe("gpt-5.4");
+    expect(normalizeCodexAppServerModelName("openai/gpt-5.5")).toBe("gpt-5.5");
+    expect(normalizeCodexAppServerModelName("gpt-5.4")).toBe("gpt-5.4");
+  });
+
+  test("executeCodexAppServerTurnOverStdio completes a turn over stdio JSONL and returns tool executions", async () => {
+    expect(
+      typeof (bridge as { executeCodexAppServerTurnOverStdio?: unknown })
+        .executeCodexAppServerTurnOverStdio,
+    ).toBe("function");
+
+    const fakeAppServer = spawn(process.execPath, [
+      "-e",
+      [
+        "const readline = require('node:readline');",
+        "const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });",
+        "const send = (message) => process.stdout.write(JSON.stringify(message) + '\\n');",
+        "rl.on('line', (line) => {",
+        "  const message = JSON.parse(line);",
+        "  if (message.id === 1 && message.method === 'initialize') {",
+        "    send({ id: 1, result: { serverInfo: { name: 'fake-codex' } } });",
+        "    return;",
+        "  }",
+        "  if (message.method === 'initialized') {",
+        "    return;",
+        "  }",
+        "  if (message.id === 2 && message.method === 'thread/start') {",
+        "    send({ method: 'thread/started', params: { thread: { id: 'thr_test_stdio' } } });",
+        "    send({ id: 2, result: { thread: { id: 'thr_test_stdio' } } });",
+        "    return;",
+        "  }",
+        "  if (message.id === 3 && message.method === 'turn/start') {",
+        "    send({ id: 3, result: { accepted: true } });",
+        "    send({ method: 'thread/tokenUsage/updated', params: { tokenUsage: { last: { inputTokens: 11, outputTokens: 0 } } } });",
+        "    send({ id: 91, method: 'item/tool/call', params: { callId: 'call_stdio_1', tool: 'request_read_file', arguments: { path: 'README.md' } } });",
+        "    return;",
+        "  }",
+        "  if (message.id === 91) {",
+        "    send({ method: 'item/agentMessage/delta', params: { delta: 'HEL' } });",
+        "    send({ method: 'item/agentMessage/delta', params: { delta: 'LO' } });",
+        "    send({ method: 'item/completed', params: { item: { type: 'agentMessage', text: 'HELLO' } } });",
+        "    send({ method: 'thread/tokenUsage/updated', params: { tokenUsage: { last: { inputTokens: 11, outputTokens: 5 } } } });",
+        "    send({ method: 'turn/completed', params: { turn: { id: 'turn_stdio_1' } } });",
+        "    setTimeout(() => process.exit(0), 0);",
+        "  }",
+        "});",
+      ].join(" "),
+    ], {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "codex-stdio-turn-"));
+
+    try {
+      const result = await (
+        bridge as {
+          executeCodexAppServerTurnOverStdio: (input: {
+            child: ReturnType<typeof spawn>;
+            model: string;
+            requestCapture: {
+              url: string;
+              body: Record<string, unknown>;
+            };
+            workspaceRoot: string;
+            executeDynamicToolCall: (input: {
+              toolCallId: string;
+              toolName: string;
+              toolArguments: unknown;
+              workspaceRoot: string;
+            }) => Promise<{
+              success: boolean;
+              contentItems: readonly {
+                type: "inputText";
+                text: string;
+              }[];
+              execution: {
+                toolName: string;
+              };
+            }>;
+          }) => Promise<{
+            finishReason: string;
+            outputText: string;
+            usage: {
+              inputTokens: number;
+              outputTokens: number;
+            };
+            dynamicToolCalls: readonly {
+              id: string;
+              type: "function";
+              function: {
+                name: string;
+                arguments: string;
+              };
+            }[];
+            dynamicToolExecutions: readonly {
+              toolName: string;
+            }[];
+          }>;
+        }
+      ).executeCodexAppServerTurnOverStdio({
+        child: fakeAppServer,
+        model: "gpt-5.4",
+        requestCapture: {
+          url: "https://api.openai.com/v1/chat/completions",
+          body: {
+            model: "chatgpt/gpt-5.4",
+            messages: [{ role: "user", content: "Reply with exactly HELLO." }],
+            tools: [
+              {
+                type: "function",
+                function: {
+                  name: "read_file",
+                  description: "Read a file",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      path: {
+                        type: "string",
+                      },
+                    },
+                    required: ["path"],
+                  },
+                },
+              },
+            ],
+          },
+        },
+        workspaceRoot,
+        executeDynamicToolCall: async ({ toolCallId, toolName, toolArguments }) => ({
+          success: true,
+          contentItems: [
+            {
+              type: "inputText",
+              text: JSON.stringify({ toolCallId, toolName, toolArguments }),
+            },
+          ],
+          execution: {
+            toolName,
+          },
+        }),
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          finishReason: "stop",
+          outputText: "HELLO",
+          dynamicToolCalls: [
+            {
+              id: "call_stdio_1",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: "{\"path\":\"README.md\"}",
+              },
+            },
+          ],
+          usage: {
+            inputTokens: 11,
+            outputTokens: 5,
+          },
+        }),
+      );
+      expect(result.dynamicToolExecutions).toEqual([{ toolName: "request_read_file" }]);
+    } finally {
+      fakeAppServer.kill();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("readCodexExecutionFailureFromSessionArtifacts reports a Codex Subscription usage-limit turn", async () => {
+    expect(
+      typeof (bridge as { readCodexExecutionFailureFromSessionArtifacts?: unknown })
+        .readCodexExecutionFailureFromSessionArtifacts,
+    ).toBe("function");
+
+    const codexHome = await mkdtemp(path.join(os.tmpdir(), "codex-session-limit-"));
+    const workspaceRoot = path.join(codexHome, "ws", "r-test-limit");
+    const sessionDir = path.join(codexHome, "sessions", "2026", "06", "20");
+    const sessionPath = path.join(sessionDir, "rollout-usage-limit.jsonl");
+
+    await mkdir(workspaceRoot, { recursive: true });
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      sessionPath,
+      [
+        JSON.stringify({
+          timestamp: "2026-06-20T18:45:11.573Z",
+          type: "session_meta",
+          payload: {
+            cwd: workspaceRoot,
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-06-20T18:45:16.682Z",
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+            rate_limits: {
+              credits: {
+                has_credits: false,
+                unlimited: false,
+                balance: "0",
+              },
+            },
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-06-20T18:45:16.714Z",
+          type: "event_msg",
+          payload: {
+            type: "task_complete",
+            last_agent_message: null,
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    try {
+      const message = await (
+        bridge as {
+          readCodexExecutionFailureFromSessionArtifacts: (input: {
+            codexHome: string;
+            workspaceRoot: string;
+          }) => Promise<string | null>;
+        }
+      ).readCodexExecutionFailureFromSessionArtifacts({
+        codexHome,
+        workspaceRoot,
+      });
+
+      expect(message).toMatch(/usage limit|credits/i);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("resolveManagedCodexExecutionHome keeps the shared Codex home short on Windows-style paths", () => {
+    expect(
+      typeof (bridge as { resolveManagedCodexExecutionHome?: unknown }).resolveManagedCodexExecutionHome,
+    ).toBe("function");
+
+    const result = (
+      bridge as {
+        resolveManagedCodexExecutionHome: (
+          runtimeStateRoot: string,
+          scopeId: string,
+          requestId: string,
+        ) => string;
+      }
+    ).resolveManagedCodexExecutionHome(
+      "C:\\Users\\erikb\\AppData\\Local\\Role Model Runtime",
+      "standalone-runtime",
+      "bench-p17-tools-multi-hard-openai.personal.openai-codex-subscription.global.gpt-5.4-turn1-36895931-f445-442a-a0c0-90b0d7fa1ed0",
+    );
+
+    expect(result).toContain("\\RMCS\\");
+    expect(result).toContain("\\s-");
+    expect(result).not.toContain("\\r-");
+    expect(result.length).toBeLessThan(120);
+    expect(result).not.toContain(
+      "bench-p17-tools-multi-hard-openai.personal.openai-codex-subscription.global.gpt-5.4-turn1-36895931-f445-442a-a0c0-90b0d7fa1ed0",
+    );
+  });
+
+  test("resolveManagedCodexWorkspaceRoot keeps request workspaces short under the shared Codex home", () => {
+    expect(
+      typeof (bridge as { resolveManagedCodexWorkspaceRoot?: unknown }).resolveManagedCodexWorkspaceRoot,
+    ).toBe("function");
+
+    const codexHome = (
+      bridge as {
+        resolveManagedCodexExecutionHome: (
+          runtimeStateRoot: string,
+          scopeId: string,
+          requestId: string,
+        ) => string;
+      }
+    ).resolveManagedCodexExecutionHome(
+      "C:\\Users\\erikb\\AppData\\Local\\Role Model Runtime",
+      "standalone-runtime",
+      "bench-p17-tools-multi-hard-openai.personal.openai-codex-subscription.global.gpt-5.4-turn1-36895931-f445-442a-a0c0-90b0d7fa1ed0",
+    );
+
+    const workspaceRoot = (
+      bridge as {
+        resolveManagedCodexWorkspaceRoot: (codexHome: string, requestId: string) => string;
+      }
+    ).resolveManagedCodexWorkspaceRoot(
+      codexHome,
+      "bench-p17-tools-multi-hard-openai.personal.openai-codex-subscription.global.gpt-5.4-turn1-36895931-f445-442a-a0c0-90b0d7fa1ed0",
+    );
+
+    expect(workspaceRoot).toContain("\\ws\\");
+    expect(workspaceRoot).toContain("\\r-");
+    expect(workspaceRoot.length).toBeLessThan(170);
+  });
+
+  test("resolveManagedCodexWorkspaceRoot leaves enough room for deep plugin staging paths on Windows", () => {
+    expect(
+      typeof (bridge as { resolveManagedCodexWorkspaceRoot?: unknown }).resolveManagedCodexWorkspaceRoot,
+    ).toBe("function");
+
+    const codexHome = (
+      bridge as {
+        resolveManagedCodexExecutionHome: (
+          runtimeStateRoot: string,
+          scopeId: string,
+          requestId: string,
+        ) => string;
+      }
+    ).resolveManagedCodexExecutionHome(
+      "C:\\Users\\erikb\\AppData\\Local\\Role Model Runtime",
+      "standalone-runtime",
+      "bench-x01-max-signal-openai.personal.openai-codex-subscription.global.gpt-5.4",
+    );
+
+    const executionHome = (
+      bridge as {
+        resolveManagedCodexWorkspaceRoot: (codexHome: string, requestId: string) => string;
+      }
+    ).resolveManagedCodexWorkspaceRoot(
+      codexHome,
+      "bench-x01-max-signal-openai.personal.openai-codex-subscription.global.gpt-5.4",
+    );
+
+    const stagedPluginPath = path.join(
+      executionHome,
+      ".tmp",
+      "plugins",
+      "plugins",
+      "build-web-data-visualization",
+      "skills",
+      "geospatial-and-cartographic-visualization",
+      "references",
+      "source-method-and-coordinate-ledger.md",
+    );
+
+    expect(stagedPluginPath.length).toBeLessThan(240);
+  });
+
+  test("cleanupManagedCodexExecutionWorkspace removes only the request workspace and preserves the shared Codex home", async () => {
+    expect(
+      typeof (bridge as { cleanupManagedCodexExecutionWorkspace?: unknown })
+        .cleanupManagedCodexExecutionWorkspace,
+    ).toBe("function");
+
+    const codexHome = await mkdtemp(path.join(os.tmpdir(), "role-model-codex-home-"));
+    const workspaceRoot = path.join(codexHome, "ws", "r-1234567890");
+    await mkdir(workspaceRoot, { recursive: true });
+    await mkdir(path.join(codexHome, "auth"), { recursive: true });
+    await writeFile(path.join(codexHome, "auth", "session.json"), '{"ok":true}');
+    await writeFile(path.join(workspaceRoot, "router.ts"), "export const ok = true;\n");
+
+    await (
+      bridge as {
+        cleanupManagedCodexExecutionWorkspace: (
+          codexHome: string,
+          workspaceRoot: string,
+        ) => Promise<void>;
+      }
+    ).cleanupManagedCodexExecutionWorkspace(codexHome, workspaceRoot);
+
+    expect(existsSync(codexHome)).toBe(true);
+    expect(existsSync(path.join(codexHome, "auth", "session.json"))).toBe(true);
+    expect(existsSync(workspaceRoot)).toBe(false);
+    expect(existsSync(path.join(codexHome, "ws"))).toBe(false);
+
+    await rm(codexHome, { recursive: true, force: true });
   });
 
   test("createRequestScopedToolRegistry does not require repoRoot or file system access", () => {

--- a/role-model-router/packages/adapter-execution/src/index.ts
+++ b/role-model-router/packages/adapter-execution/src/index.ts
@@ -110,6 +110,18 @@ export interface ProviderResponseCapture {
   readonly endpointId: string;
   readonly statusCode: number;
   readonly body: unknown;
+  readonly dynamicToolExecutions?: readonly {
+    readonly toolCallId: string;
+    readonly toolName: string;
+    readonly connectorId: string;
+    readonly connectorKind: string;
+    readonly status: "succeeded" | "failed" | "rejected";
+    readonly output: unknown;
+    readonly diagnostics: readonly {
+      readonly code: string;
+      readonly message: string;
+    }[];
+  }[];
   readonly vendorMetadata?: {
     readonly vendorId: string;
     readonly resolvedModelId?: string;

--- a/role-model-router/packages/bench-judge/src/index.test.ts
+++ b/role-model-router/packages/bench-judge/src/index.test.ts
@@ -15,7 +15,7 @@ const P17_BRIEF = {
   exemplarQuality: "authored" as const,
   deliverablesChecklist: [
     "[MUST] Must call read_file and apply_patch",
-    "[MUST] apply_patch diff must contain ---/+++ file headers and @@ hunk markers with real content",
+    "[MUST] apply_patch must contain either ---/+++ headers plus an @@ hunk marker and real change content, or a valid Codex patch envelope with real content; line numbers are optional and bare @@ is acceptable",
   ],
   antiPatterns: ["MUST NOT use diff placeholders (----/+++, [file header])"],
 };
@@ -24,7 +24,7 @@ const P17_LFM_DELIVERABLE = JSON.stringify(
   {
     tool_calls: [
       { name: "read_file", arguments: { path: "src/router.ts" } },
-      { name: "apply_patch", arguments: { patch: "----/+++" } },
+      { name: "apply_patch", arguments: { diff: "----/+++" } },
     ],
     answer: "what schema fields and tests you validated",
   },
@@ -49,7 +49,7 @@ describe("bench-judge grading prompts", () => {
     expect(prompt).toContain("## Original question");
     expect(prompt).toContain("## Example expected answer");
     expect(prompt).toContain("## Key deliverables");
-    expect(prompt).toContain("@@ hunk");
+    expect(prompt).toContain("bare @@");
     expect(prompt).not.toContain("Prompt summary:");
   });
 
@@ -96,5 +96,15 @@ describe("bench-judge grading prompts", () => {
     );
     expect(extracted).toContain('"score":0.25');
     expect(parseJudgeGradingResponse(extracted)?.score).toBe(0.25);
+  });
+
+  test("parseJudgeGradingResponse sanitizes runaway regex-noise rationale text", () => {
+    const parsed = parseJudgeGradingResponse(
+      '{"score":1,"rationale":"Good answer matching the checklist and the \'+\',\'+\',\'+\',\'+\',\'+\',\'+\',\'+\' pattern."}',
+    );
+    expect(parsed?.score).toBe(1);
+    expect(parsed?.rationale).toContain("Good answer");
+    expect(parsed?.rationale).not.toContain("'+','+','+'");
+    expect((parsed?.rationale?.length ?? 0)).toBeLessThan(200);
   });
 });

--- a/role-model-router/packages/bench-judge/src/index.ts
+++ b/role-model-router/packages/bench-judge/src/index.ts
@@ -38,6 +38,9 @@ export interface JudgeGradingResult {
 export const JUDGE_JSON_ONLY_FOLLOW_UP =
   'Reply with JSON only on one line: {"score":0.0,"rationale":"..."}. No reasoning, markdown, or extra text.';
 
+const MAX_JUDGE_RATIONALE_LENGTH = 600;
+const MAX_COMPARE_RATIONALE_LENGTH = 400;
+
 export function buildJudgeGradingPrompt(input: JudgeGradingInput): string {
   const toolLines: string[] = [];
   if (input.requiredToolCall || input.requiredToolNames?.length) {
@@ -61,7 +64,8 @@ export function buildJudgeGradingPrompt(input: JudgeGradingInput): string {
     "Score 0.0 = completely wrong or refusal without attempt.",
     "Ignore chain-of-thought or reasoning preambles. Grade ONLY the extracted formatted deliverable.",
     "For code-fix cases, verify the fix is correct — unchanged buggy code must score 0.",
-    "Placeholder diffs (----/+++), stub patches without @@ hunks, and reasoning prose submitted as code score 0.",
+    "Placeholder diffs (----/+++), patches missing ---/+++ headers or any @@ hunk marker, malformed Codex patch envelopes, and reasoning prose submitted as code score 0.",
+    "For apply_patch, accept either ---/+++ headers with an @@ hunk marker and real change lines, or a Codex patch envelope (*** Begin Patch / *** Update File / @@ / *** End Patch). Bare @@ without line numbers is acceptable.",
     ...toolLines,
     "",
     `Case: ${input.caseId}`,
@@ -126,6 +130,27 @@ function parseScoreValue(value: unknown): number | null {
   return null;
 }
 
+function sanitizeRepeatedPatternNoise(text: string): string {
+  return text.replace(
+    /(?:'[^A-Za-z0-9\s]{1,4}'\s*,\s*){4,}'[^A-Za-z0-9\s]{1,4}'/g,
+    "[regex clues omitted]",
+  );
+}
+
+function sanitizeRationaleText(text: string, maxLength: number, fallback: string): string {
+  const normalized = sanitizeRepeatedPatternNoise(text)
+    .replace(/\s+/g, " ")
+    .replace(/\s+([,.;:])/g, "$1")
+    .trim();
+  if (!normalized) {
+    return fallback;
+  }
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
 function extractBalancedJsonObjects(text: string): string[] {
   const objects: string[] = [];
   let depth = 0;
@@ -187,7 +212,11 @@ function tryParseJudgeJson(candidate: string): JudgeGradingResult | null {
     }
     return {
       score,
-      rationale: typeof parsed.rationale === "string" ? parsed.rationale : "Judge provided score.",
+      rationale: sanitizeRationaleText(
+        typeof parsed.rationale === "string" ? parsed.rationale : "Judge provided score.",
+        MAX_JUDGE_RATIONALE_LENGTH,
+        "Judge provided score.",
+      ),
       method: "judge",
     };
   } catch {
@@ -251,7 +280,11 @@ export function parseJudgeGradingResponse(raw: string): JudgeGradingResult | nul
       const rationaleMatch = withoutFences.match(/"rationale"\s*:\s*"([^"]*)"/i);
       return {
         score,
-        rationale: rationaleMatch?.[1] ?? "Judge provided score.",
+        rationale: sanitizeRationaleText(
+          rationaleMatch?.[1] ?? "Judge provided score.",
+          MAX_JUDGE_RATIONALE_LENGTH,
+          "Judge provided score.",
+        ),
         method: "judge",
       };
     }
@@ -342,8 +375,11 @@ function tryParseCompareJson(candidate: string): CompareGradingResult | null {
     }
     return {
       relativeRanking,
-      rationale:
+      rationale: sanitizeRationaleText(
         typeof parsed.rationale === "string" ? parsed.rationale : "Compare ranking provided.",
+        MAX_COMPARE_RATIONALE_LENGTH,
+        "Compare ranking provided.",
+      ),
     };
   } catch {
     return null;

--- a/role-model-router/packages/bench-routing/data/routing-capability-suite.json
+++ b/role-model-router/packages/bench-routing/data/routing-capability-suite.json
@@ -1,6 +1,6 @@
 {
   "suite_id": "routing-capability-v2",
-  "suite_version": "3.2",
+  "suite_version": "3.4",
   "description": "Capability benchmark v3: concrete code implementation, required tool calls, and multi-step prompts.",
   "task_type": "routing_capability",
   "capability_targets": [
@@ -159,6 +159,23 @@
       "expected_response": "{\"name\":\"\",\"value\":\"\"}",
       "grading_criteria": "Valid JSON with name and value keys only.",
       "accept_patterns": ["\"name\"", "\"value\""],
+      "answer_format": {
+        "kind": "json",
+        "instruction": "Return ONLY a ```json fence: {\"name\":\"...\",\"value\":\"...\"}. Do not wrap it in an `answer` field.",
+        "schema": {
+          "type": "object",
+          "required": ["name", "value"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
       "quick_benchmark": false
     },
     {
@@ -210,9 +227,9 @@
         }
       ],
       "max_tokens": 32,
-      "expected_response": "Application Programming Interface",
-      "grading_criteria": "Defines API succinctly.",
-      "accept_patterns": ["Application Programming Interface", "programming interface"],
+      "expected_response": "A concise one-line definition or correct expansion of API.",
+      "grading_criteria": "Defines API in one concise line; either a correct expansion or a brief correct one-line definition is acceptable.",
+      "accept_patterns": ["Application Programming Interface", "programming interface", "software applications", "communicate"],
       "quick_benchmark": false
     },
     {
@@ -412,14 +429,33 @@
       "messages": [
         {
           "role": "user",
-          "content": "Analyze this code-edit workflow, produce a unified diff patch for src/router.ts, and explain the refactor."
+          "content": "Current `src/router.ts`:\n```ts\nexport function route(input: { strategy: string }) {\n  return input.strategy;\n}\n```\nRefactor it by renaming `route` to `routeRuntimeRequest` and normalizing `strategy` with `trim().toLowerCase()` before returning it. Return ONLY JSON with `diff` and `rationale`."
         }
       ],
       "max_tokens": 128,
       "expected_response": "unified diff patch for router.ts with refactor explanation",
-      "grading_criteria": "Must include unified diff with ---/+++ hunks for router.ts and brief refactor rationale.",
+      "grading_criteria": "Must include unified diff with ---/+++ hunks for router.ts and brief refactor rationale covering the rename and strategy normalization.",
       "accept_patterns": ["---|\\+\\+\\+|@@", "router", "diff|patch"],
-      "quick_benchmark": false
+      "quick_benchmark": false,
+      "answer_format": {
+        "kind": "json",
+        "instruction": "Return ONLY a ```json fence: {\"diff\":\"<unified diff>\",\"rationale\":\"<brief rationale>\"}.",
+        "schema": {
+          "type": "object",
+          "required": ["diff", "rationale"],
+          "properties": {
+            "diff": {
+              "type": "string",
+              "minLength": 20
+            },
+            "rationale": {
+              "type": "string",
+              "minLength": 12
+            }
+          }
+        }
+      },
+      "example_deliverable": "{\n  \"diff\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -1,3 +1,4 @@\\n-export function route(input: { strategy: string }) {\\n-  return input.strategy;\\n+export function routeRuntimeRequest(input: { strategy: string }) {\\n+  return input.strategy.trim().toLowerCase();\\n }\\n\",\n  \"rationale\": \"Renamed the entrypoint for clarity and normalized strategy values to avoid whitespace and casing bugs.\"\n}"
     },
     {
       "case_id": "p13-code-debug",
@@ -448,14 +484,43 @@
       "messages": [
         {
           "role": "user",
-          "content": "Validate this JSON schema contract for routing diagnostics and refactor the test suite if fields are missing."
+          "content": "Current schema and test excerpt:\n```json\n{\n  \"$id\": \"routingDiagnostics.difficultyRouting\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"difficultyBucket\": { \"type\": \"string\" },\n    \"chosenEndpointId\": { \"type\": \"string\" }\n  },\n  \"required\": [\"difficultyBucket\", \"chosenEndpointId\"],\n  \"additionalProperties\": false\n}\n```\n```ts\ntest('includes requestedRoleId when routing is controller-guided', () => {\n  expect(result.routingDiagnostics.difficultyRouting.requestedRoleId).toBe('coder.patch');\n});\n```\nValidate the schema contract for routing diagnostics and refactor the test suite if fields are missing. Return ONLY JSON with `analysis`, `missing_fields`, and `test_updates`."
         }
       ],
       "max_tokens": 128,
-      "expected_response": "Technical analysis referencing code, patch, schema, or tests.",
-      "grading_criteria": "Engages with code-edit or debugging request substantively.",
-      "accept_patterns": ["code|patch|schema|test|typescript|router"],
-      "quick_benchmark": false
+      "expected_response": "Schema analysis naming missing fields and concrete test updates.",
+      "grading_criteria": "Must identify that `requestedRoleId` is missing from the schema and propose concrete test updates.",
+      "accept_patterns": ["requestedRoleId|schema|test"],
+      "quick_benchmark": false,
+      "answer_format": {
+        "kind": "json",
+        "instruction": "Return ONLY a ```json fence: {\"analysis\":\"...\",\"missing_fields\":[\"...\"],\"test_updates\":[\"...\"]}.",
+        "schema": {
+          "type": "object",
+          "required": ["analysis", "missing_fields", "test_updates"],
+          "properties": {
+            "analysis": {
+              "type": "string",
+              "minLength": 16
+            },
+            "missing_fields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            "test_updates": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          }
+        }
+      },
+      "example_deliverable": "{\n  \"analysis\": \"The schema omits `requestedRoleId`, so controller-guided routing diagnostics cannot satisfy the existing test expectation.\",\n  \"missing_fields\": [\n    \"requestedRoleId\"\n  ],\n  \"test_updates\": [\n    \"Add `requestedRoleId` to the schema properties and required list when controller-guided routing is emitted.\",\n    \"Keep the test assertion and extend fixtures to include `requestedRoleId: \\\"coder.patch\\\"`.\"\n  ]\n}"
     },
     {
       "case_id": "c01-full-refactor",
@@ -466,14 +531,50 @@
       "messages": [
         {
           "role": "user",
-          "content": "You are a senior engineer. Analyze the code-edit workflow for router.ts, produce a unified diff patch, validate the JSON schema contract for routingDiagnostics.difficultyRouting, refactor conformance tests, and explain each change with before/after examples."
+          "content": "You are a senior engineer. Current `src/router.ts`:\n```ts\nexport function route(input: { strategy: string }) {\n  return input.strategy;\n}\n```\nCurrent schema:\n```json\n{\n  \"$id\": \"routingDiagnostics.difficultyRouting\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"difficultyBucket\": { \"type\": \"string\" },\n    \"chosenEndpointId\": { \"type\": \"string\" }\n  },\n  \"required\": [\"difficultyBucket\", \"chosenEndpointId\"],\n  \"additionalProperties\": false\n}\n```\nCurrent test excerpt:\n```ts\ntest('includes requestedRoleId when routing is controller-guided', () => {\n  expect(result.routingDiagnostics.difficultyRouting.requestedRoleId).toBe('coder.patch');\n});\n```\nProduce a unified diff patch for `src/router.ts` that renames `route` to `routeRuntimeRequest` and normalizes `strategy` with `trim().toLowerCase()`. Validate the schema contract, identify any missing field, refactor the conformance test, and explain each change with before/after examples. Return ONLY JSON with `diff`, `schema_findings`, `test_updates`, and `before_after`."
         }
       ],
       "max_tokens": 200,
-      "expected_response": "Technical analysis referencing code, patch, schema, or tests.",
-      "grading_criteria": "Engages with code-edit or debugging request substantively.",
-      "accept_patterns": ["code|patch|schema|test|typescript|router"],
-      "quick_benchmark": false
+      "expected_response": "Diff, schema findings, test updates, and before/after explanations.",
+      "grading_criteria": "Must include a unified diff for router.ts, identify the missing `requestedRoleId` schema field, propose test updates, and include before/after explanations.",
+      "accept_patterns": ["requestedRoleId|schema|test|router|diff"],
+      "quick_benchmark": false,
+      "answer_format": {
+        "kind": "json",
+        "instruction": "Return ONLY a ```json fence: {\"diff\":\"<unified diff>\",\"schema_findings\":[\"...\"],\"test_updates\":[\"...\"],\"before_after\":[\"...\"]}.",
+        "schema": {
+          "type": "object",
+          "required": ["diff", "schema_findings", "test_updates", "before_after"],
+          "properties": {
+            "diff": {
+              "type": "string",
+              "minLength": 20
+            },
+            "schema_findings": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            "test_updates": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            "before_after": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          }
+        }
+      },
+      "example_deliverable": "{\n  \"diff\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -1,3 +1,4 @@\\n-export function route(input: { strategy: string }) {\\n-  return input.strategy;\\n+export function routeRuntimeRequest(input: { strategy: string }) {\\n+  return input.strategy.trim().toLowerCase();\\n }\\n\",\n  \"schema_findings\": [\n    \"`requestedRoleId` is missing from `routingDiagnostics.difficultyRouting` even though controller-guided tests expect it.\"\n  ],\n  \"test_updates\": [\n    \"Extend the schema fixture with `requestedRoleId`.\",\n    \"Keep the controller-guided conformance assertion and update fixture snapshots accordingly.\"\n  ],\n  \"before_after\": [\n    \"Before: `route` returned the raw strategy string. After: `routeRuntimeRequest` normalizes whitespace and casing.\",\n    \"Before: schema omitted `requestedRoleId`. After: controller-guided fixtures include it so tests and schema agree.\"\n  ]\n}"
     },
     {
       "case_id": "c02-ts-generics",
@@ -502,7 +603,7 @@
       "messages": [
         {
           "role": "user",
-          "content": "Read the runtime config file and tell me the routing strategy."
+          "content": "Read `state/runtime-config.yaml` and tell me the routing strategy."
         }
       ],
       "max_tokens": 96,
@@ -529,7 +630,22 @@
         }
       ],
       "required_tool_call": true,
-      "expected_tool_names": ["read_file"]
+      "expected_tool_names": ["read_file"],
+      "answer_format": {
+        "kind": "tool_calls_with_answer",
+        "instruction": "Step 1: emit the required read_file tool call for `state/runtime-config.yaml`. Step 2: after tools succeed, output ONLY a ```json fence: {\"answer\":\"<routing strategy>\"}.",
+        "schema": {
+          "type": "object",
+          "required": ["answer"],
+          "properties": {
+            "answer": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      },
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"state/runtime-config.yaml\"\n      }\n    }\n  ],\n  \"answer\": \"controller\"\n}"
     },
     {
       "case_id": "p16-tools-search",
@@ -545,7 +661,7 @@
       ],
       "max_tokens": 128,
       "expected_response": "Coherent plan or summary addressing the tool-using task.",
-      "grading_criteria": "Attempts the requested tool workflow without refusing outright.",
+      "grading_criteria": "Must call grep_search and summarize where throughputSla hard-deny happens from the provided grep results.",
       "accept_patterns": ["read|search|list|patch|tool|plan"],
       "quick_benchmark": false,
       "tools": [
@@ -565,7 +681,24 @@
             }
           }
         }
-      ]
+      ],
+      "required_tool_call": true,
+      "expected_tool_names": ["grep_search"],
+      "answer_format": {
+        "kind": "tool_calls_with_answer",
+        "instruction": "Step 1: emit the required grep_search tool call. Step 2: after tools succeed, output ONLY a ```json fence: {\"answer\":\"<summary of where hard-deny happens>\"}.",
+        "schema": {
+          "type": "object",
+          "required": ["answer"],
+          "properties": {
+            "answer": {
+              "type": "string",
+              "minLength": 8
+            }
+          }
+        }
+      },
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"grep_search\",\n      \"arguments\": {\n        \"pattern\": \"throughputSla\"\n      }\n    }\n  ],\n  \"answer\": \"Hard-deny happens in the zero-eligible fast-fail branch and when a candidate is marked `hardDeniedBySla` because its throughput is below the threshold.\"\n}"
     },
     {
       "case_id": "t01-tools-list-dir",
@@ -581,7 +714,7 @@
       ],
       "max_tokens": 96,
       "expected_response": "Coherent plan or summary addressing the tool-using task.",
-      "grading_criteria": "Attempts the requested tool workflow without refusing outright.",
+      "grading_criteria": "Must call list_dir and summarize routing-related filenames from the provided directory listing.",
       "accept_patterns": ["read|search|list|patch|tool|plan"],
       "quick_benchmark": false,
       "tools": [
@@ -601,7 +734,24 @@
             }
           }
         }
-      ]
+      ],
+      "required_tool_call": true,
+      "expected_tool_names": ["list_dir"],
+      "answer_format": {
+        "kind": "tool_calls_with_answer",
+        "instruction": "Step 1: emit the required list_dir tool call. Step 2: after tools succeed, output ONLY a ```json fence: {\"answer\":\"<summary of routing-related filenames>\"}.",
+        "schema": {
+          "type": "object",
+          "required": ["answer"],
+          "properties": {
+            "answer": {
+              "type": "string",
+              "minLength": 8
+            }
+          }
+        }
+      },
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"list_dir\",\n      \"arguments\": {\n        \"path\": \"config\"\n      }\n    }\n  ],\n  \"answer\": \"The routing-related files are `router.yaml` and `routing-policy.json`; the other files are unrelated config assets.\"\n}"
     },
     {
       "case_id": "p17-tools-multi-hard",
@@ -670,7 +820,7 @@
           }
         }
       },
-      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"src/router.ts\"\n      }\n    },\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"patch\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -12,3 +12,3 @@\\n export const MODE = \\\"difficulty\\\";\\n\"\n      }\n    }\n  ],\n  \"answer\": \"Validated MODE and throughput SLA schema fields; added guard regression test.\"\n}"
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"src/router.ts\"\n      }\n    },\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"diff\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -12,3 +12,3 @@\\n export const MODE = \\\"difficulty\\\";\\n\"\n      }\n    }\n  ],\n  \"answer\": \"Validated MODE and throughput SLA schema fields; added guard regression test.\"\n}"
     },
     {
       "case_id": "p18-tools-agent",
@@ -686,7 +836,7 @@
       ],
       "max_tokens": 160,
       "expected_response": "Coherent plan or summary addressing the tool-using task.",
-      "grading_criteria": "Attempts the requested tool workflow without refusing outright.",
+      "grading_criteria": "Must call list_endpoints and get_metrics, then recommend routing changes using the provided endpoint and latency data.",
       "accept_patterns": ["read|search|list|patch|tool|plan"],
       "quick_benchmark": false,
       "tools": [
@@ -717,7 +867,24 @@
             }
           }
         }
-      ]
+      ],
+      "required_tool_call": true,
+      "expected_tool_names": ["list_endpoints", "get_metrics", "get_metrics"],
+      "answer_format": {
+        "kind": "tool_calls_with_answer",
+        "instruction": "Step 1: emit list_endpoints and get_metrics tool calls for both compared endpoints. Step 2: after tools succeed, output ONLY a ```json fence: {\"answer\":\"<routing recommendation>\"}.",
+        "schema": {
+          "type": "object",
+          "required": ["answer"],
+          "properties": {
+            "answer": {
+              "type": "string",
+              "minLength": 12
+            }
+          }
+        }
+      },
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"list_endpoints\",\n      \"arguments\": {}\n    },\n    {\n      \"name\": \"get_metrics\",\n      \"arguments\": {\n        \"endpoint_id\": \"local.lfm2.5-8b-a1b\"\n      }\n    },\n    {\n      \"name\": \"get_metrics\",\n      \"arguments\": {\n        \"endpoint_id\": \"remote.deepseek-v4-flash\"\n      }\n    }\n  ],\n  \"answer\": \"Keep local as the default for low-latency traffic, but retain remote deepseek-v4-flash as the fallback for harder requests where quality matters more than p95 latency.\"\n}"
     },
     {
       "case_id": "t02-tools-triple",
@@ -803,6 +970,37 @@
       "expected_response": "Coherent plan or summary addressing the tool-using task.",
       "grading_criteria": "Attempts the requested tool workflow without refusing outright.",
       "accept_patterns": ["read|search|list|patch|tool|plan"],
+      "required_tool_call": true,
+      "expected_tool_names": ["read_file", "validate_schema", "apply_patch"],
+      "answer_format": {
+        "kind": "tool_calls_with_summary",
+        "instruction": "Step 1: emit the required API tool calls. Step 2: after tools, output ONLY a ```json fence: {\"plan\":[\"...\"],\"patch_summary\":\"...\",\"strategy_improvements\":[\"...\"]}.",
+        "schema": {
+          "type": "object",
+          "required": ["plan", "patch_summary", "strategy_improvements"],
+          "properties": {
+            "plan": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 3
+            },
+            "patch_summary": {
+              "type": "string",
+              "minLength": 12
+            },
+            "strategy_improvements": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        }
+      },
       "quick_benchmark": false,
       "tools": [
         {
@@ -1000,7 +1198,7 @@
           }
         }
       },
-      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"src/router.ts\"\n      }\n    },\n    {\n      \"name\": \"grep_search\",\n      \"arguments\": {\n        \"pattern\": \"MODE\"\n      }\n    },\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"patch\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -1,3 +1,3 @@\\n-MODE=fast\\n+MODE=difficulty\\n\"\n      }\n    }\n  ],\n  \"plan\": [\n    \"Read router config\",\n    \"Patch MODE to difficulty\",\n    \"Add SLA guard test\"\n  ],\n  \"patch_summary\": \"Switched MODE default to difficulty and documented throughput SLA guard.\",\n  \"test_snippet\": \"expect(guardSoleCandidate(...)).toAllowFallbackWhenHardDenied();\"\n}"
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"src/router.ts\"\n      }\n    },\n    {\n      \"name\": \"grep_search\",\n      \"arguments\": {\n        \"pattern\": \"MODE\"\n      }\n    },\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"diff\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -1,3 +1,3 @@\\n-MODE=fast\\n+MODE=difficulty\\n\"\n      }\n    }\n  ],\n  \"plan\": [\n    \"Read router config\",\n    \"Patch MODE to difficulty\",\n    \"Add SLA guard test\"\n  ],\n  \"patch_summary\": \"Switched MODE default to difficulty and documented throughput SLA guard.\",\n  \"test_snippet\": \"expect(guardSoleCandidate(...)).toAllowFallbackWhenHardDenied();\"\n}"
     },
     {
       "case_id": "x02-max-context-tools",
@@ -1548,7 +1746,7 @@
         "kind": "tool_calls",
         "instruction": "Emit all required tool calls through the API in as few turns as needed. Do not write fake TOOL_CALL text. No final prose unless asked in a follow-up."
       },
-      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"patch\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -1,3 +1,3 @@\\n-MODE=fast\\n+MODE=difficulty\\n\"\n      }\n    }\n  ]\n}"
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"diff\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -1,3 +1,3 @@\\n-MODE=fast\\n+MODE=difficulty\\n\"\n      }\n    }\n  ]\n}"
     },
     {
       "case_id": "h07-multi-turn-sla-guard",
@@ -1612,7 +1810,7 @@
       ],
       "max_tokens": 320,
       "expected_response": "read_file runtime-config.yaml and routing.strategy value",
-      "grading_criteria": "Must call read_file on runtime-config.yaml after multi-turn context.",
+      "grading_criteria": "Must call read_file on runtime-config.yaml after multi-turn context and answer with the routing.strategy value from the provided tool result.",
       "accept_patterns": ["runtime-config|routing\\.strategy|strategy"],
       "required_tool_call": true,
       "expected_tool_names": ["read_file"],
@@ -1649,7 +1847,7 @@
           }
         }
       },
-      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"src/router.ts\"\n      }\n    }\n  ],\n  \"answer\": \"createRouter\"\n}"
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"state/runtime-config.yaml\"\n      }\n    }\n  ],\n  \"answer\": \"controller\"\n}"
     },
     {
       "case_id": "h09-agent-metrics-chain",
@@ -1668,11 +1866,11 @@
         },
         {
           "role": "user",
-          "content": "Phase 1b: API get_metrics for a remote endpoint_id"
+          "content": "Phase 1b: API get_metrics for both the local and remote endpoint_ids returned by list_endpoints"
         },
         {
           "role": "assistant",
-          "content": "get_metrics emitted."
+          "content": "get_metrics emitted for both endpoints."
         },
         {
           "role": "user",
@@ -1680,11 +1878,11 @@
         }
       ],
       "max_tokens": 1024,
-      "expected_response": "list_endpoints then get_metrics tool calls and latency comparison",
-      "grading_criteria": "Must call list_endpoints and get_metrics before summarizing latency.",
+      "expected_response": "list_endpoints then get_metrics tool calls for both compared endpoints and a one-sentence remote-vs-local latency comparison",
+      "grading_criteria": "Must call list_endpoints and get_metrics for both compared endpoints before summarizing latency, and the answer must explicitly compare remote vs local p95 latency.",
       "accept_patterns": ["latency|p95|remote|local|endpoint"],
       "required_tool_call": true,
-      "expected_tool_names": ["list_endpoints", "get_metrics"],
+      "expected_tool_names": ["list_endpoints", "get_metrics", "get_metrics"],
       "tools": [
         {
           "type": "function",
@@ -1717,7 +1915,7 @@
       "quick_benchmark": true,
       "answer_format": {
         "kind": "tool_calls_with_answer",
-        "instruction": "Step 1: emit required API tool calls. Step 2: after tools succeed, output ONLY a ```json fence: {\"answer\":\"...\"}. No reasoning inside the JSON.",
+        "instruction": "Step 1: emit list_endpoints and get_metrics tool calls for both compared endpoints. Step 2: after tools succeed, output ONLY a ```json fence: {\"answer\":\"<one sentence local-vs-remote latency comparison>\"}. No reasoning inside the JSON.",
         "schema": {
           "type": "object",
           "required": ["answer"],
@@ -1729,7 +1927,7 @@
           }
         }
       },
-      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"list_endpoints\",\n      \"arguments\": {}\n    },\n    {\n      \"name\": \"get_metrics\",\n      \"arguments\": {\n        \"endpoint_id\": \"local.primary\"\n      }\n    }\n  ],\n  \"answer\": \"local.primary has lower p95 latency for this workload.\"\n}"
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"list_endpoints\",\n      \"arguments\": {}\n    },\n    {\n      \"name\": \"get_metrics\",\n      \"arguments\": {\n        \"endpoint_id\": \"local.lfm2.5-8b-a1b\"\n      }\n    },\n    {\n      \"name\": \"get_metrics\",\n      \"arguments\": {\n        \"endpoint_id\": \"remote.deepseek-v4-flash\"\n      }\n    }\n  ],\n  \"answer\": \"local.lfm2.5-8b-a1b has lower p95 latency than remote.deepseek-v4-flash for this workload.\"\n}"
     },
     {
       "case_id": "h10-agent-read-grep-patch",
@@ -1804,7 +2002,7 @@
         "kind": "tool_calls",
         "instruction": "Emit all required tool calls through the API in as few turns as needed. Do not write fake TOOL_CALL text. No final prose unless asked in a follow-up."
       },
-      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"src/router.ts\"\n      }\n    },\n    {\n      \"name\": \"grep_search\",\n      \"arguments\": {\n        \"pattern\": \"MODE\"\n      }\n    },\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"patch\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -4,3 +4,3 @@\\n-MODE=fast\\n+MODE=difficulty\\n\"\n      }\n    }\n  ]\n}"
+      "example_deliverable": "{\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"src/router.ts\"\n      }\n    },\n    {\n      \"name\": \"grep_search\",\n      \"arguments\": {\n        \"pattern\": \"MODE\"\n      }\n    },\n    {\n      \"name\": \"apply_patch\",\n      \"arguments\": {\n        \"diff\": \"--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -4,3 +4,3 @@\\n-MODE=fast\\n+MODE=difficulty\\n\"\n      }\n    }\n  ]\n}"
     },
     {
       "case_id": "h11-decompose-code-verify",

--- a/role-model-router/packages/bench-routing/src/answer-format.test.ts
+++ b/role-model-router/packages/bench-routing/src/answer-format.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "vitest";
 
 import {
   augmentCaseMessages,
+  buildScaffoldFollowUp,
   extractFormattedAnswer,
   isValidDeliverable,
   resolveAnswerFormat,
+  shouldOmitToolsForTurn,
 } from "./answer-format.ts";
 
 describe("answer-format", () => {
@@ -132,5 +134,110 @@ describe("answer-format", () => {
         structuredToolNames: ["read_file"],
       }),
     ).toBe(true);
+  });
+
+  test("extracts json fences even when a json string contains nested markdown fences", () => {
+    const caseItem = {
+      case_id: "t03-tools-agent-plan",
+      category: "tools-heavy",
+      messages: [
+        {
+          role: "user",
+          content: "Return a JSON answer with a diff snippet embedded in the answer text.",
+        },
+      ],
+      grading_criteria: "structured json answer",
+    };
+    const raw = [
+      "```json",
+      '{"answer":"Patch summary:\\n```diff\\n--- a/src/router.ts\\n+++ b/src/router.ts\\n@@ -1 +1 @@\\n-old\\n+new\\n```"}',
+      "```",
+      'TOOL_CALL name=apply_patch args={"diff":"--- a/src/router.ts\\n+++ b/src/router.ts"}',
+    ].join("\n");
+    const extracted = extractFormattedAnswer({
+      caseItem,
+      rawContent: raw,
+      structuredToolNames: [],
+    });
+    expect(extracted.extractionMethod).toBe("json_fence");
+    expect(extracted.serialized).toContain("Patch summary:");
+    expect(extracted.serialized).toContain("--- a/src/router.ts");
+  });
+
+  test("continues requesting repeated same-name tools until duplicate expectations are satisfied", () => {
+    const caseItem = {
+      case_id: "p18-tools-agent",
+      category: "tools-heavy",
+      messages: [{ role: "user", content: "compare latency profiles" }],
+      required_tool_call: true,
+      expected_tool_names: ["list_endpoints", "get_metrics", "get_metrics"],
+      answer_format: {
+        kind: "tool_calls_with_answer" as const,
+        instruction: "tools then answer",
+        schema: {
+          type: "object",
+          required: ["answer"],
+          properties: { answer: { type: "string", minLength: 1 } },
+        },
+      },
+      grading_criteria: "compare routing strategies",
+    };
+
+    const extracted = extractFormattedAnswer({
+      caseItem,
+      rawContent: "",
+      structuredToolNames: ["list_endpoints", "get_metrics"],
+      toolCalls: [
+        { function: { name: "list_endpoints", arguments: "{}" } },
+        {
+          function: {
+            name: "get_metrics",
+            arguments: '{"endpoint_id":"local.lfm2.5-8b-a1b"}',
+          },
+        },
+      ],
+    });
+
+    expect(
+      shouldOmitToolsForTurn(caseItem, ["list_endpoints", "get_metrics"], [
+        { function: { name: "list_endpoints", arguments: "{}" } },
+        {
+          function: {
+            name: "get_metrics",
+            arguments: '{"endpoint_id":"local.lfm2.5-8b-a1b"}',
+          },
+        },
+      ]),
+    ).toBe(false);
+
+    const followUp = buildScaffoldFollowUp(
+      caseItem,
+      caseItem.messages as Record<string, unknown>[],
+      "",
+      ["list_endpoints", "get_metrics"],
+      extracted,
+      [
+        {
+          function: {
+            name: "get_metrics",
+            arguments: '{"endpoint_id":"local.lfm2.5-8b-a1b"}',
+          },
+        },
+      ],
+      [
+        { function: { name: "list_endpoints", arguments: "{}" } },
+        {
+          function: {
+            name: "get_metrics",
+            arguments: '{"endpoint_id":"local.lfm2.5-8b-a1b"}',
+          },
+        },
+      ],
+    );
+
+    expect(followUp.at(-1)).toMatchObject({
+      role: "user",
+      content: "Emit exactly one API tool call now (no prose): get_metrics",
+    });
   });
 });

--- a/role-model-router/packages/bench-routing/src/answer-format.ts
+++ b/role-model-router/packages/bench-routing/src/answer-format.ts
@@ -24,7 +24,6 @@ export interface ExtractedBenchmarkAnswer {
     | "missing";
 }
 
-const JSON_FENCE_PATTERN = /```(?:json)?\s*([\s\S]*?)```/gi;
 const PLACEHOLDER_PATTERN =
   /^\.{3}$|^<[^>]+>$|^check\s*[12]$|complete typescript|your answer here|placeholder|todo|tbd|first bullet|second bullet|one sentence comparing|fenced code block|no reasoning|your final short answer|milestone 1|what changed|short test idea|what schema fields|tests you validated/i;
 
@@ -36,6 +35,45 @@ export interface AnswerFormatCaseRef {
   readonly expected_tool_names?: readonly string[];
   readonly answer_format?: BenchmarkAnswerFormat;
   readonly grading_criteria?: string;
+}
+
+function buildObservedToolCallCounts(input: {
+  readonly structuredToolNames: readonly string[];
+  readonly toolCalls?: readonly { function: { name: string; arguments: string } }[];
+}): Map<string, number> {
+  const counts = new Map<string, number>();
+  const names =
+    input.toolCalls?.map((toolCall) => toolCall.function.name).filter((name) => name.length > 0) ??
+    input.structuredToolNames;
+  for (const name of names) {
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function listMissingExpectedToolCalls(input: {
+  readonly caseItem: AnswerFormatCaseRef;
+  readonly structuredToolNames: readonly string[];
+  readonly toolCalls?: readonly { function: { name: string; arguments: string } }[];
+}): string[] {
+  const expected = input.caseItem.expected_tool_names ?? [];
+  if (expected.length === 0) {
+    return [];
+  }
+  const observedCounts = buildObservedToolCallCounts({
+    structuredToolNames: input.structuredToolNames,
+    toolCalls: input.toolCalls,
+  });
+  const missing: string[] = [];
+  for (const name of expected) {
+    const remaining = observedCounts.get(name) ?? 0;
+    if (remaining > 0) {
+      observedCounts.set(name, remaining - 1);
+    } else {
+      missing.push(name);
+    }
+  }
+  return missing;
 }
 
 function messageText(caseItem: AnswerFormatCaseRef): string {
@@ -169,10 +207,78 @@ function parseJsonCandidate(candidate: string): unknown | null {
   }
 }
 
+function stripBenchmarkToolCallLines(raw: string): string {
+  return raw
+    .split(/\r?\n/)
+    .filter((line) => !/^TOOL_CALL name=\S+\s+args=/.test(line.trim()))
+    .join("\n");
+}
+
+function isFenceLineStart(raw: string, index: number): boolean {
+  return index === 0 || raw[index - 1] === "\n";
+}
+
+function findClosingFenceIndex(raw: string, start: number): number {
+  for (let index = start; index < raw.length; index += 1) {
+    if (raw.startsWith("```", index) && isFenceLineStart(raw, index)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function collectFenceBodies(raw: string, languages?: readonly string[]): string[] {
+  const bodies: string[] = [];
+  let cursor = 0;
+  while (cursor < raw.length) {
+    const openIndex = raw.indexOf("```", cursor);
+    if (openIndex < 0) {
+      break;
+    }
+    let index = openIndex + 3;
+    const languageStart = index;
+    while (index < raw.length && /[a-z0-9_-]/i.test(raw[index] ?? "")) {
+      index += 1;
+    }
+    const language = raw.slice(languageStart, index).toLowerCase();
+    const languageAllowed =
+      !languages || languages.length === 0 || language.length === 0 || languages.includes(language);
+    while (index < raw.length && (raw[index] === " " || raw[index] === "\t")) {
+      index += 1;
+    }
+    const newlineLength =
+      raw[index] === "\r" && raw[index + 1] === "\n" ? 2 : raw[index] === "\n" ? 1 : 0;
+    if (newlineLength > 0) {
+      const bodyStart = index + newlineLength;
+      const closeIndex = findClosingFenceIndex(raw, bodyStart);
+      if (closeIndex < 0) {
+        break;
+      }
+      if (languageAllowed) {
+        bodies.push(raw.slice(bodyStart, closeIndex));
+      }
+      cursor = closeIndex + 3;
+      continue;
+    }
+    const closeIndex = raw.indexOf("```", index);
+    if (closeIndex < 0) {
+      break;
+    }
+    if (languageAllowed) {
+      const inlineBody = raw.slice(index, closeIndex).trim();
+      if (inlineBody) {
+        bodies.push(inlineBody);
+      }
+    }
+    cursor = closeIndex + 3;
+  }
+  return bodies;
+}
+
 function collectJsonFenceCandidates(raw: string): unknown[] {
   const candidates: unknown[] = [];
-  for (const match of raw.matchAll(JSON_FENCE_PATTERN)) {
-    const parsed = parseJsonCandidate(match[1] ?? "");
+  for (const body of collectFenceBodies(raw, ["json"])) {
+    const parsed = parseJsonCandidate(body);
     if (parsed !== null) {
       candidates.push(parsed);
     }
@@ -182,7 +288,7 @@ function collectJsonFenceCandidates(raw: string): unknown[] {
 
 function collectJsonObjectCandidates(raw: string): unknown[] {
   const candidates: unknown[] = [];
-  const trimmed = raw.trim();
+  const trimmed = stripBenchmarkToolCallLines(raw).trim();
   const start = trimmed.lastIndexOf("{");
   if (start >= 0) {
     for (let end = trimmed.length; end > start; end -= 1) {
@@ -213,17 +319,9 @@ function looksLikeReasoningProse(code: string): boolean {
 }
 
 function collectCodeFences(raw: string, language?: string): string[] {
-  const results: string[] = [];
-  for (const lang of [language ?? "typescript", "ts", "typescript"]) {
-    const pattern = new RegExp(`\`\`\`${lang}\\s*([\\s\\S]*?)\`\`\``, "gi");
-    for (const match of raw.matchAll(pattern)) {
-      const body = match[1]?.trim();
-      if (body) {
-        results.push(body);
-      }
-    }
-  }
-  return results;
+  return collectFenceBodies(raw, [language ?? "typescript", "ts", "typescript"])
+    .map((body) => body.trim())
+    .filter(Boolean);
 }
 
 function scoreCodeCandidate(code: string): number {
@@ -325,7 +423,7 @@ function extractTextJsonFields(
 ): Record<string, unknown> {
   const fenceCandidates = collectJsonFenceCandidates(raw);
   const objectCandidates = collectJsonObjectCandidates(raw);
-  const jsonPayload = pickJsonPayload([...fenceCandidates, ...objectCandidates], format);
+  const jsonPayload = pickJsonPayload([...objectCandidates, ...fenceCandidates], format);
   return jsonPayload && typeof jsonPayload === "object"
     ? (jsonPayload as Record<string, unknown>)
     : {};
@@ -366,22 +464,28 @@ export function deliverableCompleteness(input: {
   readonly caseItem: AnswerFormatCaseRef;
   readonly extracted: ExtractedBenchmarkAnswer;
   readonly structuredToolNames: readonly string[];
+  readonly toolCalls?: readonly { function: { name: string; arguments: string } }[];
 }): number {
   if (
     isValidDeliverable({
       caseItem: input.caseItem,
       extracted: input.extracted,
       structuredToolNames: input.structuredToolNames,
+      toolCalls: input.toolCalls,
     })
   ) {
     return 1000;
   }
   const expectedTools = input.caseItem.expected_tool_names ?? [];
+  const missingTools = listMissingExpectedToolCalls({
+    caseItem: input.caseItem,
+    structuredToolNames: input.structuredToolNames,
+    toolCalls: input.toolCalls,
+  });
   const toolScore =
     expectedTools.length === 0
       ? 1
-      : expectedTools.filter((name) => input.structuredToolNames.includes(name)).length /
-        expectedTools.length;
+      : (expectedTools.length - missingTools.length) / expectedTools.length;
   const payload =
     input.extracted.payload && typeof input.extracted.payload === "object"
       ? (input.extracted.payload as Record<string, unknown>)
@@ -445,7 +549,7 @@ export function extractFormattedAnswer(input: {
 
   const fenceCandidates = collectJsonFenceCandidates(input.rawContent);
   const objectCandidates = collectJsonObjectCandidates(input.rawContent);
-  const jsonPayload = pickJsonPayload([...fenceCandidates, ...objectCandidates], format);
+  const jsonPayload = pickJsonPayload([...objectCandidates, ...fenceCandidates], format);
 
   if (format.kind === "code_fence") {
     const codeFromFence = input.turnRawContents?.length
@@ -486,6 +590,7 @@ export function isValidDeliverable(input: {
   readonly caseItem: AnswerFormatCaseRef;
   readonly extracted: ExtractedBenchmarkAnswer;
   readonly structuredToolNames: readonly string[];
+  readonly toolCalls?: readonly { function: { name: string; arguments: string } }[];
 }): boolean {
   const { extracted, caseItem, structuredToolNames } = input;
   if (extracted.extractionMethod === "missing" || !extracted.serialized) {
@@ -501,7 +606,11 @@ export function isValidDeliverable(input: {
 
   const expectedTools = caseItem.expected_tool_names ?? [];
   if (expectedTools.length > 0) {
-    const missingTools = expectedTools.filter((name) => !structuredToolNames.includes(name));
+    const missingTools = listMissingExpectedToolCalls({
+      caseItem,
+      structuredToolNames,
+      toolCalls: input.toolCalls,
+    });
     if (missingTools.length > 0) {
       return false;
     }
@@ -624,12 +733,16 @@ export function buildTextDeliverableResponseFormat(
 export function shouldOmitToolsForTurn(
   caseItem: AnswerFormatCaseRef,
   structuredToolNames: readonly string[],
+  toolCalls?: readonly { function: { name: string; arguments: string } }[],
 ): boolean {
-  const expectedTools = caseItem.expected_tool_names ?? [];
-  if (expectedTools.length === 0) {
+  const missingTools = listMissingExpectedToolCalls({
+    caseItem,
+    structuredToolNames,
+    toolCalls,
+  });
+  if ((caseItem.expected_tool_names ?? []).length === 0) {
     return false;
   }
-  const missingTools = expectedTools.filter((name) => !structuredToolNames.includes(name));
   if (missingTools.length > 0) {
     return false;
   }
@@ -646,11 +759,78 @@ const MOCK_TOOL_CONTENT: Record<string, string> = {
   apply_patch: "Patch applied successfully. 1 file changed, 2 insertions(+), 1 deletion(-).",
 };
 
-function buildToolMessage(toolName: string, toolCallId: string): Record<string, unknown> {
+function buildMockToolContent(
+  caseItem: AnswerFormatCaseRef,
+  toolCall: { function: { name: string; arguments: string } },
+): string {
+  const toolName = toolCall.function.name;
+  const parsedArguments =
+    (parseJsonCandidate(toolCall.function.arguments) as Record<string, unknown> | null) ?? {};
+  const path = typeof parsedArguments.path === "string" ? parsedArguments.path : "";
+  const endpointId =
+    typeof parsedArguments.endpoint_id === "string" ? parsedArguments.endpoint_id : "";
+
+  switch (caseItem.case_id) {
+    case "p15-tools-read-one":
+    case "h08-multi-turn-tool-refine":
+      if (toolName === "read_file" && /runtime-config\.yaml$/i.test(path)) {
+        return ["routing:", "  strategy: controller", "  execution_mode: hybrid"].join("\n");
+      }
+      break;
+    case "p16-tools-search":
+      if (toolName === "grep_search") {
+        return [
+          "src/router.ts:16 if (input.throughputSlaHardDeny && eligible.length === 0) return deny('throughput_sla');",
+          "src/router.ts:44 const hardDenied = input.throughputSlaHardDeny && candidate.tokensPerSecond < 24;",
+        ].join("\n");
+      }
+      break;
+    case "t01-tools-list-dir":
+      if (toolName === "list_dir") {
+        return ["config/", "router.yaml", "routing-policy.json", "auth.env", "themes.css"].join(
+          "\n",
+        );
+      }
+      break;
+    case "p18-tools-agent":
+    case "h09-agent-metrics-chain":
+      if (toolName === "list_endpoints") {
+        return JSON.stringify(
+          {
+            endpoints: [
+              { endpoint_id: "local.lfm2.5-8b-a1b", model_id: "lfm2.5-8b-a1b", status: "active" },
+              {
+                endpoint_id: "remote.deepseek-v4-flash",
+                model_id: "deepseek/deepseek-v4-flash",
+                status: "active",
+              },
+            ],
+          },
+          null,
+          2,
+        );
+      }
+      if (toolName === "get_metrics" && endpointId === "local.lfm2.5-8b-a1b") {
+        return JSON.stringify({ p95_latency_ms: 62, request_count: 1200, error_rate: 0.005 });
+      }
+      if (toolName === "get_metrics" && endpointId === "remote.deepseek-v4-flash") {
+        return JSON.stringify({ p95_latency_ms: 245, request_count: 900, error_rate: 0.018 });
+      }
+      break;
+  }
+
+  return MOCK_TOOL_CONTENT[toolName] ?? `Mock response from ${toolName}.`;
+}
+
+function buildToolMessage(
+  caseItem: AnswerFormatCaseRef,
+  toolCall: { function: { name: string; arguments: string } },
+  toolCallId: string,
+): Record<string, unknown> {
   return {
     role: "tool",
     tool_call_id: toolCallId,
-    content: MOCK_TOOL_CONTENT[toolName] ?? `Mock response from ${toolName}.`,
+    content: buildMockToolContent(caseItem, toolCall),
   };
 }
 
@@ -661,14 +841,18 @@ export function buildScaffoldFollowUp(
   structuredToolNames: readonly string[],
   _extracted: ExtractedBenchmarkAnswer,
   toolCalls?: readonly { function: { name: string; arguments: string } }[],
+  allToolCalls?: readonly { function: { name: string; arguments: string } }[],
 ): Record<string, unknown>[] {
   const assistantMessage = buildAssistantScaffoldMessage(assistantOutput, toolCalls);
-  const expectedTools = caseItem.expected_tool_names ?? [];
-  const missingTools = expectedTools.filter((name) => !structuredToolNames.includes(name));
+  const missingTools = listMissingExpectedToolCalls({
+    caseItem,
+    structuredToolNames,
+    toolCalls: allToolCalls ?? toolCalls,
+  });
 
   // Build role:"tool" messages for all completed tool calls
-  const completedToolMsgs = (toolCalls ?? []).map((_tc, index) =>
-    buildToolMessage(toolCalls?.[index]?.function?.name ?? "unknown", `bench_scaffold_${index}`),
+  const completedToolMsgs = (toolCalls ?? []).map((toolCall, index) =>
+    buildToolMessage(caseItem, toolCall, `bench_scaffold_${index}`),
   );
 
   if (missingTools.length > 0) {

--- a/role-model-router/packages/bench-routing/src/diff-validator.test.ts
+++ b/role-model-router/packages/bench-routing/src/diff-validator.test.ts
@@ -10,7 +10,7 @@ const P17_LFM_DELIVERABLE = JSON.stringify(
   {
     tool_calls: [
       { name: "read_file", arguments: { path: "src/router.ts" } },
-      { name: "apply_patch", arguments: { patch: "----/+++" } },
+      { name: "apply_patch", arguments: { diff: "----/+++" } },
     ],
     answer: "what schema fields and tests you validated",
   },
@@ -27,10 +27,48 @@ describe("diff-validator", () => {
         "--- a/src/router.ts\n+++ b/src/router.ts\n@@ -1,3 +1,3 @@\n-MODE=fast\n+MODE=difficulty\n",
       ),
     ).toBe(false);
+    expect(
+      isPlaceholderUnifiedDiff(
+        [
+          "*** Begin Patch",
+          "*** Update File: src/router.ts",
+          "@@",
+          "-const MODE = 'baseline';",
+          "+const MODE = 'difficulty';",
+          "*** End Patch",
+        ].join("\n"),
+      ),
+    ).toBe(false);
   });
 
-  test("detects invalid patch arguments inside deliverable JSON", () => {
+  test("detects invalid diff arguments inside deliverable JSON", () => {
     expect(deliverableHasInvalidPatch(P17_LFM_DELIVERABLE)).toBe(true);
+  });
+
+  test("accepts Codex patch envelopes inside deliverable JSON", () => {
+    const deliverable = JSON.stringify(
+      {
+        tool_calls: [
+          {
+            name: "apply_patch",
+            arguments: {
+              diff: [
+                "*** Begin Patch",
+                "*** Update File: src/router.ts",
+                "@@",
+                "-const MODE = 'baseline';",
+                "+const MODE = 'difficulty';",
+                "*** End Patch",
+              ].join("\n"),
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
+    expect(deliverableHasInvalidPatch(deliverable)).toBe(false);
   });
 
   test("caps p17 LFM judge score below 0.5 when placeholder diff present", () => {

--- a/role-model-router/packages/bench-routing/src/diff-validator.ts
+++ b/role-model-router/packages/bench-routing/src/diff-validator.ts
@@ -7,6 +7,20 @@ const PLACEHOLDER_DIFF_MARKERS = [
   /^=======\s*$/,
 ];
 
+const CODEX_PATCH_BEGIN = /^\*\*\* Begin Patch$/m;
+const CODEX_PATCH_END = /^\*\*\* End Patch$/m;
+const CODEX_PATCH_FILE_OPERATION = /^\*\*\* (?:Update|Add|Delete) File: .+/m;
+const CODEX_PATCH_CONTENT = /^(?:@@|[+-][^\r\n]*)$/m;
+
+function isValidCodexPatchEnvelope(patch: string): boolean {
+  return (
+    CODEX_PATCH_BEGIN.test(patch) &&
+    CODEX_PATCH_END.test(patch) &&
+    CODEX_PATCH_FILE_OPERATION.test(patch) &&
+    CODEX_PATCH_CONTENT.test(patch)
+  );
+}
+
 export function isPlaceholderUnifiedDiff(diff: string): boolean {
   const trimmed = diff.trim();
   if (!trimmed) {
@@ -14,6 +28,9 @@ export function isPlaceholderUnifiedDiff(diff: string): boolean {
   }
   if (PLACEHOLDER_DIFF_MARKERS.some((pattern) => pattern.test(trimmed))) {
     return true;
+  }
+  if (isValidCodexPatchEnvelope(trimmed)) {
+    return false;
   }
   if (!trimmed.includes("@@")) {
     return true;
@@ -30,9 +47,11 @@ export function extractPatchArgumentsFromDeliverable(deliverable: string): strin
     const parsed = JSON.parse(deliverable) as unknown;
     collectPatchValues(parsed, patches);
   } catch {
-    const inline = deliverable.match(/"patch"\s*:\s*"((?:\\.|[^"\\])*)"/);
-    if (inline?.[1]) {
-      patches.push(JSON.parse(`"${inline[1]}"`) as string);
+    const inlineMatches = deliverable.matchAll(/"(?:diff|patch)"\s*:\s*"((?:\\.|[^"\\])*)"/g);
+    for (const inline of inlineMatches) {
+      if (inline[1]) {
+        patches.push(JSON.parse(`"${inline[1]}"`) as string);
+      }
     }
   }
   return patches;
@@ -49,11 +68,17 @@ function collectPatchValues(value: unknown, patches: string[]): void {
     return;
   }
   const record = value as Record<string, unknown>;
+  if (typeof record.diff === "string") {
+    patches.push(record.diff);
+  }
   if (typeof record.patch === "string") {
     patches.push(record.patch);
   }
   if (record.arguments && typeof record.arguments === "object") {
     const args = record.arguments as Record<string, unknown>;
+    if (typeof args.diff === "string") {
+      patches.push(args.diff);
+    }
     if (typeof args.patch === "string") {
       patches.push(args.patch);
     }
@@ -89,6 +114,6 @@ export function capJudgeScoreForInvalidDeliverable(input: {
   const capped = Math.min(input.score, 0.4);
   return {
     score: capped,
-    rationale: `${input.rationale} Invalid apply_patch diff (placeholder or missing @@ hunk); score capped.`,
+    rationale: `${input.rationale} Invalid apply_patch payload (placeholder or malformed unified diff / Codex patch envelope); score capped.`,
   };
 }

--- a/role-model-router/packages/bench-routing/src/index.test.ts
+++ b/role-model-router/packages/bench-routing/src/index.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "vitest";
 
+import routingCapabilitySuite from "../data/routing-capability-suite.json" with { type: "json" };
+
 import {
+  buildScaffoldFollowUp,
   buildHeuristicCompareRanking,
   buildJudgeRequestMessages,
+  capJudgeScoreForGroundedTruthMismatch,
+  extractFormattedAnswer,
   gradeBenchmarkCase,
   selectBenchmarkCases,
 } from "./index.ts";
@@ -130,6 +135,36 @@ describe("bench-routing", () => {
     expect(grade.rationale).toContain("[judge_unavailable]");
   });
 
+  test("normalizes binary exact answers when judge rejects casing only", () => {
+    const caseItem = {
+      case_id: "e01-yes-no",
+      category: "easy-trivial",
+      difficulty_bucket: "easy",
+      benchmark_eligible: true,
+      capability_targets: ["instruction_following"],
+      messages: [{ role: "user", content: "Is water wet? Answer yes or no only." }],
+      max_tokens: 8,
+      expected_response: "yes",
+      grading_criteria: "Must answer yes or no only.",
+      accept_patterns: ["^yes$", "^no$"],
+    } as const;
+
+    const grade = gradeBenchmarkCase({
+      caseItem,
+      actualResponse: '{"answer":"Yes"}',
+      requireJudge: true,
+      judgeGrade: {
+        score: 0,
+        rationale: "Judge rejected casing.",
+        method: "judge",
+      },
+    });
+
+    expect(grade.method).toBe("judge");
+    expect(grade.score).toBe(1);
+    expect(grade.rationale).toContain("case_normalized_exact_match");
+  });
+
   test("allows judge endpoint to overlap benchmark subjects without guard errors", () => {
     const caseItem = {
       case_id: "h01-implement-two-sum",
@@ -179,5 +214,449 @@ describe("bench-routing", () => {
     });
     expect(grade.score).toBe(1);
     expect(grade.method).toBe("heuristic");
+  });
+
+  test("tool workflow benchmark cases declare explicit tool requirements and answer formats", () => {
+    for (const caseId of [
+      "t01-tools-list-dir",
+      "p16-tools-search",
+      "p18-tools-agent",
+      "t03-tools-agent-plan",
+      "h08-multi-turn-tool-refine",
+    ]) {
+      const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === caseId);
+      expect(caseItem?.expected_tool_names?.length).toBeGreaterThan(0);
+      expect(caseItem?.answer_format).toBeTruthy();
+    }
+  });
+
+  test("p15 names the grounded runtime config path directly in the prompt", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "p15-tools-read-one");
+    expect(caseItem).toBeTruthy();
+    const combinedMessages = (caseItem?.messages ?? [])
+      .map((message) => (typeof message.content === "string" ? message.content : ""))
+      .join("\n");
+    expect(combinedMessages).toContain("state/runtime-config.yaml");
+  });
+
+  test("p18 encodes repeated get_metrics calls in its expected tool contract", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "p18-tools-agent");
+    expect(caseItem).toBeTruthy();
+    expect(caseItem?.expected_tool_names).toEqual([
+      "list_endpoints",
+      "get_metrics",
+      "get_metrics",
+    ]);
+  });
+
+  test("e08 declares the top-level json schema it already grades against", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "e08-format-json");
+    expect(caseItem).toBeTruthy();
+    expect(caseItem?.answer_format).toEqual({
+      kind: "json",
+      instruction:
+        'Return ONLY a ```json fence: {"name":"...","value":"..."}. Do not wrap it in an `answer` field.',
+      schema: {
+        type: "object",
+        required: ["name", "value"],
+        properties: {
+          name: { type: "string" },
+          value: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+    });
+  });
+
+  test("t03 declares explicit tool and structured summary requirements", () => {
+    const caseItem = routingCapabilitySuite.cases.find(
+      (item) => item.case_id === "t03-tools-agent-plan",
+    );
+    expect(caseItem).toBeTruthy();
+    expect(caseItem?.expected_tool_names).toEqual(["read_file", "validate_schema", "apply_patch"]);
+    expect(caseItem?.answer_format).toEqual({
+      kind: "tool_calls_with_summary",
+      instruction:
+        'Step 1: emit the required API tool calls. Step 2: after tools, output ONLY a ```json fence: {"plan":["..."],"patch_summary":"...","strategy_improvements":["..."]}.',
+      schema: {
+        type: "object",
+        required: ["plan", "patch_summary", "strategy_improvements"],
+        properties: {
+          plan: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            minItems: 3,
+          },
+          patch_summary: {
+            type: "string",
+            minLength: 12,
+          },
+          strategy_improvements: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            minItems: 2,
+          },
+        },
+        additionalProperties: false,
+      },
+    });
+  });
+
+  test("under-specified code-edit benchmark prompts include inline source context", () => {
+    for (const caseId of ["p12-code-patch", "p14-schema-validate", "c01-full-refactor"]) {
+      const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === caseId);
+      expect(caseItem).toBeTruthy();
+      const combinedMessages = (caseItem?.messages ?? [])
+        .map((message) => (typeof message.content === "string" ? message.content : ""))
+        .join("\n");
+      expect(combinedMessages).toContain("```");
+    }
+  });
+
+  test("h08 scaffold follow-up returns runtime-config content aligned to routing.strategy prompt", () => {
+    const caseItem = routingCapabilitySuite.cases.find(
+      (item) => item.case_id === "h08-multi-turn-tool-refine",
+    );
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case h08-multi-turn-tool-refine.");
+    }
+
+    const extracted = extractFormattedAnswer({
+      caseItem,
+      rawContent: '```json {"answer":"controller"} ```',
+      structuredToolNames: ["read_file"],
+      toolCalls: [
+        {
+          function: {
+            name: "read_file",
+            arguments: '{"path":"state/runtime-config.yaml"}',
+          },
+        },
+      ],
+    });
+
+    const followUp = buildScaffoldFollowUp(
+      caseItem,
+      caseItem.messages as Record<string, unknown>[],
+      '{"answer":"controller"}',
+      ["read_file"],
+      extracted,
+      [
+        {
+          function: {
+            name: "read_file",
+            arguments: '{"path":"state/runtime-config.yaml"}',
+          },
+        },
+      ],
+    );
+
+    const toolMessage = followUp.find((message) => message.role === "tool");
+    expect(typeof toolMessage?.content).toBe("string");
+    expect(String(toolMessage?.content)).toContain("routing:");
+    expect(String(toolMessage?.content)).toContain("strategy: controller");
+  });
+
+  test("caps grounded tool-case score when p15 uses the wrong path and answer", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "p15-tools-read-one");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case p15-tools-read-one.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool call and JSON answer were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          {
+            name: "read_file",
+            arguments: { path: "runtime_config.json" },
+          },
+        ],
+        answer: "round_robin",
+      }),
+    });
+
+    expect(capped.score).toBeLessThan(1);
+    expect(capped.rationale).toContain("grounded_truth_mismatch");
+  });
+
+  test("does not cap p15 when any repeated read_file call hits the grounded path", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "p15-tools-read-one");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case p15-tools-read-one.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool call and JSON answer were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          {
+            name: "read_file",
+            arguments: { path: "runtime_config.json" },
+          },
+          {
+            name: "read_file",
+            arguments: { path: "state/runtime-config.yaml" },
+          },
+        ],
+        answer: "controller",
+      }),
+    });
+
+    expect(capped.score).toBe(1);
+  });
+
+  test("does not cap p15 when the grounded runtime config path is absolute", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "p15-tools-read-one");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case p15-tools-read-one.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool call and JSON answer were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          {
+            name: "read_file",
+            arguments: { path: "C:\\Users\\erikb\\AppData\\Local\\RMCS\\ws\\run\\state\\runtime-config.yaml" },
+          },
+        ],
+        answer: "controller",
+      }),
+    });
+
+    expect(capped.score).toBe(1);
+  });
+
+  test("caps grounded tool-case score when t01 invents filenames not present in the scaffold listing", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "t01-tools-list-dir");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case t01-tools-list-dir.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool call and JSON answer were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          {
+            name: "list_dir",
+            arguments: { path: "config" },
+          },
+        ],
+        answer: "In config, the routing-related filename is routes.rb.",
+      }),
+    });
+
+    expect(capped.score).toBeLessThan(1);
+    expect(capped.rationale).toContain("grounded_truth_mismatch");
+  });
+
+  test("does not cap t01 when any repeated list_dir call inspects config", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "t01-tools-list-dir");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case t01-tools-list-dir.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool call and JSON answer were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          {
+            name: "list_dir",
+            arguments: { path: "." },
+          },
+          {
+            name: "list_dir",
+            arguments: { path: "config" },
+          },
+        ],
+        answer: "router.yaml and routing-policy.json are the routing-related filenames.",
+      }),
+    });
+
+    expect(capped.score).toBe(1);
+  });
+
+  test("does not cap t01 when list_dir inspects an absolute config path", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "t01-tools-list-dir");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case t01-tools-list-dir.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool call and JSON answer were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          {
+            name: "list_dir",
+            arguments: { path: "C:\\Users\\erikb\\AppData\\Local\\RMCS\\ws\\run\\config" },
+          },
+        ],
+        answer: "router.yaml and routing-policy.json are the routing-related filenames.",
+      }),
+    });
+
+    expect(capped.score).toBe(1);
+  });
+
+  test("caps p18 when routing advice cites comparison data without fetching both metric sets", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "p18-tools-agent");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case p18-tools-agent.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool calls and recommendation were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          { name: "list_endpoints", arguments: {} },
+          { name: "get_metrics", arguments: { endpoint_id: "remote.deepseek-v4-flash" } },
+        ],
+        answer:
+          "Route latency-sensitive traffic to local.lfm2.5-8b-a1b because its p95 latency is 62 ms versus 245 ms for remote.deepseek-v4-flash.",
+      }),
+    });
+
+    expect(capped.score).toBe(0);
+    expect(capped.rationale).toContain("grounded_truth_mismatch");
+  });
+
+  test("does not cap p18 when both metric calls are present", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "p18-tools-agent");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case p18-tools-agent.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool calls and recommendation were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          { name: "list_endpoints", arguments: {} },
+          { name: "get_metrics", arguments: { endpoint_id: "local.lfm2.5-8b-a1b" } },
+          { name: "get_metrics", arguments: { endpoint_id: "remote.deepseek-v4-flash" } },
+        ],
+        answer:
+          "Keep local as default for latency-sensitive traffic and retain remote.deepseek-v4-flash as a fallback for harder requests.",
+      }),
+    });
+
+    expect(capped.score).toBe(1);
+  });
+
+  test("caps h09 when the answer does not compare local and remote latency", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "h09-agent-metrics-chain");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case h09-agent-metrics-chain.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool calls and latency sentence were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          { name: "list_endpoints", arguments: {} },
+          { name: "get_metrics", arguments: { endpoint_id: "local.lfm2.5-8b-a1b" } },
+          { name: "get_metrics", arguments: { endpoint_id: "remote.deepseek-v4-flash" } },
+        ],
+        answer: "The remote endpoint p95 latency is 245 ms; local latency data was not available.",
+      }),
+    });
+
+    expect(capped.score).toBe(0);
+    expect(capped.rationale).toContain("grounded_truth_mismatch");
+  });
+
+  test("caps h09 when one side of the latency comparison was never fetched", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "h09-agent-metrics-chain");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case h09-agent-metrics-chain.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool calls and comparison were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          { name: "list_endpoints", arguments: {} },
+          { name: "get_metrics", arguments: { endpoint_id: "remote.deepseek-v4-flash" } },
+        ],
+        answer:
+          "The local.lfm2.5-8b-a1b endpoint has lower p95 latency than remote.deepseek-v4-flash.",
+      }),
+    });
+
+    expect(capped.score).toBe(0);
+    expect(capped.rationale).toContain("grounded_truth_mismatch");
+  });
+
+  test("does not cap h09 when both endpoint metrics support the grounded comparison", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "h09-agent-metrics-chain");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case h09-agent-metrics-chain.");
+    }
+
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem,
+      score: 1,
+      rationale: "Tool calls and comparison were present.",
+      deliverable: JSON.stringify({
+        tool_calls: [
+          { name: "list_endpoints", arguments: {} },
+          { name: "get_metrics", arguments: { endpoint_id: "local.lfm2.5-8b-a1b" } },
+          { name: "get_metrics", arguments: { endpoint_id: "remote.deepseek-v4-flash" } },
+        ],
+        answer:
+          "local.lfm2.5-8b-a1b has lower p95 latency than remote.deepseek-v4-flash for this workload.",
+      }),
+    });
+
+    expect(capped.score).toBe(1);
+  });
+
+  test("h09 encodes both compared get_metrics calls in its contract", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "h09-agent-metrics-chain");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case h09-agent-metrics-chain.");
+    }
+
+    expect(caseItem.expected_tool_names).toEqual(["list_endpoints", "get_metrics", "get_metrics"]);
+    const combinedMessages = caseItem.messages.map((message) => message.content).join("\n");
+    expect(combinedMessages).toContain("both the local and remote endpoint_ids");
+    expect(caseItem.answer_format?.instruction).toContain("both compared endpoints");
   });
 });

--- a/role-model-router/packages/bench-routing/src/index.ts
+++ b/role-model-router/packages/bench-routing/src/index.ts
@@ -216,6 +216,217 @@ function gradeBenchmarkCaseHeuristic(input: {
   return contentGrade;
 }
 
+function tryParseDeliverableJson(deliverable: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(deliverable) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function readNormalizedBinaryAnswer(caseItem: RoutingBenchmarkCase, deliverable: string): string | null {
+  const expected = caseItem.expected_response.trim().toLowerCase();
+  if (!["yes", "no", "true", "false"].includes(expected)) {
+    return null;
+  }
+
+  const parsed = tryParseDeliverableJson(deliverable);
+  const answer =
+    typeof parsed?.answer === "string"
+      ? parsed.answer
+      : typeof parsed?.value === "string"
+        ? parsed.value
+        : deliverable;
+  const normalized = answer.trim().toLowerCase();
+  return normalized === expected ? normalized : null;
+}
+
+function readToolCallArguments(
+  toolCall: Record<string, unknown> | undefined,
+): Record<string, unknown> | null {
+  if (!toolCall) {
+    return null;
+  }
+  const argumentsValue = toolCall.arguments;
+  if (argumentsValue && typeof argumentsValue === "object") {
+    return argumentsValue as Record<string, unknown>;
+  }
+  if (typeof argumentsValue === "string") {
+    try {
+      const parsed = JSON.parse(argumentsValue) as unknown;
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function readToolCalls(deliverable: Record<string, unknown>): readonly Record<string, unknown>[] {
+  const toolCalls = deliverable.tool_calls;
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+  return toolCalls.filter(
+    (toolCall): toolCall is Record<string, unknown> =>
+      !!toolCall && typeof toolCall === "object",
+  );
+}
+
+function normalizeGroundedToolPath(pathValue: unknown): string | null {
+  if (typeof pathValue !== "string") {
+    return null;
+  }
+  return pathValue.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+function groundedTruthMismatchDetails(
+  caseItem: RoutingBenchmarkCase,
+  deliverable: string,
+): string[] {
+  const parsed = tryParseDeliverableJson(deliverable);
+  if (!parsed) {
+    return [];
+  }
+  const toolCalls = readToolCalls(parsed);
+  const answer = typeof parsed.answer === "string" ? parsed.answer : "";
+  const lowerAnswer = answer.toLowerCase();
+
+  switch (caseItem.case_id) {
+    case "p15-tools-read-one":
+    case "h08-multi-turn-tool-refine": {
+      const hasGroundedReadFile = toolCalls.some((toolCall) => {
+        if (toolCall.name !== "read_file") {
+          return false;
+        }
+        const normalizedPath = normalizeGroundedToolPath(readToolCallArguments(toolCall)?.path);
+        return (
+          normalizedPath === "state/runtime-config.yaml" ||
+          normalizedPath?.endsWith("/state/runtime-config.yaml") === true
+        );
+      });
+      if (!hasGroundedReadFile) {
+        return ["expected read_file path state/runtime-config.yaml"];
+      }
+      if (lowerAnswer !== "controller") {
+        return ['expected grounded answer "controller"'];
+      }
+      return [];
+    }
+    case "t01-tools-list-dir": {
+      const inspectedConfigDir = toolCalls.some((toolCall) => {
+        if (toolCall.name !== "list_dir") {
+          return false;
+        }
+        const normalizedPath = normalizeGroundedToolPath(readToolCallArguments(toolCall)?.path);
+        return normalizedPath === "config" || normalizedPath?.endsWith("/config") === true;
+      });
+      if (!inspectedConfigDir) {
+        return ["expected list_dir path config"];
+      }
+      if (!lowerAnswer.includes("router.yaml") || !lowerAnswer.includes("routing-policy.json")) {
+        return ["expected answer grounded in router.yaml and routing-policy.json"];
+      }
+      return [];
+    }
+    case "p18-tools-agent": {
+      const hasListEndpoints = toolCalls.some((toolCall) => toolCall.name === "list_endpoints");
+      if (!hasListEndpoints) {
+        return ["expected list_endpoints call before routing recommendation"];
+      }
+      const metricEndpointIds = [
+        ...new Set(
+          toolCalls
+            .filter((toolCall) => toolCall.name === "get_metrics")
+            .map((toolCall) => readToolCallArguments(toolCall)?.endpoint_id)
+            .filter((value): value is string => typeof value === "string" && value.length > 0),
+        ),
+      ];
+      if (metricEndpointIds.length < 2) {
+        return ["expected get_metrics calls for both endpoints used in the comparison"];
+      }
+      return [];
+    }
+    case "h09-agent-metrics-chain": {
+      const hasListEndpoints = toolCalls.some((toolCall) => toolCall.name === "list_endpoints");
+      if (!hasListEndpoints) {
+        return ["expected list_endpoints call before latency comparison"];
+      }
+      const metricEndpointIds = [
+        ...new Set(
+          toolCalls
+            .filter((toolCall) => toolCall.name === "get_metrics")
+            .map((toolCall) => readToolCallArguments(toolCall)?.endpoint_id)
+            .filter((value): value is string => typeof value === "string" && value.length > 0),
+        ),
+      ];
+      if (
+        !metricEndpointIds.includes("local.lfm2.5-8b-a1b") ||
+        !metricEndpointIds.includes("remote.deepseek-v4-flash")
+      ) {
+        return ["expected get_metrics calls for both local.lfm2.5-8b-a1b and remote.deepseek-v4-flash"];
+      }
+      if (/not available|unavailable|unknown|missing/i.test(answer)) {
+        return ["expected explicit remote-vs-local latency comparison, not an unavailable-data answer"];
+      }
+      const lowerAnswerText = answer.toLowerCase();
+      const mentionsBothSides =
+        lowerAnswerText.includes("local") && lowerAnswerText.includes("remote");
+      const comparisonConnector =
+        lowerAnswerText.includes(" than ") ||
+        lowerAnswerText.includes(" versus ") ||
+        lowerAnswerText.includes(" vs ") ||
+        lowerAnswerText.includes(" compared ");
+      const localBetter =
+        mentionsBothSides &&
+        (lowerAnswerText.includes("lower") ||
+          lowerAnswerText.includes("less") ||
+          lowerAnswerText.includes("faster") ||
+          lowerAnswerText.includes("smaller") ||
+          lowerAnswerText.includes("better")) &&
+        comparisonConnector;
+      const remoteWorse =
+        mentionsBothSides &&
+        (lowerAnswerText.includes("higher") ||
+          lowerAnswerText.includes("greater") ||
+          lowerAnswerText.includes("slower") ||
+          lowerAnswerText.includes("worse")) &&
+        comparisonConnector;
+      const numericComparison =
+        lowerAnswerText.includes("62") &&
+        lowerAnswerText.includes("245") &&
+        comparisonConnector;
+      const comparesLocalLower = localBetter || remoteWorse || numericComparison;
+      if (!comparesLocalLower) {
+        return ["expected grounded comparison that local.lfm2.5-8b-a1b has lower p95 latency than remote.deepseek-v4-flash"];
+      }
+      return [];
+    }
+    default:
+      return [];
+  }
+}
+
+export function capJudgeScoreForGroundedTruthMismatch(input: {
+  readonly caseItem: RoutingBenchmarkCase;
+  readonly score: number;
+  readonly rationale: string;
+  readonly deliverable: string;
+}): { readonly score: number; readonly rationale: string } {
+  const mismatches = groundedTruthMismatchDetails(input.caseItem, input.deliverable);
+  if (mismatches.length === 0) {
+    return {
+      score: input.score,
+      rationale: input.rationale,
+    };
+  }
+  return {
+    score: 0,
+    rationale: `[grounded_truth_mismatch] ${mismatches.join("; ")}. ${input.rationale}`.trim(),
+  };
+}
+
 export function gradeBenchmarkCase(input: {
   readonly caseItem: RoutingBenchmarkCase;
   readonly actualResponse: string;
@@ -232,23 +443,55 @@ export function gradeBenchmarkCase(input: {
         method: "judge",
       };
     }
-    return input.judgeGrade;
+    const normalizedBinaryAnswer = readNormalizedBinaryAnswer(
+      input.caseItem,
+      input.actualResponse,
+    );
+    if (normalizedBinaryAnswer) {
+      return {
+        ...input.judgeGrade,
+        score: 1,
+        rationale: `[case_normalized_exact_match] Accepted ${normalizedBinaryAnswer} after case-insensitive normalization.`,
+      };
+    }
+    const capped = capJudgeScoreForGroundedTruthMismatch({
+      caseItem: input.caseItem,
+      score: input.judgeGrade.score,
+      rationale: input.judgeGrade.rationale,
+      deliverable: input.actualResponse,
+    });
+    return {
+      ...input.judgeGrade,
+      score: capped.score,
+      rationale: capped.rationale,
+    };
   }
 
   const heuristic = gradeBenchmarkCaseHeuristic(input);
+  const grounded = capJudgeScoreForGroundedTruthMismatch({
+    caseItem: input.caseItem,
+    score: heuristic.score,
+    rationale: heuristic.rationale,
+    deliverable: input.actualResponse,
+  });
+  const cappedHeuristic = {
+    ...heuristic,
+    score: grounded.score,
+    rationale: grounded.rationale,
+  };
   if (input.judgeUnavailable) {
     const cappedScore =
-      heuristic.score >= 1
-        ? heuristic.score
-        : Math.min(heuristic.score, JUDGE_UNAVAILABLE_HEURISTIC_CAP);
+      cappedHeuristic.score >= 1
+        ? cappedHeuristic.score
+        : Math.min(cappedHeuristic.score, JUDGE_UNAVAILABLE_HEURISTIC_CAP);
     return {
-      ...heuristic,
+      ...cappedHeuristic,
       score: cappedScore,
-      rationale: `[judge_unavailable] Heuristic fallback: ${heuristic.rationale}`,
+      rationale: `[judge_unavailable] Heuristic fallback: ${cappedHeuristic.rationale}`,
       method: "heuristic",
     };
   }
-  return heuristic;
+  return cappedHeuristic;
 }
 
 export function buildJudgeRequestMessages(

--- a/role-model-router/packages/bench-routing/src/judge-brief.test.ts
+++ b/role-model-router/packages/bench-routing/src/judge-brief.test.ts
@@ -23,7 +23,7 @@ describe("judge-brief", () => {
     expect(transcript.length).toBeGreaterThan(240);
   });
 
-  test("p17 checklist includes @@ hunk requirement for apply_patch", () => {
+  test("p17 checklist includes unified diff or Codex patch requirement for apply_patch", () => {
     const caseItem = routingCapabilitySuite.cases.find(
       (item) => item.case_id === "p17-tools-multi-hard",
     );
@@ -32,11 +32,12 @@ describe("judge-brief", () => {
       throw new Error("Expected benchmark case p17-tools-multi-hard.");
     }
     const checklist = buildJudgeDeliverablesChecklist(caseItem);
-    expect(checklist.some((line) => line.includes("@@ hunk"))).toBe(true);
+    expect(checklist.some((line) => line.includes("Codex patch envelope"))).toBe(true);
+    expect(checklist.some((line) => line.includes("line numbers are optional"))).toBe(true);
   });
 
-  test("quick suite cases expose authored example_deliverable at suite 3.2", () => {
-    expect(routingCapabilitySuite.suite_version).toBe("3.2");
+  test("quick suite cases expose authored example_deliverable at suite 3.4", () => {
+    expect(routingCapabilitySuite.suite_version).toBe("3.4");
     const quickCases = routingCapabilitySuite.cases.filter((item) => item.quick_benchmark);
     expect(quickCases.length).toBe(12);
     for (const caseItem of quickCases) {
@@ -55,5 +56,16 @@ describe("judge-brief", () => {
     const brief = buildJudgeGradingBrief(caseItem);
     expect(brief.exemplarQuality).toBe("authored");
     expect(brief.exemplarAnswer).toContain("withLock");
+  });
+
+  test("omits trivial regex accept patterns from judge checklist prose", () => {
+    const caseItem = routingCapabilitySuite.cases.find((item) => item.case_id === "e06-timezone");
+    expect(caseItem).toBeTruthy();
+    if (!caseItem) {
+      throw new Error("Expected benchmark case e06-timezone.");
+    }
+    const checklist = buildJudgeDeliverablesChecklist(caseItem);
+    expect(checklist.some((line) => line.includes(".+"))).toBe(false);
+    expect(checklist.some((line) => line.includes("Match patterns"))).toBe(false);
   });
 });

--- a/role-model-router/packages/bench-routing/src/judge-brief.ts
+++ b/role-model-router/packages/bench-routing/src/judge-brief.ts
@@ -34,7 +34,7 @@ const GLOBAL_ANTI_PATTERNS = [
   "MUST NOT use diff placeholders (----/+++, [file header])",
   "MUST NOT emit prose-only TOOL_CALL lines without API tool_calls",
   "MUST NOT submit reasoning prose as the graded code deliverable",
-  "MUST NOT leave apply_patch arguments as stub text without @@ hunks",
+  "MUST NOT leave apply_patch arguments as placeholder or malformed patch content",
 ] as const;
 
 export function formatQuestionTranscript(caseItem: JudgeBriefCaseRef): string {
@@ -52,6 +52,31 @@ function splitGradingCriteria(criteria: string): string[] {
     .split(/[.;]\s+/)
     .map((part) => part.trim())
     .filter((part) => part.length > 8);
+}
+
+function isTrivialAcceptPattern(pattern: string): boolean {
+  const trimmed = pattern.trim();
+  return (
+    trimmed === ".+" ||
+    /^\.\{\d+(,\d*)?\}$/.test(trimmed) ||
+    /^[\^\$\.\+\*\?\(\)\[\]\{\}\\|,\s]+$/.test(trimmed)
+  );
+}
+
+function describeAcceptPattern(pattern: string): string | null {
+  const trimmed = pattern.trim();
+  if (!trimmed || isTrivialAcceptPattern(trimmed)) {
+    return null;
+  }
+  const exactLiteralMatch = trimmed.match(/^\^([A-Za-z0-9 _:/.-]+)\$$/);
+  if (exactLiteralMatch) {
+    return `exact value ${exactLiteralMatch[1]}`;
+  }
+  return trimmed;
+}
+
+function summarizeAcceptPatternsForJudge(patterns: readonly string[]): string[] {
+  return [...new Set(patterns.map(describeAcceptPattern).filter((value): value is string => !!value))];
 }
 
 export function buildJudgeDeliverablesChecklist(caseItem: JudgeBriefCaseRef): string[] {
@@ -74,12 +99,15 @@ export function buildJudgeDeliverablesChecklist(caseItem: JudgeBriefCaseRef): st
   }
 
   if (caseItem.accept_patterns?.length) {
-    checklist.push(`[SHOULD] Match patterns: ${caseItem.accept_patterns.join(", ")}`);
+    const patternSummaries = summarizeAcceptPatternsForJudge(caseItem.accept_patterns);
+    if (patternSummaries.length > 0) {
+      checklist.push(`[SHOULD] Match clues: ${patternSummaries.join(", ")}`);
+    }
   }
 
   if (caseItem.expected_tool_names?.includes("apply_patch")) {
     checklist.push(
-      "[MUST] apply_patch diff must contain ---/+++ file headers and @@ hunk markers with real content",
+      "[MUST] apply_patch must contain either ---/+++ headers plus an @@ hunk marker and real change content, or a valid Codex patch envelope with real content; line numbers are optional and bare @@ is acceptable",
     );
   }
 
@@ -104,7 +132,9 @@ function deriveExemplarAnswer(caseItem: JudgeBriefCaseRef): string {
     parts.push(
       `Tool calls: ${toolNames
         .map((name) =>
-          name === "apply_patch" ? `${name} with valid unified diff (---/+++/@@)` : name,
+          name === "apply_patch"
+            ? `${name} with ---/+++ headers plus @@ hunk marker (line numbers optional) or Codex patch envelope`
+            : name,
         )
         .join(", ")}`,
     );

--- a/role-model-router/packages/sqlite-memory/src/index.ts
+++ b/role-model-router/packages/sqlite-memory/src/index.ts
@@ -86,12 +86,53 @@ const RUNTIME_TELEMETRY_INSERT_COLUMNS = [
   "dimensions_json",
 ] as const;
 const DIFFICULTY_BUCKETS = ["easy", "medium", "hard"] as const;
+const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+const SQLITE_BUSY_RETRY_DELAY_MS = 100;
+const SQLITE_BUSY_MAX_ATTEMPTS = 3;
 const MAINTENANCE_DEFAULTS = [
   { key: "backup.policy", value: "wal-copy-on-demand" },
   { key: "deletion.policy", value: "explicit-export-delete" },
   { key: "redaction.level", value: "strict" },
   { key: "retention.class", value: "standard" },
 ] as const;
+
+function openSqliteDatabase(databasePath: string): DatabaseSync {
+  const database = new DatabaseSync(databasePath);
+  database.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+  return database;
+}
+
+function isSqliteBusyError(error: unknown): boolean {
+  return error instanceof Error && /database is locked|SQLITE_BUSY/i.test(error.message);
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function withSqliteBusyRetry<T>(databasePath: string, operation: (database: DatabaseSync) => T): T {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= SQLITE_BUSY_MAX_ATTEMPTS; attempt += 1) {
+    const database = openSqliteDatabase(databasePath);
+    try {
+      const result = operation(database);
+      database.close();
+      return result;
+    } catch (error) {
+      lastError = error;
+      try {
+        database.close();
+      } catch {
+        // Ignore close failures while retrying the original busy error.
+      }
+      if (!isSqliteBusyError(error) || attempt >= SQLITE_BUSY_MAX_ATTEMPTS) {
+        throw error;
+      }
+      sleepSync(SQLITE_BUSY_RETRY_DELAY_MS * attempt);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("sqlite write failed");
+}
 
 function isRuntimeTelemetryDifficultyBucket(
   value: string | null | undefined,
@@ -2510,7 +2551,7 @@ export function upsertObservedThroughputPenaltyState(
 export function readObservedThroughputPenaltyState(
   input: ReadObservedThroughputPenaltyStateInput,
 ): ObservedThroughputPenaltyStateRecord | null {
-  const database = new DatabaseSync(input.databasePath);
+  const database = openSqliteDatabase(input.databasePath);
   const row = database
     .prepare(
       `SELECT endpoint_id, last_observed_tokens_per_sec, min_tokens_per_sec, penalty_factor, activated_at_ms, expires_at_ms, last_observation_measured_at_ms, updated_at_ms
@@ -2723,173 +2764,184 @@ export function clearBenchmarkRunArtifacts(
 }
 
 export function persistObservedBenchmarkSample(input: PersistObservedBenchmarkSampleInput): void {
-  const database = new DatabaseSync(input.databasePath);
   const sample = {
     ...input.sample,
     source_type: "benchmark" as const,
   };
-  database
-    .prepare(
-      "INSERT OR REPLACE INTO observed_performance_samples (sample_id, endpoint_id, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
-    )
-    .run(
-      sampleIdFor(sample),
-      sample.endpoint_id,
-      sample.request_id ?? null,
-      sample.routing_decision_id ?? null,
-      sample.source_type,
-      sample.timestamp_ms,
-      JSON.stringify(sample),
-    );
-  if (sample.difficulty_bucket) {
-    const difficultyBucket = sample.difficulty_bucket;
-    database
-      .prepare(
-        "INSERT OR REPLACE INTO observed_performance_samples_by_difficulty (sample_id, endpoint_id, difficulty_bucket, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      )
-      .run(
-        segmentedSampleIdFor(sample),
-        sample.endpoint_id,
-        difficultyBucket,
-        sample.request_id ?? null,
-        sample.routing_decision_id ?? null,
-        sample.source_type,
-        sample.timestamp_ms,
-        JSON.stringify(sample),
+  for (let attempt = 1; ; attempt += 1) {
+    const database = openSqliteDatabase(input.databasePath);
+    try {
+      database
+        .prepare(
+          "INSERT OR REPLACE INTO observed_performance_samples (sample_id, endpoint_id, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          sampleIdFor(sample),
+          sample.endpoint_id,
+          sample.request_id ?? null,
+          sample.routing_decision_id ?? null,
+          sample.source_type,
+          sample.timestamp_ms,
+          JSON.stringify(sample),
+        );
+      if (sample.difficulty_bucket) {
+        const difficultyBucket = sample.difficulty_bucket;
+        database
+          .prepare(
+            "INSERT OR REPLACE INTO observed_performance_samples_by_difficulty (sample_id, endpoint_id, difficulty_bucket, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            segmentedSampleIdFor(sample),
+            sample.endpoint_id,
+            difficultyBucket,
+            sample.request_id ?? null,
+            sample.routing_decision_id ?? null,
+            sample.source_type,
+            sample.timestamp_ms,
+            JSON.stringify(sample),
+          );
+        const priorBucketRows = database
+          .prepare(
+            "SELECT sample_json FROM observed_performance_samples_by_difficulty WHERE endpoint_id = ? AND difficulty_bucket = ? ORDER BY timestamp_ms ASC, sample_id ASC",
+          )
+          .all(sample.endpoint_id, difficultyBucket) as Array<{ sample_json: string }>;
+        const bucketSamples = priorBucketRows.map(
+          (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
+        );
+        const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, {
+          nowMs: sample.timestamp_ms,
+        });
+        database
+          .prepare(
+            "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
+          )
+          .run(
+            `${sample.endpoint_id}:${difficultyBucket}:${bucketProfile.measured_at_ms}`,
+            sample.endpoint_id,
+            difficultyBucket,
+            bucketProfile.measured_at_ms,
+            JSON.stringify(bucketProfile),
+          );
+      }
+      const priorRows = database
+        .prepare(
+          "SELECT sample_json FROM observed_performance_samples WHERE endpoint_id = ? ORDER BY timestamp_ms ASC, sample_id ASC",
+        )
+        .all(sample.endpoint_id) as Array<{ sample_json: string }>;
+      const allSamples = priorRows.map(
+        (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
       );
-    const priorBucketRows = database
-      .prepare(
-        "SELECT sample_json FROM observed_performance_samples_by_difficulty WHERE endpoint_id = ? AND difficulty_bucket = ? ORDER BY timestamp_ms ASC, sample_id ASC",
-      )
-      .all(sample.endpoint_id, difficultyBucket) as Array<{ sample_json: string }>;
-    const bucketSamples = priorBucketRows.map(
-      (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
-    );
-    const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, {
-      nowMs: sample.timestamp_ms,
-    });
-    database
-      .prepare(
-        "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
-      )
-      .run(
-        `${sample.endpoint_id}:${difficultyBucket}:${bucketProfile.measured_at_ms}`,
-        sample.endpoint_id,
-        difficultyBucket,
-        bucketProfile.measured_at_ms,
-        JSON.stringify(bucketProfile),
-      );
+      const profile = aggregateObservedPerformanceSamples(allSamples, {
+        nowMs: sample.timestamp_ms,
+      });
+      database
+        .prepare(
+          "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
+        )
+        .run(
+          `${sample.endpoint_id}:${profile.measured_at_ms}`,
+          sample.endpoint_id,
+          profile.measured_at_ms,
+          JSON.stringify(profile),
+        );
+      return;
+    } catch (error) {
+      if (!isSqliteBusyError(error) || attempt >= SQLITE_BUSY_MAX_ATTEMPTS) {
+        throw error;
+      }
+      sleepSync(SQLITE_BUSY_RETRY_DELAY_MS * attempt);
+    } finally {
+      database.close();
+    }
   }
-  const priorRows = database
-    .prepare(
-      "SELECT sample_json FROM observed_performance_samples WHERE endpoint_id = ? ORDER BY timestamp_ms ASC, sample_id ASC",
-    )
-    .all(sample.endpoint_id) as Array<{ sample_json: string }>;
-  const allSamples = priorRows.map(
-    (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
-  );
-  const profile = aggregateObservedPerformanceSamples(allSamples, {
-    nowMs: sample.timestamp_ms,
-  });
-  database
-    .prepare(
-      "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
-    )
-    .run(
-      `${sample.endpoint_id}:${profile.measured_at_ms}`,
-      sample.endpoint_id,
-      profile.measured_at_ms,
-      JSON.stringify(profile),
-    );
-  database.close();
 }
 
 export function persistRuntimeObservationBundle(input: PersistRuntimeObservationBundleInput): void {
-  const database = new DatabaseSync(input.databasePath);
   const observation = input.observation;
   const telemetryRecord = toRuntimeTelemetryRecord(observation);
-  database
-    .prepare(
-      "INSERT OR REPLACE INTO runtime_observations (request_id, routing_decision_id, endpoint_id, conversation_id, created_at_ms, observation_json) VALUES (?, ?, ?, ?, ?, ?)",
-    )
-    .run(
-      observation.requestId,
-      observation.routingDecisionId,
-      observation.endpointId,
-      observation.conversationId,
-      observation.usageEvent.timestamp_ms,
-      JSON.stringify(observation),
-    );
-  database
-    .prepare(
-      "INSERT OR REPLACE INTO observed_performance_samples (sample_id, endpoint_id, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
-    )
-    .run(
-      sampleIdFor(observation.observedPerformance.sample),
-      observation.endpointId,
-      observation.observedPerformance.sample.request_id ?? null,
-      observation.observedPerformance.sample.routing_decision_id ?? null,
-      observation.observedPerformance.sample.source_type,
-      observation.observedPerformance.sample.timestamp_ms,
-      JSON.stringify(observation.observedPerformance.sample),
-    );
-  if (observation.observedPerformance.sample.difficulty_bucket) {
-    const difficultyBucket = observation.observedPerformance.sample.difficulty_bucket;
+  withSqliteBusyRetry(input.databasePath, (database) => {
     database
       .prepare(
-        "INSERT OR REPLACE INTO observed_performance_samples_by_difficulty (sample_id, endpoint_id, difficulty_bucket, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO runtime_observations (request_id, routing_decision_id, endpoint_id, conversation_id, created_at_ms, observation_json) VALUES (?, ?, ?, ?, ?, ?)",
       )
       .run(
-        segmentedSampleIdFor(observation.observedPerformance.sample),
+        observation.requestId,
+        observation.routingDecisionId,
         observation.endpointId,
-        difficultyBucket,
+        observation.conversationId,
+        observation.usageEvent.timestamp_ms,
+        JSON.stringify(observation),
+      );
+    database
+      .prepare(
+        "INSERT OR REPLACE INTO observed_performance_samples (sample_id, endpoint_id, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run(
+        sampleIdFor(observation.observedPerformance.sample),
+        observation.endpointId,
         observation.observedPerformance.sample.request_id ?? null,
         observation.observedPerformance.sample.routing_decision_id ?? null,
         observation.observedPerformance.sample.source_type,
         observation.observedPerformance.sample.timestamp_ms,
         JSON.stringify(observation.observedPerformance.sample),
       );
-    const priorBucketRows = database
-      .prepare(
-        "SELECT sample_json FROM observed_performance_samples_by_difficulty WHERE endpoint_id = ? AND difficulty_bucket = ? ORDER BY timestamp_ms ASC, sample_id ASC",
-      )
-      .all(observation.endpointId, difficultyBucket) as Array<{
-      sample_json: string;
-    }>;
-    const bucketSamples = priorBucketRows.map(
-      (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
-    );
-    const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, {
-      nowMs: observation.observedPerformance.sample.timestamp_ms,
-    });
+    if (observation.observedPerformance.sample.difficulty_bucket) {
+      const difficultyBucket = observation.observedPerformance.sample.difficulty_bucket;
+      database
+        .prepare(
+          "INSERT OR REPLACE INTO observed_performance_samples_by_difficulty (sample_id, endpoint_id, difficulty_bucket, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          segmentedSampleIdFor(observation.observedPerformance.sample),
+          observation.endpointId,
+          difficultyBucket,
+          observation.observedPerformance.sample.request_id ?? null,
+          observation.observedPerformance.sample.routing_decision_id ?? null,
+          observation.observedPerformance.sample.source_type,
+          observation.observedPerformance.sample.timestamp_ms,
+          JSON.stringify(observation.observedPerformance.sample),
+        );
+      const priorBucketRows = database
+        .prepare(
+          "SELECT sample_json FROM observed_performance_samples_by_difficulty WHERE endpoint_id = ? AND difficulty_bucket = ? ORDER BY timestamp_ms ASC, sample_id ASC",
+        )
+        .all(observation.endpointId, difficultyBucket) as Array<{
+        sample_json: string;
+      }>;
+      const bucketSamples = priorBucketRows.map(
+        (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
+      );
+      const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, {
+        nowMs: observation.observedPerformance.sample.timestamp_ms,
+      });
+      database
+        .prepare(
+          "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(
+          `${observation.endpointId}:${difficultyBucket}:${bucketProfile.measured_at_ms}`,
+          observation.endpointId,
+          difficultyBucket,
+          bucketProfile.measured_at_ms,
+          JSON.stringify(bucketProfile),
+        );
+    }
     database
       .prepare(
-        "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
       )
       .run(
-        `${observation.endpointId}:${difficultyBucket}:${bucketProfile.measured_at_ms}`,
+        `${observation.endpointId}:${observation.observedPerformance.profile.measured_at_ms}`,
         observation.endpointId,
-        difficultyBucket,
-        bucketProfile.measured_at_ms,
-        JSON.stringify(bucketProfile),
+        observation.observedPerformance.profile.measured_at_ms,
+        JSON.stringify(observation.observedPerformance.profile),
       );
-  }
-  database
-    .prepare(
-      "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
-    )
-    .run(
-      `${observation.endpointId}:${observation.observedPerformance.profile.measured_at_ms}`,
-      observation.endpointId,
-      observation.observedPerformance.profile.measured_at_ms,
-      JSON.stringify(observation.observedPerformance.profile),
-    );
-  database
-    .prepare(
-      `INSERT OR REPLACE INTO runtime_telemetry_records (${RUNTIME_TELEMETRY_INSERT_COLUMNS.join(", ")}) VALUES (${RUNTIME_TELEMETRY_INSERT_COLUMNS.map(() => "?").join(", ")})`,
-    )
-    .run(...runtimeTelemetryInsertValues(telemetryRecord));
-  database.close();
+    database
+      .prepare(
+        `INSERT OR REPLACE INTO runtime_telemetry_records (${RUNTIME_TELEMETRY_INSERT_COLUMNS.join(", ")}) VALUES (${RUNTIME_TELEMETRY_INSERT_COLUMNS.map(() => "?").join(", ")})`,
+      )
+      .run(...runtimeTelemetryInsertValues(telemetryRecord));
+  });
 }
 
 export interface PersistRuntimeTelemetryFailureInput {
@@ -2907,7 +2959,6 @@ export interface PersistRuntimeTelemetryFailureInput {
 }
 
 export function persistRuntimeTelemetryFailure(input: PersistRuntimeTelemetryFailureInput): void {
-  const database = new DatabaseSync(input.databasePath);
   const createdAtMs = Date.now();
   const routingDecisionId = input.routingDecisionId ?? `decision-${input.requestId}`;
   const endpointId = input.endpointId ?? "routing.failed.pre-execution";
@@ -2917,12 +2968,13 @@ export function persistRuntimeTelemetryFailure(input: PersistRuntimeTelemetryFai
     endpointId,
     createdAtMs,
   );
-  database
-    .prepare(
-      `INSERT OR REPLACE INTO runtime_telemetry_records (${RUNTIME_TELEMETRY_INSERT_COLUMNS.join(", ")}) VALUES (${RUNTIME_TELEMETRY_INSERT_COLUMNS.map(() => "?").join(", ")})`,
-    )
-    .run(...runtimeTelemetryInsertValues(telemetryRecord));
-  database.close();
+  withSqliteBusyRetry(input.databasePath, (database) => {
+    database
+      .prepare(
+        `INSERT OR REPLACE INTO runtime_telemetry_records (${RUNTIME_TELEMETRY_INSERT_COLUMNS.join(", ")}) VALUES (${RUNTIME_TELEMETRY_INSERT_COLUMNS.map(() => "?").join(", ")})`,
+      )
+      .run(...runtimeTelemetryInsertValues(telemetryRecord));
+  });
 }
 
 export function readRuntimeObservationBundle(
@@ -2944,7 +2996,7 @@ export function readRuntimeObservationBundle(
 export function readObservedPerformanceSamples(
   input: ReadObservedPerformanceSamplesInput,
 ): readonly ObservedPerformanceSample[] {
-  const database = new DatabaseSync(input.databasePath);
+  const database = openSqliteDatabase(input.databasePath);
   const rows = (
     input.difficultyBucket
       ? database
@@ -2968,7 +3020,7 @@ export function readObservedPerformanceSamples(
 export function readLatestObservedProfile(
   input: ReadLatestObservedProfileInput,
 ): ObservedPerformanceProfile | null {
-  const database = new DatabaseSync(input.databasePath);
+  const database = openSqliteDatabase(input.databasePath);
   const row = (
     input.difficultyBucket
       ? database
@@ -2998,7 +3050,7 @@ export function readLatestObservedProfilesByEndpointIds(
     return {};
   }
 
-  const database = new DatabaseSync(input.databasePath);
+  const database = openSqliteDatabase(input.databasePath);
   const placeholders = input.endpointIds.map(() => "?").join(", ");
   const rows = (
     input.difficultyBucket
@@ -3100,19 +3152,19 @@ export function readAdvisoryMaxDifficultyRecommendation(
 export function upsertDifficultyClassificationCache(
   input: UpsertDifficultyClassificationCacheInput,
 ): void {
-  const database = new DatabaseSync(input.databasePath);
-  database
-    .prepare(
-      "INSERT OR REPLACE INTO difficulty_classification_cache (conversation_id, cache_json, updated_at_ms) VALUES (?, ?, ?)",
-    )
-    .run(input.cache.conversationId, JSON.stringify(input.cache), input.cache.cachedAtMs);
-  database.close();
+  withSqliteBusyRetry(input.databasePath, (database) => {
+    database
+      .prepare(
+        "INSERT OR REPLACE INTO difficulty_classification_cache (conversation_id, cache_json, updated_at_ms) VALUES (?, ?, ?)",
+      )
+      .run(input.cache.conversationId, JSON.stringify(input.cache), input.cache.cachedAtMs);
+  });
 }
 
 export function readDifficultyClassificationCache(
   input: ReadDifficultyClassificationCacheInput,
 ): DifficultyClassificationCacheRecord | null {
-  const database = new DatabaseSync(input.databasePath);
+  const database = openSqliteDatabase(input.databasePath);
   const row = database
     .prepare("SELECT cache_json FROM difficulty_classification_cache WHERE conversation_id = ?")
     .get(input.conversationId) as

--- a/role-model-router/packages/sqlite-memory/test/index.test.ts
+++ b/role-model-router/packages/sqlite-memory/test/index.test.ts
@@ -1,4 +1,6 @@
 import { mkdtemp, readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -21,6 +23,7 @@ import {
   persistObservedBenchmarkSample,
   persistProviderAccounts,
   persistRetrievalReceipt,
+  persistRuntimeObservationBundle,
   persistRuntimeTelemetryFailure,
   readConversationContinuity,
   readLatestObservedProfile,
@@ -2515,6 +2518,327 @@ describe("persistObservedBenchmarkSample benchmark_mode", () => {
     });
     expect(samples).toHaveLength(1);
     expect(samples[0]?.benchmark_mode).toBe("quick");
+  });
+
+  test("retries through a transient sqlite write lock when persisting benchmark samples", async () => {
+    const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-runtime-state-"));
+    const initialized = initializeSqliteMemory({
+      runtimeStateRoot,
+      scopeId: "workspace-dev-benchmark-lock-retry",
+    });
+    const endpointId = "local.test.model.locked";
+    const locker = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        [
+          'import { DatabaseSync } from "node:sqlite";',
+          "const databasePath = process.argv[1];",
+          "const database = new DatabaseSync(databasePath);",
+          'database.exec("PRAGMA journal_mode = WAL");',
+          'database.exec("BEGIN IMMEDIATE");',
+          'process.stdout.write("locked\\n");',
+          "setTimeout(() => {",
+          "  try {",
+          '    database.exec("COMMIT");',
+          "  } finally {",
+          "    database.close();",
+          "    process.exit(0);",
+          "  }",
+          "}, 250);",
+        ].join(" "),
+        initialized.databasePath,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    try {
+      await once(locker.stdout!, "data");
+      persistObservedBenchmarkSample({
+        databasePath: initialized.databasePath,
+        sample: {
+          endpoint_id: endpointId,
+          endpoint_version: "v1",
+          source_type: "benchmark",
+          benchmark_mode: "full",
+          difficulty_bucket: "hard",
+          timestamp_ms: 3_000,
+          latency_ms: 700,
+          judge_score: 0.82,
+          request_id: "full-hard-locked-1",
+        },
+      });
+      await once(locker, "exit");
+    } finally {
+      if (!locker.killed) {
+        locker.kill("SIGTERM");
+      }
+    }
+
+    const samples = readObservedPerformanceSamples({
+      databasePath: initialized.databasePath,
+      endpointId,
+    });
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.benchmark_mode).toBe("full");
+    expect(samples[0]?.judge_score).toBe(0.82);
+  });
+
+  test("retries through a transient sqlite write lock when persisting runtime observation bundles", async () => {
+    const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-runtime-state-"));
+    const initialized = initializeSqliteMemory({
+      runtimeStateRoot,
+      scopeId: "workspace-dev-observation-lock-retry",
+    });
+
+    const validation = await runRuntimeAdapterValidation({
+      repoRoot,
+      fixtureRoot: path.join(repoRoot, "testdata", "router-runtime", "fixtures"),
+      runtimeStateRoot,
+      scopeId: "workspace-dev-observation-lock-retry",
+    });
+    const history = await readJson<{
+      byEndpointId: Record<
+        string,
+        Parameters<typeof createRuntimeObservationBundle>[0]["priorSamples"]
+      >;
+    }>("testdata/router-runtime/fixtures/observability-history.json");
+    const policy = await readJson<
+      Parameters<typeof createRuntimeObservationBundle>[0]["capturePolicy"]
+    >("testdata/router-runtime/fixtures/observability-policy.json");
+    const bundle = createRuntimeObservationBundle({
+      decision: validation.decision,
+      routingDiagnostics: validation.routingDiagnostics,
+      retrievalReceipt: validation.retrievalReceipt,
+      contextEnvelope: validation.contextEnvelope,
+      execution: validation.execution,
+      priorSamples: history.byEndpointId[validation.decision.chosen_endpoint_id] ?? [],
+      maintenancePolicy: {
+        "redaction.level": "strict",
+        "retention.class": "standard",
+      },
+      capturePolicy: policy,
+    });
+
+    const locker = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        [
+          'import { DatabaseSync } from "node:sqlite";',
+          "const databasePath = process.argv[1];",
+          "const database = new DatabaseSync(databasePath);",
+          'database.exec("PRAGMA journal_mode = WAL");',
+          'database.exec("BEGIN IMMEDIATE");',
+          'process.stdout.write("locked\\n");',
+          "setTimeout(() => {",
+          "  try {",
+          '    database.exec("COMMIT");',
+          "  } finally {",
+          "    database.close();",
+          "    process.exit(0);",
+          "  }",
+          "}, 250);",
+        ].join(" "),
+        initialized.databasePath,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    try {
+      await once(locker.stdout!, "data");
+      expect(() =>
+        persistRuntimeObservationBundle({
+          databasePath: initialized.databasePath,
+          observation: bundle,
+        }),
+      ).not.toThrow();
+      await once(locker, "exit");
+    } finally {
+      if (!locker.killed) {
+        locker.kill("SIGTERM");
+      }
+    }
+  });
+
+  test("waits through a transient sqlite lock when reading difficulty classification cache", async () => {
+    const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-runtime-state-"));
+    const initialized = initializeSqliteMemory({
+      runtimeStateRoot,
+      scopeId: "workspace-dev-difficulty-cache-lock-read",
+    });
+
+    const locker = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        [
+          'import { DatabaseSync } from "node:sqlite";',
+          "const databasePath = process.argv[1];",
+          "const database = new DatabaseSync(databasePath);",
+          'database.exec("PRAGMA journal_mode = WAL");',
+          'database.exec("BEGIN IMMEDIATE");',
+          'process.stdout.write("locked\\n");',
+          "setTimeout(() => {",
+          "  try {",
+          '    database.exec("COMMIT");',
+          "  } finally {",
+          "    database.close();",
+          "    process.exit(0);",
+          "  }",
+          "}, 250);",
+        ].join(" "),
+        initialized.databasePath,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    try {
+      await once(locker.stdout!, "data");
+      expect(
+        sqliteMemory.readDifficultyClassificationCache({
+          databasePath: initialized.databasePath,
+          conversationId: "bench-conversation",
+        }),
+      ).toBeNull();
+      await once(locker, "exit");
+    } finally {
+      if (!locker.killed) {
+        locker.kill("SIGTERM");
+      }
+    }
+  });
+
+  test("retries through a transient sqlite write lock when persisting difficulty classification cache", async () => {
+    const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-runtime-state-"));
+    const initialized = initializeSqliteMemory({
+      runtimeStateRoot,
+      scopeId: "workspace-dev-difficulty-cache-lock-write",
+    });
+
+    const locker = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        [
+          'import { DatabaseSync } from "node:sqlite";',
+          "const databasePath = process.argv[1];",
+          "const database = new DatabaseSync(databasePath);",
+          'database.exec("PRAGMA journal_mode = WAL");',
+          'database.exec("BEGIN IMMEDIATE");',
+          'process.stdout.write("locked\\n");',
+          "setTimeout(() => {",
+          "  try {",
+          '    database.exec("COMMIT");',
+          "  } finally {",
+          "    database.close();",
+          "    process.exit(0);",
+          "  }",
+          "}, 250);",
+        ].join(" "),
+        initialized.databasePath,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    try {
+      await once(locker.stdout!, "data");
+      expect(() =>
+        sqliteMemory.upsertDifficultyClassificationCache({
+          databasePath: initialized.databasePath,
+          cache: {
+            conversationId: "bench-conversation",
+            difficulty: "easy",
+            fallbackApplied: false,
+            cachedAtMs: 1_000,
+            expiresAtMs: 2_000,
+            rubricSignals: {
+              codeIndicators: 0,
+              toolCount: 0,
+              historyTurnCount: 0,
+              instructionConstraintCount: 0,
+              contextTokens: 0,
+            },
+          },
+        }),
+      ).not.toThrow();
+      await once(locker, "exit");
+    } finally {
+      if (!locker.killed) {
+        locker.kill("SIGTERM");
+      }
+    }
+
+    expect(
+      sqliteMemory.readDifficultyClassificationCache({
+        databasePath: initialized.databasePath,
+        conversationId: "bench-conversation",
+      }),
+    ).toMatchObject({
+      difficulty: "easy",
+      fallbackApplied: false,
+    });
+  });
+
+  test("waits through a transient sqlite lock when reading advisory max difficulty recommendations", async () => {
+    const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-runtime-state-"));
+    const initialized = initializeSqliteMemory({
+      runtimeStateRoot,
+      scopeId: "workspace-dev-advisory-lock-read",
+    });
+
+    const locker = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        [
+          'import { DatabaseSync } from "node:sqlite";',
+          "const databasePath = process.argv[1];",
+          "const database = new DatabaseSync(databasePath);",
+          'database.exec("PRAGMA journal_mode = WAL");',
+          'database.exec("BEGIN IMMEDIATE");',
+          'process.stdout.write("locked\\n");',
+          "setTimeout(() => {",
+          "  try {",
+          '    database.exec("COMMIT");',
+          "  } finally {",
+          "    database.close();",
+          "    process.exit(0);",
+          "  }",
+          "}, 250);",
+        ].join(" "),
+        initialized.databasePath,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    try {
+      await once(locker.stdout!, "data");
+      expect(
+        sqliteMemory.readAdvisoryMaxDifficultyRecommendation({
+          databasePath: initialized.databasePath,
+          endpointId: "remote.test.endpoint",
+          thresholds: {
+            minSamples: 1,
+            maxFailureRate: 0.5,
+            minQualityScore: 0.5,
+            minTokensPerSec: 1,
+          },
+        }),
+      ).toMatchObject({
+        recommendedMaxDifficulty: null,
+      });
+      await once(locker, "exit");
+    } finally {
+      if (!locker.killed) {
+        locker.kill("SIGTERM");
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- harden benchmark extraction, per-case grading, and grounded validators
- fix multi-turn tool scaffolding and repeated tool-call preservation
- tighten routing benchmark cases and regression coverage for benchmark correctness

## Validation
- corepack pnpm exec vitest run role-model-router/packages/bench-routing/src/index.test.ts
- corepack pnpm exec vitest run role-model-router/packages/bench-routing/src/answer-format.test.ts
- focused live benchmark validation on ports 3472, 3473, and 3474