### PR TITLE
Make runtime version test hermetic under tag CI

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts
@@ -70,6 +70,7 @@ describe("resolveRuntimeVersionInfo", () => {
       resolveRuntimeVersionInfo({
         repoRoot,
         fallbackConfigVersion: "1.1",
+        env: {},
         runGitCommand: (args) => {
           const command = args.join(" ");
           if (command.startsWith("tag --list")) {


### PR DESCRIPTION
## Summary
- stop the runtime-version git fallback test from inheriting live tag workflow environment variables
- keep the test focused on the mocked git responses it already supplies

## Validation
- corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/runtime-version.test.ts
- npx biome check role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts