### PR TITLE
Fix Codex bridge fallback and packaging cleanup

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -7500,6 +7500,26 @@ export function createRequestScopedToolRegistry(
     return buildRequestScopedGrepResult(options.workspaceRoot, pattern);
   };
 
+  const executeListDir = async (toolArguments: unknown): Promise<unknown> => {
+    return buildRequestScopedListDirResult(options.workspaceRoot, toolArguments);
+  };
+
+  const executeWriteFile = async (toolArguments: unknown): Promise<unknown> => {
+    return await writeRequestScopedWorkspaceFile(options.workspaceRoot, toolArguments);
+  };
+
+  const executeCreateDirectory = async (toolArguments: unknown): Promise<unknown> => {
+    return await createRequestScopedWorkspaceDirectory(options.workspaceRoot, toolArguments);
+  };
+
+  const executeMoveFile = async (toolArguments: unknown): Promise<unknown> => {
+    return await moveRequestScopedWorkspacePath(options.workspaceRoot, toolArguments);
+  };
+
+  const executeDeleteFile = async (toolArguments: unknown): Promise<unknown> => {
+    return await deleteRequestScopedWorkspacePath(options.workspaceRoot, toolArguments);
+  };
+
   const executeApplyPatch = async (toolArguments: unknown): Promise<unknown> => {
     const diff = readRequestScopedDiffArgument(toolArguments);
     if (!diff) {
@@ -7527,6 +7547,20 @@ export function createRequestScopedToolRegistry(
                 return { content: await executeReadFile(toolArguments) };
               case "grep_search":
                 return { content: await executeGrepSearch(toolArguments) };
+              case "list_dir":
+                return { content: await executeListDir(toolArguments) };
+              case "write_file":
+                return { content: await executeWriteFile(toolArguments) };
+              case "create_directory":
+              case "create_folder":
+              case "mkdir":
+                return { content: await executeCreateDirectory(toolArguments) };
+              case "move_file":
+              case "rename_file":
+                return { content: await executeMoveFile(toolArguments) };
+              case "delete_file":
+              case "remove_file":
+                return { content: await executeDeleteFile(toolArguments) };
               case "apply_patch":
                 return { content: await executeApplyPatch(toolArguments) };
               case "list_endpoints":
@@ -7534,7 +7568,9 @@ export function createRequestScopedToolRegistry(
               case "get_metrics":
                 return { content: buildRequestScopedMetrics(toolArguments) };
               default:
-                return { content: toolArguments };
+                throw new Error(
+                  `Request-scoped tool ${tool.name} is not implemented by the Codex Subscription bridge.`,
+                );
             }
           },
         })),
@@ -7632,7 +7668,9 @@ function resolveRequestScopedWorkspacePath(
     normalizedResolvedPath !== normalizedWorkspaceRoot.toLowerCase() &&
     !normalizedResolvedPath.startsWith(workspacePrefix)
   ) {
-    throw new Error(`Path ${requestedPath} escapes the managed Codex workspace.`);
+    throw new Error(
+      `Path ${requestedPath} is outside the managed Codex workspace. Use shell commands for external filesystem paths instead of the request-scoped file tools.`,
+    );
   }
   return resolvedPath;
 }
@@ -7642,6 +7680,9 @@ function readRequestScopedPathArgument(toolArguments: unknown): string | null {
     "path",
     "file_path",
     "filepath",
+    "directory_path",
+    "dir_path",
+    "folder_path",
   ]);
 }
 
@@ -7651,6 +7692,34 @@ function readRequestScopedPatternArgument(toolArguments: unknown): string | null
 
 function readRequestScopedDiffArgument(toolArguments: unknown): string | null {
   return readRequestScopedStringValue(readRequestScopedObject(toolArguments), ["diff", "patch"]);
+}
+
+function readRequestScopedContentArgument(toolArguments: unknown): string | null {
+  return readRequestScopedStringValue(readRequestScopedObject(toolArguments), [
+    "content",
+    "contents",
+    "text",
+  ]);
+}
+
+function readRequestScopedSourcePathArgument(toolArguments: unknown): string | null {
+  return readRequestScopedStringValue(readRequestScopedObject(toolArguments), [
+    "source_path",
+    "sourcePath",
+    "from",
+    "old_path",
+    "oldPath",
+  ]);
+}
+
+function readRequestScopedDestinationPathArgument(toolArguments: unknown): string | null {
+  return readRequestScopedStringValue(readRequestScopedObject(toolArguments), [
+    "destination_path",
+    "destinationPath",
+    "to",
+    "new_path",
+    "newPath",
+  ]);
 }
 
 function collectRequestScopedWorkspaceFiles(rootPath: string): string[] {
@@ -7682,20 +7751,109 @@ function buildRequestScopedGrepResult(
     throw new Error("This runtime request did not include a workspace root.");
   }
   const matcher = new RegExp(patternText, "i");
-  const matches: string[] = [];
+  const matchBlocks: string[] = [];
   for (const filePath of collectRequestScopedWorkspaceFiles(workspaceRoot)) {
     const relativePath = path.relative(workspaceRoot, filePath).replace(/\\/g, "/");
     const lines = readFileSync(filePath, "utf8").split(/\r?\n/);
+    const fileMatches: string[] = [];
     lines.forEach((line, index) => {
       if (matcher.test(line)) {
-        matches.push(`line ${index + 1}: ${line}`);
+        fileMatches.push(`line ${index + 1}: ${line}`);
       }
     });
-    if (matches.length > 0) {
-      return `Found ${matches.length} matches in ${relativePath}:\n${matches.join("\n")}`;
+    if (fileMatches.length > 0) {
+      matchBlocks.push(`${relativePath}:\n${fileMatches.join("\n")}`);
     }
   }
+  if (matchBlocks.length > 0) {
+    const totalMatches = matchBlocks.reduce(
+      (sum, block) => sum + Math.max(0, block.split(/\r?\n/).length - 1),
+      0,
+    );
+    return `Found ${totalMatches} matches for ${patternText}:\n${matchBlocks.join("\n\n")}`;
+  }
   return `Found 0 matches for ${patternText}.`;
+}
+
+function buildRequestScopedListDirResult(
+  workspaceRoot: string | undefined,
+  toolArguments: unknown,
+): string {
+  if (!workspaceRoot) {
+    throw new Error("This runtime request did not include a workspace root.");
+  }
+  const requestedPath = readRequestScopedPathArgument(toolArguments) ?? ".";
+  const resolvedPath = resolveRequestScopedWorkspacePath(workspaceRoot, requestedPath);
+  const stats = statSync(resolvedPath);
+  if (!stats.isDirectory()) {
+    throw new Error(`Path ${requestedPath} is not a directory.`);
+  }
+  const relativePath = path.relative(workspaceRoot, resolvedPath).replace(/\\/g, "/");
+  const renderedPath = relativePath.length > 0 ? relativePath : ".";
+  const entries = readdirSync(resolvedPath, { withFileTypes: true })
+    .map((entry) => (entry.isDirectory() ? `${entry.name}/` : entry.name))
+    .sort(compareText);
+  return `Directory ${renderedPath}:\n${entries.join("\n")}`;
+}
+
+async function writeRequestScopedWorkspaceFile(
+  workspaceRoot: string | undefined,
+  toolArguments: unknown,
+): Promise<string> {
+  const requestedPath = readRequestScopedPathArgument(toolArguments);
+  if (!requestedPath) {
+    throw new Error("write_file requires a path string.");
+  }
+  const content = readRequestScopedContentArgument(toolArguments);
+  if (content === null) {
+    throw new Error("write_file requires content text.");
+  }
+  const resolvedPath = resolveRequestScopedWorkspacePath(workspaceRoot, requestedPath);
+  await mkdir(path.dirname(resolvedPath), { recursive: true });
+  await writeFile(resolvedPath, content, "utf8");
+  return `Wrote ${requestedPath}.`;
+}
+
+async function createRequestScopedWorkspaceDirectory(
+  workspaceRoot: string | undefined,
+  toolArguments: unknown,
+): Promise<string> {
+  const requestedPath = readRequestScopedPathArgument(toolArguments);
+  if (!requestedPath) {
+    throw new Error("create_directory requires a path string.");
+  }
+  const resolvedPath = resolveRequestScopedWorkspacePath(workspaceRoot, requestedPath);
+  await mkdir(resolvedPath, { recursive: true });
+  return `Created directory ${requestedPath}.`;
+}
+
+async function moveRequestScopedWorkspacePath(
+  workspaceRoot: string | undefined,
+  toolArguments: unknown,
+): Promise<string> {
+  const sourcePath = readRequestScopedSourcePathArgument(toolArguments);
+  const destinationPath = readRequestScopedDestinationPathArgument(toolArguments);
+  if (!sourcePath || !destinationPath) {
+    throw new Error("move_file requires source and destination path strings.");
+  }
+  const resolvedSourcePath = resolveRequestScopedWorkspacePath(workspaceRoot, sourcePath);
+  const resolvedDestinationPath = resolveRequestScopedWorkspacePath(workspaceRoot, destinationPath);
+  await mkdir(path.dirname(resolvedDestinationPath), { recursive: true });
+  await rename(resolvedSourcePath, resolvedDestinationPath);
+  return `Moved ${sourcePath} to ${destinationPath}.`;
+}
+
+async function deleteRequestScopedWorkspacePath(
+  workspaceRoot: string | undefined,
+  toolArguments: unknown,
+): Promise<string> {
+  const requestedPath = readRequestScopedPathArgument(toolArguments);
+  if (!requestedPath) {
+    throw new Error("delete_file requires a path string.");
+  }
+  const resolvedPath = resolveRequestScopedWorkspacePath(workspaceRoot, requestedPath);
+  await rm(resolvedPath, { recursive: true, force: true });
+  return `Deleted ${requestedPath}.`;
 }
 
 function parsePatchTargetPath(diff: string): string | null {
@@ -8065,10 +8223,43 @@ function readCodexAppServerMessageText(data: unknown): string {
 }
 
 function readCodexAppServerErrorMessage(error: unknown, fallback: string): string {
-  if (typeof error === "object" && error !== null && "message" in error) {
-    const message = (error as { readonly message?: unknown }).message;
-    if (typeof message === "string" && message.trim().length > 0) {
-      return message;
+  const parts: string[] = [];
+  const pending: unknown[] = [error];
+  const seen = new Set<unknown>();
+  while (pending.length > 0) {
+    const current = pending.shift();
+    if (current === null || current === undefined || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    if (typeof current === "string" && current.trim().length > 0) {
+      parts.push(current.trim());
+      continue;
+    }
+    if (typeof current !== "object") {
+      continue;
+    }
+    const record = current as Record<string, unknown>;
+    for (const key of ["message", "code", "type", "error_description", "detail", "details"]) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        parts.push(value.trim());
+      }
+    }
+    for (const key of ["error", "cause", "data", "body", "response"]) {
+      if (key in record) {
+        pending.push(record[key]);
+      }
+    }
+  }
+  if (parts.length > 0) {
+    return [...new Set(parts)].join(" | ").slice(0, 2_000);
+  }
+  if (error !== undefined) {
+    try {
+      return JSON.stringify(error).slice(0, 2_000);
+    } catch {
+      return String(error);
     }
   }
   return fallback;
@@ -8583,10 +8774,27 @@ export function buildCodexTurnPrompt(requestCapture: ProviderRequestCapture): st
         : Array.isArray(requestCapture.body.input)
           ? requestCapture.body.input
           : [];
-  const dynamicToolNames = buildCodexAppServerDynamicToolBindings(requestCapture).map((tool) =>
+  const dynamicToolBindings = buildCodexAppServerDynamicToolBindings(requestCapture);
+  const dynamicToolNames = dynamicToolBindings.map((tool) =>
     tool.originalName === tool.exposedName
       ? tool.originalName
       : `${tool.originalName} -> ${tool.exposedName}`,
+  );
+  const hasRequestScopedFileTools = dynamicToolBindings.some((tool) =>
+    [
+      "read_file",
+      "grep_search",
+      "list_dir",
+      "write_file",
+      "create_directory",
+      "create_folder",
+      "mkdir",
+      "move_file",
+      "rename_file",
+      "delete_file",
+      "remove_file",
+      "apply_patch",
+    ].includes(tool.originalName),
   );
   const hostedToolNames = readCodexHostedToolNames(requestCapture);
   const conversation = rawMessages
@@ -8623,6 +8831,13 @@ export function buildCodexTurnPrompt(requestCapture: ProviderRequestCapture): st
     ...(dynamicToolNames.length > 0
       ? [
           `Request-scoped dynamic tools are available for this turn: ${dynamicToolNames.join(", ")}.`,
+        ]
+      : []),
+    ...(hasRequestScopedFileTools
+      ? [
+          "Request-scoped file tools only operate inside the managed Codex workspace.",
+          "When the user references an absolute or external filesystem path outside that workspace, use shell tools to inspect and read it instead of assuming the path is inaccessible.",
+          "If a shell command successfully lists or reads an external path, continue with shell-based inspection rather than asking the user to copy files into the workspace.",
         ]
       : []),
     "Use any available hosted or request-scoped tools whenever they help satisfy the request, including file and shell operations when exposed through those tools.",
@@ -9026,10 +9241,7 @@ export async function executeCodexAppServerTurnOverStdio(input: {
           cwd: input.workspaceRoot,
           approvalPolicy: "never",
           sandboxPolicy: {
-            type: "readOnly",
-            access: {
-              type: "fullAccess",
-            },
+            type: "danger-full-access",
           },
           ...(structuredOutputSchema ? { outputSchema: structuredOutputSchema } : {}),
         },
@@ -16375,6 +16587,7 @@ export async function createRuntimeBridgeBackend(
                   }) => {
                     runtimeToolRegistry ??= createRequestScopedToolRegistry(codexDynamicTools, {
                       workspaceRoot,
+                      applyPatchMode: "mutate",
                     });
                     const originalToolName =
                       originalToolNameByExposedName.get(toolName) ?? toolName;

--- a/role-model-router/apps/runtime-host-bridge/src/validate-packaging.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/validate-packaging.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import { createServer } from "node:net";
@@ -63,6 +63,37 @@ async function fetchJson<TValue>(url: string, init?: RequestInit): Promise<TValu
     throw new Error(`Request to ${url} failed with ${response.status}: ${await response.text()}`);
   }
   return (await response.json()) as TValue;
+}
+
+async function stopProcessTree(child: ChildProcess): Promise<void> {
+  if (child.pid == null || child.exitCode !== null) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  } else {
+    child.kill("SIGTERM");
+  }
+
+  const deadline = Date.now() + 10_000;
+  while (child.exitCode === null && Date.now() < deadline) {
+    await delay(100);
+  }
+
+  if (child.exitCode === null && child.pid != null) {
+    if (process.platform === "win32") {
+      spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } else {
+      child.kill("SIGKILL");
+    }
+  }
 }
 
 function extractChatOutputText(payload: unknown): string {
@@ -565,9 +596,15 @@ export async function runRuntimePackagingValidation(): Promise<{
   } catch (error) {
     validationError = error;
   } finally {
-    child.kill("SIGTERM");
-    await mockUpstream.close();
-    await rm(runtimeStateRoot, { recursive: true, force: true });
+    try {
+      await stopProcessTree(child);
+    } finally {
+      try {
+        await mockUpstream.close();
+      } finally {
+        await rm(runtimeStateRoot, { recursive: true, force: true });
+      }
+    }
   }
 
   const stderrOutput = stderrChunks.join("").trim();

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -354,6 +354,24 @@ describe("runtime-host-bridge executable packaging", () => {
     expect(validatePackagingText).toContain("security.audit");
   });
 
+  test("packaged runtime validation tears down the packaged process tree before cleaning release artifacts", async () => {
+    const validatePackagingPath = path.join(
+      repoRoot,
+      "role-model-router",
+      "apps",
+      "runtime-host-bridge",
+      "src",
+      "validate-packaging.ts",
+    );
+    const validatePackagingText = await readFile(validatePackagingPath, "utf8");
+
+    expect(validatePackagingText).toContain("async function stopProcessTree");
+    expect(validatePackagingText).toContain(
+      'spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"]',
+    );
+    expect(validatePackagingText).toContain("await stopProcessTree(child);");
+  });
+
   test("packaged runtime validation rebuilds the bridge before creating the SEA executable", async () => {
     const manifest = await readManifest("role-model-router/apps/runtime-host-bridge/package.json");
 

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -2657,7 +2657,7 @@ describe("runtime-host-bridge", () => {
     ).toBe("function");
   });
 
-  test("createRequestScopedToolRegistry produces a working registry with correct tool names and passthrough execution", async () => {
+  test("createRequestScopedToolRegistry produces explicit failures for unimplemented bridged tool names", async () => {
     const createRequestScopedToolRegistry = (
       bridge as {
         createRequestScopedToolRegistry: (
@@ -2697,11 +2697,12 @@ describe("runtime-host-bridge", () => {
     });
 
     expect(result.executions).toHaveLength(1);
-    expect(result.executions[0].status).toBe("succeeded");
+    expect(result.executions[0].status).toBe("failed");
     expect(result.executions[0].toolName).toBe("lookupRegistry");
-    expect(result.executions[0].output).toEqual({
-      endpointId: "openai.personal.openai-codex-subscription.global.gpt-5.4",
-    });
+    expect(result.executions[0].output).toBeNull();
+    expect(result.executions[0].diagnostics[0]?.message).toContain(
+      "is not implemented by the Codex Subscription bridge",
+    );
   });
 
   test("seedManagedCodexWorkspaceFixture stages benchmark files for Codex tool-heavy cases", async () => {
@@ -2735,7 +2736,7 @@ describe("runtime-host-bridge", () => {
     }
   });
 
-  test("createRequestScopedToolRegistry executes read_file, grep_search, and apply_patch against a staged workspace", async () => {
+  test("createRequestScopedToolRegistry executes read/list/write tools and apply_patch against a staged workspace", async () => {
     const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-codex-tools-"));
     try {
       await (
@@ -2781,6 +2782,35 @@ describe("runtime-host-bridge", () => {
             },
           },
           {
+            name: "list_dir",
+            description: "List a directory from the benchmark workspace.",
+            inputSchema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+            },
+          },
+          {
+            name: "write_file",
+            description: "Write a file into the benchmark workspace.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+                content: { type: "string" },
+              },
+              required: ["path", "content"],
+            },
+          },
+          {
+            name: "create_directory",
+            description: "Create a directory in the benchmark workspace.",
+            inputSchema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+          {
             name: "apply_patch",
             description: "Apply a unified diff patch in the benchmark workspace.",
             inputSchema: {
@@ -2820,6 +2850,48 @@ describe("runtime-host-bridge", () => {
       expect(String(grepResult.executions[0]?.output)).toContain("src/router.ts");
       expect(String(grepResult.executions[0]?.output)).toContain("evaluateEligibility");
 
+      const listDirResult = await executeToolCalls(registry, {
+        requestId: "codex-tool-list-dir",
+        toolCalls: [
+          {
+            name: "list_dir",
+            arguments: { path: "src" },
+            providerToolId: "call-list-dir",
+          },
+        ],
+      });
+      expect(listDirResult.executions[0]?.status).toBe("succeeded");
+      expect(String(listDirResult.executions[0]?.output)).toContain("Directory src:");
+      expect(String(listDirResult.executions[0]?.output)).toContain("router.ts");
+
+      const createDirectoryResult = await executeToolCalls(registry, {
+        requestId: "codex-tool-create-dir",
+        toolCalls: [
+          {
+            name: "create_directory",
+            arguments: { path: "notes" },
+            providerToolId: "call-create-dir",
+          },
+        ],
+      });
+      expect(createDirectoryResult.executions[0]?.status).toBe("succeeded");
+      expect(String(createDirectoryResult.executions[0]?.output)).toContain("Created directory");
+
+      const writeFileResult = await executeToolCalls(registry, {
+        requestId: "codex-tool-write-file",
+        toolCalls: [
+          {
+            name: "write_file",
+            arguments: { path: "notes/summary.md", content: "# summary\n" },
+            providerToolId: "call-write-file",
+          },
+        ],
+      });
+      expect(writeFileResult.executions[0]?.status).toBe("succeeded");
+      expect(readFileSync(path.join(workspaceRoot, "notes", "summary.md"), "utf8")).toContain(
+        "# summary",
+      );
+
       const patchResult = await executeToolCalls(registry, {
         requestId: "codex-tool-patch",
         toolCalls: [
@@ -2845,6 +2917,114 @@ describe("runtime-host-bridge", () => {
       );
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("createRequestScopedToolRegistry fails explicitly for unsupported bridged tools", async () => {
+    const createRequestScopedToolRegistry = (
+      bridge as {
+        createRequestScopedToolRegistry: (
+          dynamicTools: readonly {
+            readonly name: string;
+            readonly description?: string;
+            readonly inputSchema: Record<string, unknown>;
+          }[],
+          options?: {
+            readonly workspaceRoot?: string;
+            readonly applyPatchMode?: "ack" | "mutate";
+          },
+        ) => { connectors: readonly { tools: readonly { name: string }[] }[] };
+      }
+    ).createRequestScopedToolRegistry;
+
+    const registry = createRequestScopedToolRegistry([
+      {
+        name: "nonstandard_runtime_tool",
+        description: "A tool the Codex bridge cannot execute.",
+        inputSchema: {
+          type: "object",
+        },
+      },
+    ]);
+
+    const result = await executeToolCalls(registry, {
+      requestId: "codex-tool-unsupported",
+      toolCalls: [
+        {
+          name: "nonstandard_runtime_tool",
+          arguments: {},
+          providerToolId: "call-unsupported",
+        },
+      ],
+    });
+
+    expect(result.executions[0]?.status).toBe("failed");
+    expect(result.executions[0]?.diagnostics[0]?.message).toContain(
+      "is not implemented by the Codex Subscription bridge",
+    );
+  });
+
+  test("createRequestScopedToolRegistry tells Codex to use shell tools for external file paths", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-codex-tools-"));
+    const externalRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-codex-external-"));
+    try {
+      await (
+        bridge as {
+          seedManagedCodexWorkspaceFixture: (workspaceRoot: string) => Promise<void>;
+        }
+      ).seedManagedCodexWorkspaceFixture(workspaceRoot);
+      const externalPath = path.join(externalRoot, "notes.md");
+      await writeFile(externalPath, "# external notes\n", "utf8");
+
+      const createRequestScopedToolRegistry = (
+        bridge as {
+          createRequestScopedToolRegistry: (
+            dynamicTools: readonly {
+              readonly name: string;
+              readonly description?: string;
+              readonly inputSchema: Record<string, unknown>;
+            }[],
+            options?: {
+              readonly workspaceRoot?: string;
+              readonly applyPatchMode?: "ack" | "mutate";
+            },
+          ) => { connectors: readonly { tools: readonly { name: string }[] }[] };
+        }
+      ).createRequestScopedToolRegistry;
+
+      const registry = createRequestScopedToolRegistry(
+        [
+          {
+            name: "read_file",
+            description: "Read a file from the benchmark workspace.",
+            inputSchema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+        { workspaceRoot },
+      );
+
+      const readResult = await executeToolCalls(registry, {
+        requestId: "codex-tool-read-external",
+        toolCalls: [
+          {
+            name: "read_file",
+            arguments: { path: externalPath },
+            providerToolId: "call-read-external",
+          },
+        ],
+      });
+
+      expect(readResult.executions[0]?.status).toBe("failed");
+      expect(readResult.executions[0]?.diagnostics[0]?.message).toContain(
+        "Use shell commands for external filesystem paths",
+      );
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(externalRoot, { recursive: true, force: true });
     }
   });
 
@@ -3069,6 +3249,10 @@ describe("runtime-host-bridge", () => {
           "    return;",
           "  }",
           "  if (message.id === 3 && message.method === 'turn/start') {",
+          "    if (message.params?.sandboxPolicy?.type !== 'danger-full-access') {",
+          "      send({ method: 'turn/failed', params: { error: { message: 'sandbox policy mismatch', code: 'invalid_request', data: { received: message.params?.sandboxPolicy } } } });",
+          "      return;",
+          "    }",
           "    send({ id: 3, result: { accepted: true } });",
           "    send({ method: 'thread/tokenUsage/updated', params: { tokenUsage: { last: { inputTokens: 11, outputTokens: 0 } } } });",
           "    send({ id: 91, method: 'item/tool/call', params: { callId: 'call_stdio_1', tool: 'request_read_file', arguments: { path: 'README.md' } } });",
@@ -3205,6 +3389,75 @@ describe("runtime-host-bridge", () => {
       expect(result.dynamicToolExecutions).toEqual([{ toolName: "request_read_file" }]);
     } finally {
       fakeAppServer.kill();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("executeCodexAppServerTurnOverStdio preserves nested app-server error details for fallback classification", async () => {
+    const fakeAppServer = spawn(
+      process.execPath,
+      [
+        "-e",
+        [
+          "const { createInterface } = require('node:readline');",
+          "const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });",
+          "const send = (payload) => process.stdout.write(JSON.stringify(payload) + '\\n');",
+          "rl.on('line', (line) => {",
+          "  const message = JSON.parse(line);",
+          "  if (message.id === 1 && message.method === 'initialize') {",
+          "    send({ id: 1, result: { serverInfo: { name: 'fake-codex' } } });",
+          "    return;",
+          "  }",
+          "  if (message.method === 'initialized') {",
+          "    return;",
+          "  }",
+          "  if (message.id === 2 && message.method === 'thread/start') {",
+          "    send({ id: 2, result: { thread: { id: 'thr_test_stdio_error' } } });",
+          "    return;",
+          "  }",
+          "  if (message.id === 3 && message.method === 'turn/start') {",
+          "    send({ method: 'turn/failed', params: { error: { message: 'Invalid Request: The API rejected this request.', code: 'invalid_request', data: { code: 'insufficient_quota', detail: 'The authenticated ChatGPT account has no remaining credits for this turn.' } } } });",
+          "    setTimeout(() => process.exit(0), 0);",
+          "  }",
+          "});",
+        ].join(" "),
+      ],
+      {
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      },
+    );
+
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "codex-stdio-error-"));
+
+    try {
+      await expect(
+        (
+          bridge as {
+            executeCodexAppServerTurnOverStdio: (input: {
+              child: ReturnType<typeof spawn>;
+              model: string;
+              requestCapture: {
+                url: string;
+                body: Record<string, unknown>;
+              };
+              workspaceRoot: string;
+            }) => Promise<unknown>;
+          }
+        ).executeCodexAppServerTurnOverStdio({
+          child: fakeAppServer,
+          model: "gpt-5.4",
+          requestCapture: {
+            url: "https://api.openai.com/v1/responses",
+            body: {
+              model: "gpt-5.4",
+              input: "Check the fallback behavior.",
+            },
+          },
+          workspaceRoot,
+        }),
+      ).rejects.toThrow(/insufficient_quota|no remaining credits/i);
+    } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
     }
   });
@@ -3481,7 +3734,7 @@ describe("runtime-host-bridge", () => {
     }
   });
 
-  test("Codex tool path produces judged execution results in packaged-runtime-like environment (not file errors)", async () => {
+  test("Codex tool path surfaces explicit failures for unimplemented request-scoped tool names in packaged-runtime-like environments", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "role-model-packaged-sim-"));
     try {
       const loadMcpConnectorConfigs = (
@@ -3548,12 +3801,12 @@ describe("runtime-host-bridge", () => {
       });
 
       expect(result.executions).toHaveLength(1);
-      expect(result.executions[0].status).toBe("succeeded");
+      expect(result.executions[0].status).toBe("failed");
       expect(result.executions[0].toolName).toBe("lookupRegistry");
-      expect(result.executions[0].output).toEqual({
-        endpointId: "openai.personal.openai-codex-subscription.global.gpt-5.4",
-      });
-      expect(result.executions[0].diagnostics).toEqual([]);
+      expect(result.executions[0].output).toBeNull();
+      expect(result.executions[0].diagnostics[0]?.message).toContain(
+        "is not implemented by the Codex Subscription bridge",
+      );
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
@@ -3605,6 +3858,22 @@ describe("runtime-host-bridge", () => {
       body: {
         model: "gpt-5.4",
         input: "Find the current Cloudflare stock price with a source.",
+        tools: [
+          {
+            type: "function",
+            name: "read_file",
+            description: "Read a file.",
+            parameters: {
+              type: "object",
+              properties: {
+                path: {
+                  type: "string",
+                },
+              },
+              required: ["path"],
+            },
+          },
+        ],
       },
     });
 
@@ -3615,6 +3884,12 @@ describe("runtime-host-bridge", () => {
     expect(prompt).toContain("Built-in web search is allowed when helpful.");
     expect(prompt).toContain(
       "Use any available hosted or request-scoped tools whenever they help satisfy the request",
+    );
+    expect(prompt).toContain(
+      "Request-scoped file tools only operate inside the managed Codex workspace.",
+    );
+    expect(prompt).toContain(
+      "use shell tools to inspect and read it instead of assuming the path is inaccessible",
     );
   });
 

--- a/role-model-router/apps/runtime-host-bridge/test/openai-codex-subscription-matrix.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/openai-codex-subscription-matrix.test.ts
@@ -704,5 +704,5 @@ describe("OpenAI Codex Subscription model matrix", () => {
       await backend.shutdown();
       await rm(runtimeStateRoot, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary
- add real request-scoped file tool support and explicit unsupported-tool failures for the Codex subscription bridge
- preserve nested app-server error details for retry/fallback classification and run Codex app-server turns with full-access sandbox policy
- clean up packaged runtime validation by terminating the spawned process tree before release directory cleanup

## Validation
- corepack pnpm --filter @role-model-router/runtime-host-bridge test
- corepack pnpm run runtime:validate-packaging
- targeted vitest/biome/tsc checks for runtime-host-bridge

## Notes
- local ci:check in this environment stops at lint:rust because cargo is not installed on this machine; GitHub Actions will provide the full CI signal