### PR TITLE
Keep docs deploy green when secrets are absent

### DIFF
--- a/.github/workflows/docs-site-deploy.yml
+++ b/.github/workflows/docs-site-deploy.yml
@@ -88,39 +88,48 @@ jobs:
           name: docs-site-build
           path: apps/docs-site/build/client
 
-      - name: Require Cloudflare secrets
+      - name: Check Cloudflare deploy posture
+        id: cloudflare_ready
         shell: bash
         run: |
           if [[ -z "$CLOUDFLARE_API_TOKEN" || -z "$CLOUDFLARE_ACCOUNT_ID" ]]; then
-            echo "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID must be set for docs deployment." >&2
-            exit 1
+            echo "::notice::Skipping docs deploy because Cloudflare secrets are not configured."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
+        if: steps.cloudflare_ready.outputs.ready == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 10.6.5
 
       - name: Setup Node.js
+        if: steps.cloudflare_ready.outputs.ready == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
 
       - name: Print toolchain versions
+        if: steps.cloudflare_ready.outputs.ready == 'true'
         run: |
           node --version
           pnpm --version
 
       - name: Install dependencies
+        if: steps.cloudflare_ready.outputs.ready == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Select Pages branch
+        if: steps.cloudflare_ready.outputs.ready == 'true'
         shell: bash
         run: |
           echo "PAGES_BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
 
       - name: Deploy docs site
+        if: steps.cloudflare_ready.outputs.ready == 'true'
         run: |
           pnpm exec wrangler pages deploy apps/docs-site/build/client \
             --project-name role-model-dev \

--- a/.recursive/DECISIONS.md
+++ b/.recursive/DECISIONS.md
@@ -9,16 +9,19 @@
   - added Codex Subscription first-attempt pinning for tool-bearing and non-text turns, while keeping the broader eligible endpoint pool available for reroute after retry or fallback
   - hardened upstream failure classification and cooldown handling so timeout, network, rate-limit, quota, provider-auth, and upstream-5xx failures can drive retry or reroute with escalating endpoint cooldown windows; repaired Codex auth now clears stale provider-auth cooldowns
   - made session bootstrap treat peer auto-reload degradation as advisory so remote-only readiness is not blocked by `peer reload incomplete`
+  - changed `docs-site-deploy.yml` so missing Cloudflare secrets emit a skip notice and keep the workflow green instead of failing the merged `main` commit on an environment-only deploy precondition
 - Why:
   - routed Codex Subscription requests could lose forced tool intent, mis-handle tool-heavy or multimodal turns, and stay artificially denied after recoverable execution failures
   - remote-only operators could see a false degraded readiness summary when local peer reload lagged even though the runtime was otherwise execution-ready
+  - release gating on GitHub should fail for broken builds or broken deploy logic, not for an intentionally absent Pages credential in repositories or forks that still need docs-build validation
 - How:
   - verified with targeted host/provider tests, full local `corepack pnpm run ci:check`, rebuilt-runtime probes on `:3456`, and live exact-model plus alias requests that executed GPT 5.4 tool calls through the Codex Subscription path
+  - added a repo-owned docs workflow contract test in `apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs` and verified it red/green against the workflow YAML before rerunning local CI
 - What was not done:
   - no new provider families or generic hosted-browser/tool runtime were introduced
   - invalid-request responses still fail fast instead of falling back to a different endpoint
 - Known issues / follow-ups:
-  - docs, runtime routing memory, and release notes need to stay aligned whenever Codex Subscription heuristics or cooldown policy change again
+  - docs, runtime routing memory, release notes, and GitHub workflow guidance need to stay aligned whenever Codex Subscription heuristics, cooldown policy, or release automation posture change again
 
 ### Run `60-runtime-ui-paper-linear-review-alignment`
 

--- a/.recursive/STATE.md
+++ b/.recursive/STATE.md
@@ -2,6 +2,7 @@
 
 ## Current State
 
+- `/.github/workflows/docs-site-deploy.yml` now treats missing Cloudflare deploy secrets as a non-fatal skip on non-PR events: docs still build, the static artifact is uploaded, and the workflow emits a clear skip notice instead of failing `main` for an environment-only deploy precondition.
 - `/role-model-router/apps/runtime-host-bridge/`, `/role-model-router/packages/adapter-execution/`, and `/role-model-router/packages/provider-openai/` now preserve OpenAI chat-completions `tool_choice` through routed execution, keep forced tool choice only on the initial tool-bearing turn, and prefer eligible Codex Subscription GPT 5.4 endpoints for tool-bearing or non-text turns before reopening the broader fallback pool.
 - Upstream execution failures now drive runtime-owned fallback cooldowns with escalating windows of `10m`, `30m`, `1h`, `5h`, `10h`, and `20h`. Timeout, network, rate-limit, quota-exhausted, provider-auth, and upstream-5xx failures remain fallback-eligible, while invalid requests still fail fast without fallback. Repaired Codex auth clears stale provider-auth cooldowns so recovered subscription endpoints can re-enter routing immediately.
 - Session bootstrap now treats peer auto-reload degradation as advisory: `peer reload incomplete` still appears in readiness detail, but `/healthz` and session readiness can summarize as `ready` when all non-advisory stages succeeded.

--- a/.recursive/memory/patterns/github-ci-and-release-workflow.md
+++ b/.recursive/memory/patterns/github-ci-and-release-workflow.md
@@ -38,6 +38,7 @@ Trust: current repo-local baseline; validate again after workflow topology or re
 
 - `/.github/workflows/docs-site-deploy.yml` should always prove that the docs site builds on pull requests and pushes, even when deploy credentials are unavailable.
 - Deployment must remain a non-PR concern. Gate the Cloudflare publish path behind explicit secret and account checks so content validation and deployment authorization stay separable.
+- When those secrets are absent, the workflow should emit an explicit skip notice and stay green rather than failing the merged commit. Missing deploy credentials are environment posture, not a product regression.
 - Keep the built static artifact available from the workflow so GitHub-only docs failures can be inspected without rerunning locally.
 
 ## Release publication pattern

--- a/apps/docs-site/package.json
+++ b/apps/docs-site/package.json
@@ -31,6 +31,7 @@
     "pages:dev": "npm run build && wrangler pages dev ./build/client",
     "pages:deploy": "npm run build && wrangler pages deploy ./build/client --project-name role-model-dev",
     "start": "serve ./build/client",
+    "test": "node --test",
     "types:check": "react-router typegen && fumadocs-mdx && tsc --noEmit",
     "upstream:sync": "node ./scripts/upstream-sync.mjs --write",
     "upstream:sync:latest": "node ./scripts/upstream-sync.mjs --write --ref main"

--- a/apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
+++ b/apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+const workflowPath = path.join(repoRoot, ".github", "workflows", "docs-site-deploy.yml");
+
+test("docs deploy workflow skips gracefully when Cloudflare secrets are absent", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /Skipping docs deploy because Cloudflare secrets are not configured\./);
+  assert.doesNotMatch(workflow, /exit 1/);
+  assert.match(workflow, /if:\s*steps\.cloudflare_ready\.outputs\.ready == 'true'/);
+});

--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -86,7 +86,7 @@ Job model:
 Notes:
 
 - PRs validate the docs build without requiring Cloudflare secrets.
-- non-PR deploys fail early with a clear secret-missing message instead of a later `wrangler` error.
+- non-PR deploys only run when Cloudflare secrets are present; otherwise the workflow emits a clear skip notice and stays green.
 
 ### `cla.yml`
 


### PR DESCRIPTION
## Summary
- skip Cloudflare Pages deploy cleanly when deploy secrets are not configured
- add a docs workflow contract test so the secret-missing path stays green
- update release/CI docs and recursive memory for the new deploy posture

## Verification
- corepack pnpm --filter @role-model/docs-site test
- corepack pnpm run docs:build
- corepack pnpm run ci:check
- corepack pnpm run runtime:package-sea