### PR TITLE
Fix: Regenerate protocol types to include benchmark in MetricSource

### DIFF
--- a/packages/protocol-types/src/generated.ts
+++ b/packages/protocol-types/src/generated.ts
@@ -341,7 +341,7 @@ export interface RoleDefinition {
 
 export interface MetricEntry {
   value: number;
-  source: "measured" | "declared" | "default" | "catalog";
+  source: "measured" | "declared" | "default" | "catalog" | "benchmark";
   raw?: {
     [k: string]: unknown;
   };


### PR DESCRIPTION
The router-decision schema was updated to include `benchmark` in the metricEntry.source enum (addendum 10), but the generated TypeScript types in `packages/protocol-types/src/generated.ts` were not committed. This caused TSC build failures in CI binary builds.