### PR TITLE
Fix runtime bridge lint regressions

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -81,8 +81,8 @@ import {
   upsertDifficultyClassificationCache,
   upsertObservedThroughputPenaltyState,
   upsertProviderDeviceAuthSession,
-  upsertRuntimeMaintenanceValue,
   upsertRuntimeControllerAssignment,
+  upsertRuntimeMaintenanceValue,
   upsertProviderAccount as upsertSqliteProviderAccount,
   upsertRuntimeEndpoint as upsertSqliteRuntimeEndpoint,
 } from "@role-model-router/sqlite-memory";
@@ -2848,10 +2848,9 @@ export function classifyUpstreamExecutionFailure(input: {
   readonly message?: string;
   readonly fallbackStatusCode?: number;
 }): UpstreamExecutionError {
-  const message =
-    input.message?.trim().length
-      ? input.message.trim()
-      : summarizeProviderError(input.statusCode ?? input.fallbackStatusCode ?? 502, input.body);
+  const message = input.message?.trim().length
+    ? input.message.trim()
+    : summarizeProviderError(input.statusCode ?? input.fallbackStatusCode ?? 502, input.body);
   const searchText = [
     message,
     readNestedProviderErrorField(input.body, "message"),
@@ -3074,7 +3073,10 @@ export function resolveExecutionFailureCooldownDurationMs(failureCount: number):
       Math.max(1, Math.trunc(failureCount)) - 1,
     ),
   );
-  return EXECUTION_FAILURE_COOLDOWN_SCHEDULE_MS[scheduleIndex]!;
+  return (
+    EXECUTION_FAILURE_COOLDOWN_SCHEDULE_MS[scheduleIndex] ??
+    EXECUTION_FAILURE_COOLDOWN_SCHEDULE_MS[EXECUTION_FAILURE_COOLDOWN_SCHEDULE_MS.length - 1]
+  );
 }
 
 function recordExecutionFailureCooldown(input: {
@@ -16154,7 +16156,7 @@ export async function createRuntimeBridgeBackend(
       routeRuntimeRequest({
         request: {
           ...plan.routingRequest,
-          ...((() => {
+          ...(() => {
             const cooldownDeniedEndpoints = readActiveExecutionFailureCooldownEndpointIds({
               databasePath: initialization.databasePath,
               nowMs: Date.now(),
@@ -16163,7 +16165,7 @@ export async function createRuntimeBridgeBackend(
               ...new Set([...denyEndpoints, ...cooldownDeniedEndpoints]),
             ];
             return mergedDenyEndpoints.length > 0 ? { denyEndpoints: mergedDenyEndpoints } : {};
-          })()),
+          })(),
         },
         registry: currentRegistry,
         catalog: currentNormalizedCatalog,
@@ -16374,7 +16376,8 @@ export async function createRuntimeBridgeBackend(
                     runtimeToolRegistry ??= createRequestScopedToolRegistry(codexDynamicTools, {
                       workspaceRoot,
                     });
-                    const originalToolName = originalToolNameByExposedName.get(toolName) ?? toolName;
+                    const originalToolName =
+                      originalToolNameByExposedName.get(toolName) ?? toolName;
                     const executionResult = dynamicToolNames.has(originalToolName)
                       ? await executeToolCalls(runtimeToolRegistry, {
                           requestId,

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -12675,7 +12675,9 @@ describe("runtime-host-bridge", () => {
           if (authorization === "Bearer moonshot-primary-live-key") {
             primaryAttempts += 1;
             if (primaryAttempts === 1) {
-              throw new Error("Connection Error: Could not reach the AI service. Request timed out.");
+              throw new Error(
+                "Connection Error: Could not reach the AI service. Request timed out.",
+              );
             }
             return new Response(
               JSON.stringify({
@@ -12843,7 +12845,8 @@ describe("runtime-host-bridge", () => {
 
   test("classifies subscription quota exhaustion as fallback-eligible without retrying the same endpoint", () => {
     expect(
-      typeof (bridge as { classifyUpstreamExecutionFailure?: unknown }).classifyUpstreamExecutionFailure,
+      typeof (bridge as { classifyUpstreamExecutionFailure?: unknown })
+        .classifyUpstreamExecutionFailure,
     ).toBe("function");
 
     const error = (


### PR DESCRIPTION
## Summary
- remove the new non-null assertion in runtime cooldown scheduling
- apply Biome import and formatting fixes required by CI

## Verification
- corepack pnpm exec biome check role-model-router/apps/runtime-host-bridge/src/index.ts role-model-router/apps/runtime-host-bridge/test/index.test.ts
- cargo-based rust lint was not runnable locally because cargo is not installed in this Windows environment