### PR TITLE
Prepare run 61 baseline fixes

### DIFF
--- a/role-model-router/apps/launcher/main.go
+++ b/role-model-router/apps/launcher/main.go
@@ -32,9 +32,61 @@ func resolveRuntimeStateRoot(packageDir string) string {
 	return filepath.Join(packageDir, "runtime-state")
 }
 
+func looksLikeWorkspaceRoot(directory string) bool {
+	markers := []string{
+		".git",
+		".agents",
+		"pnpm-workspace.yaml",
+		"package.json",
+		"pyproject.toml",
+	}
+
+	for _, marker := range markers {
+		if _, err := os.Stat(filepath.Join(directory, marker)); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func resolveWorkspaceRootFromAncestors(packageDir string) string {
+	current := filepath.Clean(packageDir)
+	for {
+		if looksLikeWorkspaceRoot(current) {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return packageDir
+		}
+		current = parent
+	}
+}
+
+func resolveStandaloneWorkspaceRoot(packageDir string) string {
+	if override := strings.TrimSpace(os.Getenv("ROLE_MODEL_WORKSPACE_ROOT")); override != "" {
+		if info, err := os.Stat(override); err == nil && info.IsDir() {
+			return filepath.Clean(override)
+		}
+	}
+
+	discovered := resolveWorkspaceRootFromAncestors(packageDir)
+	if discovered != filepath.Clean(packageDir) {
+		return discovered
+	}
+
+	if cwd, err := os.Getwd(); err == nil && cwd != "" && looksLikeWorkspaceRoot(cwd) {
+		return filepath.Clean(cwd)
+	}
+
+	return filepath.Clean(packageDir)
+}
+
 func buildRuntimeArgs(packageDir string, runtimeStateRoot string) []string {
+	workspaceRoot := resolveStandaloneWorkspaceRoot(packageDir)
 	return []string{
-		"--repo-root", packageDir,
+		"--repo-root", workspaceRoot,
 		"--runtime-state-root", runtimeStateRoot,
 		"--scope-id", "standalone-runtime",
 		"--host", runtimeHost,

--- a/role-model-router/apps/launcher/main_test.go
+++ b/role-model-router/apps/launcher/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,6 +30,25 @@ func TestBuildRuntimeArgsUsesStandalonePaths(t *testing.T) {
 		if got[index] != want[index] {
 			t.Fatalf("arg %d mismatch: expected %q, got %q", index, want[index], got[index])
 		}
+	}
+}
+
+func TestBuildRuntimeArgsUsesAncestorWorkspaceRootWhenPackageLivesInsideRepo(t *testing.T) {
+	tempRoot := t.TempDir()
+	workspaceRoot := filepath.Join(tempRoot, "workspace")
+	packageDir := filepath.Join(workspaceRoot, "role-model-router", "dist", "release", "win32-x64")
+	runtimeStateRoot := filepath.Join(tempRoot, "runtime-state")
+
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("mkdir package dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "pnpm-workspace.yaml"), []byte("packages:\n"), 0o644); err != nil {
+		t.Fatalf("write workspace marker: %v", err)
+	}
+
+	got := buildRuntimeArgs(packageDir, runtimeStateRoot)
+	if got[1] != workspaceRoot {
+		t.Fatalf("expected repo-root %q, got %q", workspaceRoot, got[1])
 	}
 }
 

--- a/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
@@ -1413,9 +1413,7 @@ export function isPrimaryRoutingAliasId(aliasId: string): boolean {
   );
 }
 
-function readPrimaryRoutingAliasExecutionMode(
-  aliasId: string,
-): UnifiedRuntimeExecutionMode | null {
+function readPrimaryRoutingAliasExecutionMode(aliasId: string): UnifiedRuntimeExecutionMode | null {
   for (const suffix of primaryRoutingAliasExecutionSuffixes) {
     if (primaryRoutingAliasPrefixes.some((prefix) => aliasId === `${prefix}.${suffix}`)) {
       return suffix.replaceAll("-", "_") as UnifiedRuntimeExecutionMode;
@@ -1502,9 +1500,7 @@ function canonicalizeUnifiedRuntimeRoutingAliases(
   const normalizedAliases = mergeCanonicalAliasEntries(
     config.modelAliases.map((alias) => {
       const canonicalLegacyAlias = canonicalizeLegacyRoutingAliasId(alias, config);
-      const aliasExecutionMode = readPrimaryRoutingAliasExecutionMode(
-        canonicalLegacyAlias.aliasId,
-      );
+      const aliasExecutionMode = readPrimaryRoutingAliasExecutionMode(canonicalLegacyAlias.aliasId);
       if (
         config.modelAliases?.length === 1 &&
         aliasExecutionMode !== null &&

--- a/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
@@ -1413,6 +1413,17 @@ export function isPrimaryRoutingAliasId(aliasId: string): boolean {
   );
 }
 
+function readPrimaryRoutingAliasExecutionMode(
+  aliasId: string,
+): UnifiedRuntimeExecutionMode | null {
+  for (const suffix of primaryRoutingAliasExecutionSuffixes) {
+    if (primaryRoutingAliasPrefixes.some((prefix) => aliasId === `${prefix}.${suffix}`)) {
+      return suffix.replaceAll("-", "_") as UnifiedRuntimeExecutionMode;
+    }
+  }
+  return null;
+}
+
 function canonicalizeSinglePrimaryRoutingAlias(
   alias: UnifiedRuntimeModelAliasConfig,
   config: UnifiedRuntimeConfig,
@@ -1491,6 +1502,16 @@ function canonicalizeUnifiedRuntimeRoutingAliases(
   const normalizedAliases = mergeCanonicalAliasEntries(
     config.modelAliases.map((alias) => {
       const canonicalLegacyAlias = canonicalizeLegacyRoutingAliasId(alias, config);
+      const aliasExecutionMode = readPrimaryRoutingAliasExecutionMode(
+        canonicalLegacyAlias.aliasId,
+      );
+      if (
+        config.modelAliases?.length === 1 &&
+        aliasExecutionMode !== null &&
+        aliasExecutionMode !== config.executionMode
+      ) {
+        return canonicalizeSinglePrimaryRoutingAlias(canonicalLegacyAlias, config);
+      }
       return canonicalLegacyAlias;
     }),
   );

--- a/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
@@ -1491,12 +1491,6 @@ function canonicalizeUnifiedRuntimeRoutingAliases(
   const normalizedAliases = mergeCanonicalAliasEntries(
     config.modelAliases.map((alias) => {
       const canonicalLegacyAlias = canonicalizeLegacyRoutingAliasId(alias, config);
-      if (
-        config.modelAliases?.length === 1 &&
-        isPrimaryRoutingAliasId(canonicalLegacyAlias.aliasId)
-      ) {
-        return canonicalizeSinglePrimaryRoutingAlias(canonicalLegacyAlias, config);
-      }
       return canonicalLegacyAlias;
     }),
   );

--- a/role-model-router/apps/runtime-host-bridge/test/unified-runtime-config.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/unified-runtime-config.test.ts
@@ -1233,4 +1233,34 @@ observed_data:
       },
     ]);
   });
+
+  test("renames a single primary alias when its execution suffix becomes stale", () => {
+    const merged = mergeUnifiedRuntimeConfigDocuments(
+      {
+        version: "1.0",
+        routing: {
+          strategy: "difficulty",
+        },
+        execution_mode: "hybrid",
+        model_aliases: {
+          "difficulty.hybrid": {
+            mode: "difficulty",
+            model_ids: ["remote/vision-model", "remote/code-model"],
+          },
+        },
+      },
+      {
+        execution_mode: "remote_only",
+      },
+    );
+
+    expect(merged.executionMode).toBe("remote_only");
+    expect(merged.modelAliases).toEqual([
+      {
+        aliasId: "difficulty.remote-only",
+        mode: "difficulty",
+        modelIds: ["remote/vision-model", "remote/code-model"],
+      },
+    ]);
+  });
 });

--- a/role-model-router/apps/runtime-host-bridge/test/unified-runtime-config.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/unified-runtime-config.test.ts
@@ -1204,4 +1204,33 @@ observed_data:
       },
     ]);
   });
+
+  test("preserves explicitly configured modern primary alias ids even when routing strategy differs", () => {
+    const merged = mergeUnifiedRuntimeConfigDocuments(
+      {
+        version: "1.0",
+        routing: {
+          strategy: "balanced",
+        },
+        execution_mode: "remote_only",
+        model_aliases: {
+          "difficulty.remote-only": {
+            mode: "difficulty",
+            model_ids: ["remote/vision-model", "remote/code-model"],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(merged.routingStrategy).toBe("balanced");
+    expect(merged.executionMode).toBe("remote_only");
+    expect(merged.modelAliases).toEqual([
+      {
+        aliasId: "difficulty.remote-only",
+        mode: "difficulty",
+        modelIds: ["remote/vision-model", "remote/code-model"],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Prepare the baseline for run 61 without starting the recursive run.

- Resolve packaged launcher `--repo-root` from an ancestor workspace root when available, with an explicit `ROLE_MODEL_WORKSPACE_ROOT` override.
- Preserve explicitly configured modern primary aliases such as `difficulty.remote-only` instead of rewriting them to the active routing strategy alias.
- Add regression coverage using generic fixture model ids, avoiding fixed Codex Subscription model versions.

## Validation

- `GO111MODULE=off go test` in `role-model-router/apps/launcher`
- `corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/unified-runtime-config.test.ts`
- `corepack pnpm --filter @role-model-router/runtime-host-bridge build`
- `corepack pnpm --filter @role-model-router/runtime-host-bridge run test:critical`

## Notes

Run 61 is not started by this PR. This is only baseline preparation.