### PR TITLE
fix pi role-model diagnostics and model guidance

### DIFF
--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md
@@ -1,0 +1,257 @@
+Run: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/`
+Phase: `00 Requirements`
+Status: `LOCKED`
+LockedAt: `2026-07-17T06:40:42Z`
+LockHash: `2cd2aec61bb37be5839189b80583f92d73e87f264b2a382c96134a9765b28032`
+Workflow version: `recursive-mode-audit-v2`
+User approval: `2026-07-17` (requirements approved for run creation)
+Inputs:
+- `/.recursive/RECURSIVE.md`
+- `/.recursive/STATE.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/memory/MEMORY.md`
+- `/.recursive/memory/domains/pi-role-model-package.md`
+- `/.recursive/memory/domains/runtime-routing-and-provider-capabilities.md`
+- `/.recursive/run/55-pi-role-model-package/00-requirements.md`
+- `/.recursive/run/56-pi-role-model-gap-closure/00-requirements.md`
+- `packages/pi-role-model/src/extension.ts`
+- `packages/pi-role-model/src/commands.ts`
+- `packages/pi-role-model/src/downstream-openai.ts`
+- `packages/pi-role-model/src/provider-registration.ts`
+- `apps/docs-site/content/docs/integrations/pi.mdx`
+Outputs:
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+Scope note: Improve the Pi integration UX around Role-Model command execution, model-id guidance, and invalid endpoint/model failures so supported paths are truthful, failures are actionable, and repo-owned behavior is clearly separated from upstream Pi defects.
+
+## TODO
+
+- [x] Ground the draft in current recursive control-plane docs and relevant Pi/runtime memory
+- [x] Re-read the current `pi-role-model` package and Pi integration docs
+- [x] Separate repo-owned defects from upstream Pi defects
+- [x] Lock the canonical Pi CLI model-id form in Phase 00 rather than deferring it
+- [x] Carry forward auth, trust, and secret-safety invariants from the existing Pi integration baseline
+- [x] Define supported command-path and prompt-path requirements
+- [x] Define minimum actionable `status` and `doctor` diagnostics
+- [x] Define canonical model-id guidance requirements
+- [x] Define deterministic invalid endpoint/model error requirements
+- [x] Require QA to prove unsupported invocation-mode behavior, not only supported flows
+- [x] Capture user approval of this requirement before creating the run
+- [x] Complete Coverage Gate checklist
+- [x] Complete Approval Gate checklist
+
+## Run Metadata
+
+- Priority: `P1`
+- Run type: `integration bugfix`
+- Primary subsystems:
+  - `packages/pi-role-model/**`
+  - `apps/docs-site/content/docs/integrations/pi.mdx`
+- Secondary subsystems:
+  - `role-model-router/apps/runtime-host-bridge/**`
+  - `protocol/fixtures/downstream-openai/**`
+- User-visible outcome:
+  - Pi users get one truthful command path for Role-Model diagnostics, one truthful prompt path for Role-Model execution, and actionable errors when they use an invalid endpoint or model.
+
+## Relevant Prior Runs
+
+- `54-alias-capability-discovery-contract`
+- `55-pi-role-model-package`
+- `56-pi-role-model-gap-closure`
+- `59-observe-taxonomy-analytics-completion`
+- `68-codex-subscription-tool-call-parity`
+
+## Problem Summary
+
+The current Pi integration has three user-facing gaps:
+
+1. slash-command behavior is not truthfully defined across Pi invocation modes, so users can hit zero-output behavior and conclude routing is broken
+2. Role-Model model-id guidance is inconsistent, so users try foreign ids such as `gpt-4o` under provider `role-model` and get misleading `no_eligible_target` failures
+3. invalid endpoint and model failures are not turned into descriptive repo-owned help, so users do not get clear recovery guidance
+
+This run must make the supported Pi paths explicit, keep the working provider path healthy, align model-id guidance, and return actionable errors for invalid endpoint/model usage.
+
+## Fixed Decisions
+
+1. This run stays within repo-owned Role-Model surfaces and does not attempt to patch upstream Pi core.
+2. The Windows Pi exit assertion is an external Pi bug; this run may document and detect it, but not fix it here.
+3. Role-Model remains an external runtime and the routing authority.
+4. Foreign upstream ids such as `gpt-4o` are not valid canonical model ids under provider `role-model`.
+5. For explicit Pi provider invocations such as `--provider role-model`, the canonical user-facing model-id form is the provider-relative Role-Model id that Pi lists for that provider, for example `baseline.remote-only`.
+6. If Pi or package internals also accept a fully qualified compatibility form such as `role-model/<alias>`, that form is compatibility-only guidance unless a Pi API explicitly requires it for active-model storage or display.
+7. If a Pi invocation mode cannot execute package commands because of Pi-core limitations, the repo must treat that as an explicit limitation, not as silent implied support.
+8. Remote endpoints remain blocked by default unless an existing trusted-remote setting from the Pi integration contract is explicitly enabled.
+9. Auth-required runtime discovery or provider use remains fail-closed unless an already-supported token source is configured.
+10. Error and help output must never print raw token values, credential material, or sensitive local auth-cache paths.
+11. Invalid endpoint and invalid model errors must have deterministic repo-owned diagnostics.
+12. Controller-generated explanation may be additive, but must never be required for the user to receive a useful error.
+13. Phase 3 must use `TDD Mode: strict`.
+14. Phase 5 must use real local Pi verification.
+
+## Requirements
+
+### `R1` Establish the real Pi command and provider surface matrix
+
+Description:
+Phase 1 must verify which Pi invocation paths actually execute package commands, which paths only send model prompts, and which paths are unsupported or Pi-core-limited.
+
+Acceptance criteria:
+- Phase 1 records the behavior of interactive slash commands, any Pi RPC command path, `pi -p` or print-mode slash-command attempts, and `--provider role-model` prompt execution.
+- Phase 1 identifies which observed failures are repo-owned versus upstream Pi-owned.
+- Phase 1 maps each supported or unsupported path to the exact files and tests that own it.
+
+### `R2` Repo-owned command paths must be truthful and non-silent
+
+Description:
+The package must not leave users with a repo-owned "did nothing" outcome when using supported command surfaces.
+
+Acceptance criteria:
+- supported command paths return visible package-owned output for `setup`, `status`, `doctor`, and alias commands
+- if Pi-core does not actually invoke package commands in print or noninteractive mode, repo docs and skill guidance explicitly mark that path unsupported
+- package docs and QA stop treating unsupported slash-command paths as supported
+- no supported repo-owned command path may appear to succeed while emitting no actionable output
+
+### `R3` Canonical Role-Model model-id guidance must be consistent
+
+Description:
+Users need one clear answer for which model ids are valid with `--provider role-model`.
+
+Acceptance criteria:
+- package output, docs, skill guidance, and QA consistently use the canonical provider-relative Role-Model model-id form for explicit Pi provider calls, for example `baseline.remote-only`
+- any alternate accepted form such as `role-model/<alias>` is documented as compatibility-only, not as competing primary guidance
+- examples and smoke commands use real Role-Model ids, not foreign provider ids
+- alias list and recommended-alias output expose the exact ids users should pass to Pi
+
+### `R4` Invalid model selection must fail with actionable guidance
+
+Description:
+A user who tries `--provider role-model --model gpt-4o` must get a clear explanation and recovery path rather than an unexplained routing failure.
+
+Acceptance criteria:
+- package docs and skill guidance explicitly explain that foreign ids such as `gpt-4o` are not canonical Role-Model provider ids
+- the supported command path exposes a valid recommended alias and a discoverable alias list
+- expected failure behavior for invalid foreign ids is documented together with the remedy
+- QA includes at least one invalid-foreign-id proof and one valid-Role-Model-id proof
+
+### `R5` The working provider execution path must remain healthy
+
+Description:
+The run must preserve the part that already works: prompting Pi through `--provider role-model` with a valid Role-Model model id.
+
+Acceptance criteria:
+- real Pi prompt execution through `--provider role-model` and a valid Role-Model id succeeds
+- runtime request receipts prove the request reached Role-Model
+- rich discovery and compact model-list behavior remain internally consistent with the chosen canonical id guidance
+- if output listing changes, related tests, fixtures, and docs are updated together
+
+### `R6` `status` and `doctor` diagnostics must expose a minimum actionable fact set
+
+Description:
+Supported diagnostic commands must surface enough structured facts to debug invocation-mode, endpoint, discovery, and model-id problems without requiring source inspection.
+
+Acceptance criteria:
+- `/role-model status` reports at minimum the configured endpoint, endpoint trust state, runtime reachability, discovery state or failure class, canonical model-id guidance for explicit provider calls, alias count, recommended alias, and active or selected alias state when available
+- `/role-model doctor` reports failing checks as classified categories rather than raw exception text alone
+- doctor output includes explicit remediation for at least invalid endpoint, auth-required-without-supported-token-source, unknown model id, foreign model id under `role-model`, known alias with no eligible target, and unsupported command invocation mode
+- diagnostic output is secret-safe and does not expose raw token values, credential material, or sensitive local auth-cache paths
+- tests cover at least one healthy output and one failing output for each major diagnostic category
+
+### `R7` Docs and skill guidance must match real behavior
+
+Description:
+The repo must stop teaching users invocation paths that are unsupported or misleading.
+
+Acceptance criteria:
+- `apps/docs-site/content/docs/integrations/pi.mdx`, package README content, and `skills/role-model/SKILL.md` explain the supported command invocation path, the supported prompt invocation path, the canonical provider-relative Role-Model model-id form for explicit provider calls, how to discover valid aliases, and why raw HTTP fallback is debug-only rather than the primary path
+- guidance distinguishes external Pi bugs from Role-Model integration bugs
+- docs do not imply that `pi -p "/role-model ..."` is supported unless Phase 1 proves that it is
+
+### `R8` Invalid endpoint and model selections must fail with actionable guidance
+
+Description:
+When Pi or an agent attempts to use an unknown, blocked, unreachable, incompatible, or non-routable endpoint or model, the integration must return a descriptive repo-owned error that explains what failed and how to recover.
+
+Acceptance criteria:
+- invalid endpoint failures distinguish at least malformed endpoint URL, blocked remote endpoint by trust policy, endpoint unreachable or timeout, runtime reachable but incompatible, and runtime requiring auth without a supported configured token source
+- invalid model failures distinguish at least unknown model id, foreign provider model id used under `role-model`, known alias with no eligible target, and known alias removed or no longer discoverable
+- every error includes what input was rejected, why it failed, whether the runtime was reached, and one or more concrete recovery actions
+- recovery guidance references supported discovery surfaces such as alias list, recommended alias, current endpoint status, and the supported invocation mode when relevant
+- error and help output redact raw token values, credential material, and sensitive local auth-cache paths
+- controller-generated advisory text is optional only: it may enrich a classified error when a healthy controller path exists, but it must not be required to produce the base error
+- failure to generate advisory text must not hide or replace the deterministic base error
+- tests cover each failure class and verify stable user-visible messages
+
+### `R9` Real Pi QA must cover both command truth and prompt truth
+
+Description:
+Phase 5 must verify the corrected guidance against real local Pi behavior.
+
+Acceptance criteria:
+- Phase 5 verifies the supported command path for `setup`, `status`, `doctor`, `alias list`, and `alias recommended`
+- Phase 5 verifies that `status` and `doctor` include the minimum diagnostic fact set required by `R6`
+- Phase 5 verifies `pi --list-models role-model` or the owning equivalent model-list surface
+- Phase 5 verifies at least one unsupported slash-command path such as `pi -p "/role-model status"` or the actual current unsupported mode and confirms that docs and diagnostics describe that limitation truthfully
+- Phase 5 verifies one valid Role-Model prompt path and one invalid foreign-id path
+- Phase 5 verifies at least one invalid-endpoint path
+- Phase 5 cross-checks Pi behavior against Role-Model runtime receipts
+- if the Windows Pi exit assertion still appears after successful output, Phase 5 records it as an upstream Pi defect rather than misclassifying the provider path as broken
+
+## Out of Scope
+
+- fixing Pi's Windows libuv/assertion bug upstream
+- adding managed runtime ownership to `pi-role-model`
+- changing Role-Model routing semantics or benchmark behavior
+- making foreign model ids such as `gpt-4o` become valid canonical ids under provider `role-model`
+- bypassing Pi as the primary supported integration path by blessing raw `curl` as the normal user workflow
+
+## Constraints
+
+- keep Role-Model as the routing and metadata authority
+- keep automated tests deterministic and offline-safe by default
+- use strict TDD for code changes
+- if Pi-core makes a path impossible, fail clearly in docs and QA rather than pretending support
+- preserve existing working provider execution behavior while tightening diagnostics and guidance
+- preserve the existing fail-closed auth and blocked-remote trust boundaries from earlier Pi integration runs
+- keep all diagnostics and help text secret-safe; never print raw token values, credential material, or sensitive local auth-cache paths
+- do not invoke the controller to explain failures until the error has already been locally classified
+- do not let advisory generation mutate the failure class or hide the raw validation facts
+
+## Late-Phase Requirements
+
+- Phase 6 updates `/.recursive/DECISIONS.md` with the canonical provider-relative Pi model-id form, the supported versus unsupported invocation-mode matrix, the deterministic invalid endpoint/model error contract, and any remaining accepted Pi-core limitations.
+- Phase 7 updates `/.recursive/STATE.md` to reflect the supported command path, the supported prompt path, the canonical provider-relative model-id form for explicit provider calls, and the final deterministic diagnostic behavior.
+- Phase 8 reviews `/.recursive/memory/domains/pi-role-model-package.md` and `/.recursive/memory/domains/runtime-routing-and-provider-capabilities.md` because the run changes durable Pi integration guidance and error-handling expectations.
+
+## Required Evidence
+
+- Phase 1 command/provider path matrix covering supported and unsupported invocation modes
+- explicit proof of the canonical provider-relative model-id form and any retained compatibility-only forms
+- RED and GREEN logs for each code-bearing implementation slice
+- automated test logs for diagnostics, invalid endpoint handling, and invalid model handling
+- docs and skill diff proof for canonical model-id guidance and unsupported-mode guidance
+- Pi transcripts for the supported command path, model listing, an unsupported slash-command path, a valid provider prompt, an invalid foreign-id prompt, and an invalid-endpoint case
+- Role-Model health/version/discovery snippets and runtime request receipts with secrets redacted
+- no-secret-output evidence for diagnostic and error paths
+
+## Coverage Gate
+
+- [x] `R1` covers supported versus unsupported Pi command and provider surfaces
+- [x] `R2` covers visible non-silent behavior for supported command paths
+- [x] `R3` covers canonical Role-Model model-id guidance
+- [x] `R4` covers actionable invalid foreign-model handling
+- [x] `R5` covers preserving the working provider execution path
+- [x] `R6` covers minimum actionable `status` and `doctor` diagnostics
+- [x] `R7` covers docs and skill alignment
+- [x] `R8` covers deterministic invalid endpoint/model diagnostics plus optional controller advisory
+- [x] `R9` covers real Pi QA for valid, invalid, and unsupported invocation paths
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] the scope is limited to repo-owned Pi integration UX, guidance, and error handling
+- [x] upstream Pi bugs remain documented but out of scope
+- [x] deterministic base errors are required before any optional controller-generated advisory
+- [x] acceptance criteria are observable and suitable for later audited phases
+- [x] the user approved this requirement for run creation on `2026-07-17`
+
+Approval: PASS

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-worktree.md
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-worktree.md
@@ -1,0 +1,154 @@
+Run: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/`
+Phase: `00 Worktree`
+Status: `LOCKED`
+LockedAt: `2026-07-17T06:59:32Z`
+LockHash: `bc6675ce8be942466c9633d75ad93813aeb7a7265915a023bf1e8e457b4d93ac`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- Current git repository state
+Outputs:
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-worktree.md`
+Scope note: This document records the Phase 0 worktree context and the executable diff basis that all later audited phases must reuse.
+
+## TODO
+
+- [x] Confirm the selected worktree location and isolation approach
+- [x] Confirm the base branch and worktree branch values
+- [x] Run setup and verify the clean or explicitly acknowledged baseline state
+- [x] Confirm the diff basis fields still match live git state
+- [x] Complete Coverage Gate checklist
+- [x] Complete Approval Gate checklist
+
+## Directory Selection
+
+- Repository root: `D:\DEV\role-model`
+- Preferred worktree location: `.worktrees/75-pi-role-model-cli-ux-and-model-id-hardening/`
+- Actual worktree path: `D:\DEV\role-model\.worktrees\75-pi-role-model-cli-ux-and-model-id-hardening`
+- Git ignored: Yes. `git check-ignore .worktrees` resolves to `.worktrees`.
+
+## Safety Verification
+
+- Original branch / repo state observed at init time: `main` @ `788c18eec021230a5c0c925931d610875993f65c`
+- Base branch source of truth: `main`
+- Worktree branch: `recursive/75-pi-role-model-cli-ux-and-model-id-hardening`
+- Isolation: confirmed. The worktree is a separate checkout on a feature branch and does not share the main working tree.
+- Controller checkout dirtiness acknowledged:
+  - staged run-75 requirement artifacts exist only in the controller checkout before manual sync into the worktree
+  - unrelated controller modifications exist under `role-model-router/vendor/llama-swap/dist-assets/win32-x64/`
+  - those controller-only changes are not part of the worktree diff basis for this run
+- Worktree-local pre-phase status after sync: `?? .recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/`
+
+## Worktree Creation
+
+Command:
+
+```bash
+git worktree add .worktrees/75-pi-role-model-cli-ux-and-model-id-hardening -b recursive/75-pi-role-model-cli-ux-and-model-id-hardening
+```
+
+Output confirmed:
+
+```text
+Preparing worktree (new branch 'recursive/75-pi-role-model-cli-ux-and-model-id-hardening')
+Updating files: 100% (8654/8654), done.
+HEAD is now at 788c18ee Merge pull request #55 from try-works/codex/kimi-provider-regression-fixes
+```
+
+## Requirements Sync Into Worktree
+
+Because run 75 was created and locked in the controller checkout before the feature worktree existed, the following files were copied into the worktree so recursive-mode can continue from the isolated branch:
+
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/00-requirements.receipt.json`
+
+No production source files were copied from the dirty controller checkout into the worktree.
+
+## Main Branch Protection
+
+- Base branch source of truth at init time: `main`
+- Base commit: `788c18eec021230a5c0c925931d610875993f65c`
+- Worktree branch: `recursive/75-pi-role-model-cli-ux-and-model-id-hardening`
+- No main-branch execution; all Phase 1+ work for run 75 will proceed from the isolated worktree only.
+
+## Project Setup
+
+Commands executed in the worktree:
+
+```bash
+corepack pnpm install --frozen-lockfile
+```
+
+Result: PASS. Install completed in `19.4s` using `pnpm v10.6.5` for `44` workspace projects.
+
+Observed setup caveat:
+
+- pnpm warned that dependency build scripts for `@biomejs/biome`, `esbuild`, `sharp`, and `workerd` were ignored pending `pnpm approve-builds`
+- this warning did not block the targeted `pi-role-model` baseline build or test commands below
+
+## Test Baseline Verification
+
+Commands and results (all executed from the worktree):
+
+1. `corepack pnpm --filter @try-works/pi-role-model build`
+   - PASS. `tsc --noEmit -p tsconfig.json` completed without TypeScript errors.
+2. `corepack pnpm --filter @try-works/pi-role-model test`
+   - PASS. `15` test files and `92` tests passed in `19.39s`.
+   - Notable baseline coverage included:
+     - `commands.test.ts`
+     - `downstream-openai.test.ts`
+     - `extension.test.ts`
+     - `runtime-discovery.test.ts`
+     - `validate-agent-path.test.ts`
+
+All targeted baseline checks pass before any run-75 production changes.
+
+## Worktree Context
+
+- Base branch: `main`
+- Worktree branch: `recursive/75-pi-role-model-cli-ux-and-model-id-hardening`
+- Base commit: `788c18eec021230a5c0c925931d610875993f65c`
+- Worktree HEAD: `788c18eec021230a5c0c925931d610875993f65c` (initially identical to base)
+- Subsequent recursive-mode phases for run 75 must execute from `D:\DEV\role-model\.worktrees\75-pi-role-model-cli-ux-and-model-id-hardening`.
+
+## Diff Basis For Later Audits
+
+- Baseline type: `local commit`
+- Baseline reference: `788c18eec021230a5c0c925931d610875993f65c`
+- Comparison reference: `working-tree`
+- Normalized baseline: `788c18eec021230a5c0c925931d610875993f65c`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 788c18eec021230a5c0c925931d610875993f65c`
+- Base branch: `main`
+- Worktree branch: `recursive/75-pi-role-model-cli-ux-and-model-id-hardening`
+- Diff basis notes: the worktree was created from `main` at commit `788c18eec021230a5c0c925931d610875993f65c`. Later audited phases must compare against this commit and must not mix in the dirty controller checkout's unrelated vendor changes.
+
+## Router Policy Check
+
+Delegated or routed work is not yet required for Phase 0. The worktree currently contains:
+
+- `/.recursive/config/recursive-router.json` present
+- `/.recursive/config/recursive-router-discovered.json` absent
+
+If routed delegation is used in later phases, the discovery inventory must be refreshed or copied into the worktree before any route resolution, and the resulting route decision must be recorded in the relevant phase artifact or subagent action record.
+
+## Traceability
+
+- Recursive workflow safety -> Phase 0 records a reusable executable diff basis before audited phases begin.
+- Run 75 requirements (`00-requirements.md`) are locked inside the worktree and remain the authoritative source for later phases.
+- The isolated worktree protects the main working tree from implementation churn while the controller checkout remains dirty for unrelated reasons.
+
+## Coverage Gate
+
+- [x] Worktree location and branch context are recorded
+- [x] Setup and baseline verification are recorded
+- [x] Diff basis fields are executable against live git state
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] Phase 0 context is ready for downstream audited phases
+- [x] No unresolved setup or diff-basis inconsistencies remain
+
+Approval: PASS

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md
@@ -1,0 +1,406 @@
+Run: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/`
+Phase: `01 AS-IS`
+Status: `LOCKED`
+LockedAt: `2026-07-17T07:12:35Z`
+LockHash: `45ff7bf466d98f8d31055dd4bdfca5bc56c826bfe75bc8f692519d5c44cf4181`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md` (LOCKED)
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-worktree.md` (LOCKED)
+- `packages/pi-role-model/src/extension.ts`
+- `packages/pi-role-model/src/commands.ts`
+- `packages/pi-role-model/src/downstream-openai.ts`
+- `packages/pi-role-model/src/provider-registration.ts`
+- `packages/pi-role-model/src/runtime-discovery.ts`
+- `packages/pi-role-model/src/config.ts`
+- `packages/pi-role-model/src/types.ts`
+- `packages/pi-role-model/README.md`
+- `packages/pi-role-model/skills/role-model/SKILL.md`
+- `apps/docs-site/content/docs/integrations/pi.mdx`
+- `packages/pi-role-model/test/commands.test.ts`
+- `packages/pi-role-model/test/downstream-openai.test.ts`
+- `packages/pi-role-model/test/extension.test.ts`
+- `packages/pi-role-model/test/runtime-discovery.test.ts`
+- Local Pi source/docs at `D:/pi/node_modules/@earendil-works/pi-coding-agent/**`
+- Real local runtime and Pi CLI observations captured on `2026-07-17`
+Outputs:
+- This file.
+Scope note: This artifact records the authoritative current-state matrix for Pi command invocation, provider execution, model-id guidance, and invalid endpoint/model handling before run-75 remediation.
+
+## TODO
+
+- [x] Re-read locked requirements and worktree baseline
+- [x] Re-read the affected Pi package source, tests, docs, and skill guidance
+- [x] Reproduce the supported provider prompt path and the observed unsupported/non-actionable paths
+- [x] Build the source-requirement inventory for R1-R9
+- [x] Record current behavior with concrete code and runtime evidence
+- [x] Separate repo-owned defects from upstream Pi defects
+- [x] Record gaps, ownership boundaries, and worktree diff basis
+- [x] Complete audited-phase gates
+
+## Audit Context
+
+- Audit Execution Mode: `self-audit`
+- Subagent Availability: `unavailable`
+- Subagent Capability Probe: no route inventory was refreshed into this worktree and this phase is dominated by local source/runtime inspection.
+- Delegation Decision Basis: direct inspection is sufficient because the affected scope is a small repo-owned package plus local Pi/runtime behavior that must be verified firsthand.
+- Delegation Override Reason: N/A
+- Audit Inputs Provided:
+  - locked run-75 requirements and worktree artifacts
+  - current `pi-role-model` package source, tests, README, and skill
+  - docs-site Pi integration page
+  - local Pi extension/provider documentation and type declarations
+  - live Role-Model runtime responses and live Pi CLI reproductions
+
+## Effective Inputs Re-read
+
+- `00-requirements.md` defines R1-R9 and fixes four key decisions for this phase: provider-relative model ids are canonical for `--provider role-model`; print/noninteractive slash-command support must be proven rather than assumed; Windows Pi assertion fallout is out of scope; deterministic base errors are required before any optional controller advisory.
+- `00-worktree.md` establishes the isolated branch `recursive/75-pi-role-model-cli-ux-and-model-id-hardening` at base commit `788c18eec021230a5c0c925931d610875993f65c`.
+- Baseline package checks already pass in this worktree: `corepack pnpm --filter @try-works/pi-role-model build` and `corepack pnpm --filter @try-works/pi-role-model test`.
+- Live runtime evidence on `2026-07-17` confirms `http://127.0.0.1:3456` is reachable, `/api/version` reports commit `788c18eec021230a5c0c925931d610875993f65c`, and `/v1/models` plus `/api/role-model/downstream/openai` expose provider-relative ids such as `baseline.remote-only`.
+- Live Pi evidence on `2026-07-17` confirms:
+  - `pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."` succeeds
+  - `pi --no-session --provider role-model --model gpt-4o -p "Reply with ok."` fails with a generic `400 no_eligible_target`
+  - `pi --no-session -p "/role-model status"` exits `0` with no output
+  - `pi list` and `pi --list-models role-model` both print useful output and then hit a Windows assertion
+- The currently installed Pi package points to `D:\DEV\role-model\.worktrees\59-observe-taxonomy-analytics-completion\packages\pi-role-model`, so Phase 5 must reinstall from this worktree before final QA.
+
+## Prior Recursive Evidence Reviewed
+
+- `/.recursive/run/55-pi-role-model-package/00-requirements.md` and downstream artifacts: established the original package/runtime ownership boundary and interactive command surfaces.
+- `/.recursive/run/56-pi-role-model-gap-closure/00-requirements.md` and `01-as-is.md`: established trust/auth fail-closed behavior, richer discovery, and alias-selection behavior, but did not resolve run-75 command-truth or canonical-id drift.
+- `/.recursive/run/59-observe-taxonomy-analytics-completion/01.5-root-cause.md`: relevant only as context that the currently installed Pi package points at another worktree and therefore cannot be the final QA source of truth for this run.
+
+## Source Requirement Inventory
+
+- `R1` | Disposition: `in-scope` | Source Quote: Establish the real Pi command and provider surface matrix | Summary: interactive slash commands, print-mode slash-command attempts, and explicit provider prompts must be separated by proven behavior and ownership; current reality is interactive command support plus a healthy explicit provider prompt path, with print-mode slash-command behavior unsupported in practice | Owner: `src/extension.ts`, local Pi docs/types, live Pi CLI evidence
+- `R2` | Disposition: `in-scope` | Source Quote: Repo-owned command paths must be truthful and non-silent | Summary: the package must not imply a supported command path that produces no visible output; current command emission depends entirely on `ui.notify` and is truthful only in interactive contexts | Owner: `src/extension.ts`, `src/commands.ts`, docs/skill guidance
+- `R3` | Disposition: `in-scope` | Source Quote: Canonical Role-Model model-id guidance must be consistent | Summary: live runtime/provider surfaces use provider-relative ids such as `baseline.remote-only`, but docs/tests/examples still drift toward prefixed ids | Owner: `src/downstream-openai.ts`, docs-site, package README, tests/fixtures
+- `R4` | Disposition: `in-scope` | Source Quote: Invalid model selection must fail with actionable guidance | Summary: foreign ids such as `gpt-4o` under provider `role-model` must be explained and redirected to valid aliases; current provider prompt path still falls through to generic Pi/runtime errors | Owner: provider prompt seam, command diagnostics, docs
+- `R5` | Disposition: `in-scope` | Source Quote: The working provider execution path must remain healthy | Summary: the valid provider-relative prompt path already works and must be preserved while diagnostics are tightened | Owner: `src/downstream-openai.ts`, `src/provider-registration.ts`, live Pi CLI evidence
+- `R6` | Disposition: `in-scope` | Source Quote: `status` and `doctor` diagnostics must expose a minimum actionable fact set | Summary: current status/doctor output covers endpoint/version/basic alias data, but not canonical provider-call model-id guidance, unsupported invocation mode, or detailed invalid-model classes | Owner: `src/commands.ts`, `src/runtime-discovery.ts`
+- `R7` | Disposition: `in-scope` | Source Quote: Docs and skill guidance must match real behavior | Summary: docs/skills must stop implying unsupported print-mode slash commands and must adopt provider-relative ids as the primary guidance | Owner: docs-site page, package README, Pi skill
+- `R8` | Disposition: `in-scope` | Source Quote: Invalid endpoint and model selections must fail with actionable guidance | Summary: command discovery already classifies endpoint failures, but the supported provider prompt path lacks repo-owned invalid-model and downstream-error shaping today | Owner: `src/config.ts`, `src/runtime-discovery.ts`, provider registration seam
+- `R9` | Disposition: `in-scope` | Source Quote: Real Pi QA must cover both command truth and prompt truth | Summary: final QA must reinstall from this worktree and prove valid, invalid, and unsupported paths against real Pi behavior; current repo coverage is unit-only | Owner: run artifacts, live Pi install state, Phase 5 QA
+
+## Current Behavior by Requirement
+
+### R1 - Real Pi command and provider surface matrix
+
+Current command/provider behavior is split across three materially different paths:
+
+| Path | Evidence | Current result | Ownership |
+| --- | --- | --- | --- |
+| Interactive slash command inside Pi | `packages/pi-role-model/src/extension.ts:131-136` registers one `role-model` command; local Pi types document command context actions as interactive-only at `D:/pi/node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts:1143` | Supported in interactive Pi contexts through `ctx.ui.notify(...)` | repo-owned |
+| Print/noninteractive slash command via `pi -p "/role-model ..."` | `pi --no-session -p "/role-model status"` exited `0` with no output on `2026-07-17`; package command handler only notifies UI (`extension.ts:133-135`) | Unsupported in practice and currently silent | mixed: repo-owned silence on top of Pi-mode limitation |
+| Explicit provider prompt path via `--provider role-model --model <id>` | `pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."` returned `ok.` on `2026-07-17` | Supported and healthy for valid Role-Model ids | repo-owned integration + runtime routing |
+| Model listing via `pi --list-models role-model` | live CLI lists provider-relative ids, then hits Windows assertion | Useful output is correct; post-output crash is upstream | upstream Pi defect after successful output |
+
+The repo already has enough evidence to stop treating `pi -p "/role-model ..."` as a supported diagnostic path. The provider execution path is the only proven prompt path.
+
+### R2 - Repo-owned command paths are truthful and non-silent
+
+The package registers `/role-model` as a command whose handler always writes through `context?.ui?.notify?.(...)` and never returns visible text via a non-UI channel (`packages/pi-role-model/src/extension.ts:131-136`). This is sufficient for interactive Pi, but it produces a repo-owned silent outcome whenever the invocation mode does not provide `ui.notify`.
+
+The command implementation itself returns structured text (`packages/pi-role-model/src/commands.ts:37-43`, `:213-392`), so the silence is not in command computation. The silence occurs at the final emission seam.
+
+Current docs/skill guidance do not truthfully narrow supported command usage to the interactive path:
+
+- docs-site tells users simply to run `/role-model setup`, `/role-model status`, `/role-model doctor` "Inside Pi" (`apps/docs-site/content/docs/integrations/pi.mdx:44-58`)
+- package README lists commands but does not distinguish interactive slash commands from print-mode prompts
+- package skill tells the user to check `/role-model status` first without warning that `pi -p "/role-model status"` is not a supported path
+
+### R3 - Canonical Role-Model model-id guidance
+
+Live runtime and live Pi provider registration currently converge on provider-relative ids such as `baseline.remote-only`:
+
+- `createPiModelSelection(...)` returns `id: model.id` with no `role-model/` prefixing (`packages/pi-role-model/src/downstream-openai.ts:126-146`)
+- `mapDiscoveryToProviderConfig(...)` registers models with `id: model.id` (`packages/pi-role-model/src/downstream-openai.ts:148-182`)
+- live `/v1/models` and `/api/role-model/downstream/openai` expose ids such as `baseline.remote-only`
+- live `pi --list-models role-model` prints provider-relative ids
+
+However the repo still has canonical-id drift:
+
+- docs-site says `/role-model alias use <alias>` switches to matching `role-model/<alias>` (`apps/docs-site/content/docs/integrations/pi.mdx:71-72`)
+- docs-site also says registered ids are shaped as `role-model/<alias>` (`apps/docs-site/content/docs/integrations/pi.mdx:74-80`)
+- package fixtures and many tests still center prefixed ids like `role-model/auto` (`packages/pi-role-model/test/fixtures.ts:5-67`, `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/downstream-openai.test.ts`, `packages/pi-role-model/test/extension.test.ts`)
+- `resolveAliasId(...)` deliberately accepts both prefixed and unprefixed forms (`packages/pi-role-model/src/commands.ts:142-155`), but the package does not currently label one form as canonical and the other as compatibility-only
+
+### R4 - Invalid model selection guidance
+
+The explicit provider path currently gives poor guidance for foreign ids:
+
+- `pi --no-session --provider role-model --model gpt-4o -p "Reply with ok."` produced:
+  - `Warning: Model "gpt-4o" not found for provider "role-model". Using custom model id.`
+  - `400 no_eligible_target: no targets for model gpt-4o satisfy the inferred request capabilities.`
+
+That message does not explain that `gpt-4o` is a foreign provider id under provider `role-model`, does not point to `alias list`, and does not provide the recommended replacement id.
+
+Repo command surfaces can help after the fact:
+
+- `status` reports alias count and selected alias (`packages/pi-role-model/src/commands.ts:243-268`)
+- `alias list` and `alias recommended` expose valid ids (`packages/pi-role-model/src/commands.ts:327-345`)
+
+But the supported provider prompt path itself has no repo-owned preflight or response shaping for foreign ids today.
+
+### R5 - Working provider execution path remains healthy
+
+The healthy path is confirmed:
+
+- `pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."` succeeded on `2026-07-17`
+- provider registration maps discovery models directly and uses the runtime's downstream OpenAI endpoint (`packages/pi-role-model/src/downstream-openai.ts:148-182`)
+- runtime discovery and model listing agree on the same provider-relative id family
+
+The package must preserve this seam while improving diagnostics. The Windows assertion after `pi list` / `pi --list-models role-model` is downstream of the successful output and is not evidence that the provider path is broken.
+
+### R6 - `status` and `doctor` minimum actionable facts
+
+Current `status` is richer than early runs but still incomplete for run-75 requirements. It reports:
+
+- state, endpoint, runtime version/build
+- alias count
+- selected alias and stored alias drift
+- provider registered/not registered
+- auth placeholder/required
+- local/remote trust
+- fallback flag
+- warnings
+
+Evidence: `packages/pi-role-model/src/commands.ts:243-268`.
+
+Missing from `status` relative to run-75 requirements:
+
+- explicit canonical provider-call model-id guidance
+- explicit recommended alias in the status body
+- invocation-mode truth such as interactive-only command path
+- richer failure taxonomy for model validation and unsupported mode
+
+Current `doctor` is mostly a happy-path checklist plus discovery failure passthrough (`packages/pi-role-model/src/commands.ts:271-290`). It does not classify:
+
+- unknown model id
+- foreign model id under `role-model`
+- known alias with no eligible target
+- unsupported command invocation mode
+- invalid endpoint subclasses beyond whatever `RoleModelDiscoveryError` exposes
+
+`formatDiscoveryError(...)` is limited to runtime-discovery failures (`packages/pi-role-model/src/commands.ts:157-167`).
+
+### R7 - Docs and skill guidance match real behavior
+
+Current docs/skill behavior is partially correct on runtime ownership and trust/auth boundaries, but incomplete or inconsistent on run-75 concerns:
+
+- docs-site correctly explains external runtime ownership and trust/auth boundaries (`apps/docs-site/content/docs/integrations/pi.mdx:27-42`)
+- package README correctly keeps runtime ownership narrow and avoids auth-file coupling
+- package skill correctly frames Role-Model as routing authority and points runtime install requests back to the repo README
+
+But guidance gaps remain:
+
+- docs-site still teaches `role-model/<alias>` as the registered model-id form (`pi.mdx:71-80`)
+- none of the docs distinguish the supported interactive command path from the unsupported print-mode slash-command path
+- none of the docs explain that the supported prompt path is `--provider role-model --model <provider-relative-id>`
+- none of the docs explain the generic `gpt-4o` failure class and its remedy
+- current guidance does not frame raw HTTP use as debug-only fallback versus the primary supported Pi integration path
+
+### R8 - Deterministic invalid endpoint and model diagnostics
+
+Endpoint classification is partially present today for command-driven discovery:
+
+- `config.ts` classifies `invalid-endpoint`, `remote-blocked`, `remote-untrusted`, and local/remote-allowed trust states (`packages/pi-role-model/src/config.ts:34-73`)
+- `runtime-discovery.ts` classifies `unavailable`, `timeout`, `incompatible`, `blocked-remote`, and `auth-required` (`packages/pi-role-model/src/runtime-discovery.ts:12-38`, `:174-266`)
+
+That endpoint classification is only surfaced through command discovery failures. It does not currently extend to the explicit provider prompt path.
+
+Model-failure handling is the main missing seam:
+
+- package provider registration currently passes only static OpenAI-compatible config (`packages/pi-role-model/src/provider-registration.ts:10-16`, `packages/pi-role-model/src/types.ts:92-117`)
+- local Pi supports custom provider `streamSimple` hooks for provider-owned error handling (`D:/pi/node_modules/@earendil-works/pi-coding-agent/docs/custom-provider.md:372`, `:600`, `:641-644`)
+- local Pi also documents `after_provider_response` as an inspection hook (`D:/pi/node_modules/@earendil-works/pi-coding-agent/docs/extensions.md:297-298`, `:649-654`)
+- current package types do not model `streamSimple` or `after_provider_response`, and current package code does not use either seam
+
+As a result, provider prompt failures currently bubble up as raw Pi/runtime messages instead of deterministic repo-owned help.
+
+### R9 - Real Pi QA coverage
+
+Current repository coverage is unit-only:
+
+- tests assert command formatting, provider registration mapping, and discovery behavior
+- tests do not prove live Pi command invocation behavior
+- tests do not cover real invalid foreign-id prompts
+- tests do not cover invalid endpoint prompt behavior
+- tests do not cover the installed-package/worktree mismatch now present in the local Pi environment
+
+Phase 5 therefore still needs:
+
+- explicit reinstall from this worktree
+- interactive command proofs
+- model-list proof
+- unsupported print-mode slash-command proof
+- valid provider prompt proof
+- invalid foreign-id prompt proof
+- invalid-endpoint proof
+
+## Relevant Code Pointers
+
+- `packages/pi-role-model/src/extension.ts`
+  - startup discovery and command registration: `27-137`
+  - command output seam is `context?.ui?.notify(...)`: `131-136`
+- `packages/pi-role-model/src/commands.ts`
+  - help text and command dispatcher: `22-35`, `213-392`
+  - discovery error formatting: `157-167`
+  - status output: `243-268`
+  - doctor output: `271-290`
+  - alias resolution compatibility behavior: `142-155`
+  - alias list/recommended/use paths: `327-388`
+- `packages/pi-role-model/src/downstream-openai.ts`
+  - fail-closed auth validation: `30-56`
+  - provider-relative active-model selection: `126-146`
+  - provider registration model ids: `148-182`
+- `packages/pi-role-model/src/provider-registration.ts`
+  - provider registration is a thin pass-through today: `4-16`
+- `packages/pi-role-model/src/config.ts`
+  - endpoint trust classification: `34-73`
+- `packages/pi-role-model/src/runtime-discovery.ts`
+  - discovery failure states and error mapping: `12-38`, `174-266`
+- `packages/pi-role-model/src/types.ts`
+  - local package Pi type surface currently omits `streamSimple` and `after_provider_response`: `92-127`
+- `apps/docs-site/content/docs/integrations/pi.mdx`
+  - command guidance: `44-58`
+  - alias-use wording and registered model-id wording drift: `71-80`
+- `packages/pi-role-model/README.md`
+  - command list and runtime ownership guidance
+- `packages/pi-role-model/skills/role-model/SKILL.md`
+  - command-first troubleshooting guidance without noninteractive-mode caveat
+- Local Pi docs/types
+  - extension command contexts are interactive-only: `D:/pi/node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts:1143`
+  - provider custom-stream seam exists: `D:/pi/node_modules/@earendil-works/pi-coding-agent/docs/custom-provider.md:372`, `:600`, `:641-644`
+
+## Known Unknowns
+
+- Whether the repo should use Pi's `streamSimple` seam, `after_provider_response`, a `message_end` rewrite, or a request-time preflight combination to own invalid-model/provider errors on the prompt path.
+- Whether the installed Pi package from worktree 59 differs behaviorally from this worktree beyond the already-observed command/model-id issues; Phase 5 must eliminate this uncertainty by reinstalling from the run-75 worktree.
+- Whether any additional Pi command surfaces beyond interactive slash commands and print-mode prompts are worth documenting for Role-Model users; Phase 1 found no repo-owned evidence that such a surface is currently required.
+
+## Evidence
+
+- Live runtime health/version/discovery observed on `2026-07-17` at `http://127.0.0.1:3456`
+- Live provider prompt success:
+  - `pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."` -> `ok.`
+- Live invalid foreign-id failure:
+  - `pi --no-session --provider role-model --model gpt-4o -p "Reply with ok."` -> warning + `400 no_eligible_target`
+- Live unsupported slash-command proof:
+  - `pi --no-session -p "/role-model status"` -> exit `0` with no output
+- Live model-list proof:
+  - `pi --list-models role-model` lists provider-relative ids and then hits a Windows assertion
+- Live install-path proof:
+  - `pi list` shows installed package path under worktree `59-observe-taxonomy-analytics-completion`
+
+## Reproduction Steps (Novice-Runnable)
+
+1. Run a valid provider-relative prompt:
+
+```bash
+pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."
+```
+
+Expected current result: `ok.`
+
+2. Run a foreign model id under provider `role-model`:
+
+```bash
+pi --no-session --provider role-model --model gpt-4o -p "Reply with ok."
+```
+
+Expected current result: Pi warning about custom model id, then `400 no_eligible_target`.
+
+3. Attempt a print-mode slash command:
+
+```bash
+pi --no-session -p "/role-model status"
+```
+
+Expected current result: exit `0` with no visible output.
+
+4. List registered provider models:
+
+```bash
+pi --list-models role-model
+```
+
+Expected current result: provider-relative ids such as `baseline.remote-only`, then a Windows assertion after output.
+
+## Gaps Found
+
+None. Phase 1 identified no analysis gaps beyond the mapped current-state defects already captured above. The remaining work is remediation, not additional AS-IS discovery.
+
+## Earlier Phase Reconciliation
+
+- `00-requirements.md` remains valid and fully aligned with the observed runtime/provider matrix. No requirement widening was needed during AS-IS analysis.
+- `00-worktree.md` remains valid. Base commit and worktree diff basis are unchanged.
+- No addenda exist yet for run 75.
+
+## Subagent Contribution Verification
+
+- No subagent was used for this phase.
+- Main-agent verification consisted of direct source inspection, live CLI reproduction, and cross-checking against local Pi docs/types.
+- Acceptance Decision: N/A
+- Repair Performed After Verification: none
+
+## Repair Work Performed
+
+- No production code, tests, or docs were changed in this phase.
+- This artifact records current behavior only.
+
+## Requirement Completion Status
+
+- `R1` | Status: blocked | Rationale: the command/provider surface matrix is now proven, but unsupported noninteractive slash-command behavior remains unremediated | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R2` | Status: blocked | Rationale: repo-owned command emission is truthful only in interactive UI contexts; unsupported silent path still exists | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R3` | Status: blocked | Rationale: canonical provider-relative ids are not yet consistent across docs/tests/examples | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R4` | Status: blocked | Rationale: invalid foreign ids still fail with generic runtime/Pi output | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R5` | Status: blocked | Rationale: the healthy provider path is confirmed, but preservation plus companion diagnostics still require implementation and QA | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R6` | Status: blocked | Rationale: status/doctor outputs are still below the required diagnostic fact set | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R7` | Status: blocked | Rationale: docs and skill guidance do not yet match the proven invocation/model-id truth | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R8` | Status: blocked | Rationale: invalid endpoint/model diagnostics are incomplete and not surfaced on the provider prompt path | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+- `R9` | Status: blocked | Rationale: real Pi QA is not yet worktree-local and does not cover the required transcript matrix | Blocking Evidence: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md`
+
+## Traceability
+
+- `R1`, `R2` -> `src/extension.ts` command registration/output seam + local Pi interactive-only command context contract
+- `R3`, `R7` -> `src/downstream-openai.ts` provider-relative ids + docs/test drift
+- `R4`, `R8` -> provider execution seam currently lacking repo-owned error shaping
+- `R5` -> live valid provider prompt proof + direct provider-relative model registration
+- `R6` -> current `status` / `doctor` output scope in `src/commands.ts`
+- `R9` -> installed-package mismatch and missing real-Pi transcript set
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `788c18eec021230a5c0c925931d610875993f65c`
+- Comparison reference: `working-tree`
+- Normalized baseline: `788c18eec021230a5c0c925931d610875993f65c`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 788c18eec021230a5c0c925931d610875993f65c`
+- Planned or claimed changed files: this Phase 1 artifact only
+- Unexplained drift: none
+
+## Audit Verdict
+
+Audit: PASS
+
+The current-state matrix is now explicit: the valid provider prompt path works, the print-mode slash-command path is not truthfully supported, canonical provider-relative ids are not yet documented consistently, and invalid provider/model failures do not yet return repo-owned help.
+
+## Coverage Gate
+
+- [x] R1-R9 are each mapped to concrete current-state evidence
+- [x] Supported and unsupported invocation paths are explicitly separated
+- [x] Repo-owned defects are distinguished from the upstream Windows assertion
+- [x] Worktree-local diff basis remains clean for Phase 2+
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] The AS-IS artifact is specific enough to drive root-cause analysis and implementation planning
+- [x] No requirement contradictions remain
+- [x] Audit passed
+
+Approval: PASS

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01.5-root-cause.md
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01.5-root-cause.md
@@ -1,0 +1,316 @@
+Run: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/`
+Phase: `01.5 Root Cause Analysis`
+Status: `LOCKED`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md` (LOCKED)
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-worktree.md` (LOCKED)
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md` (DRAFT until locked in this phase)
+- `/.agents/skills/recursive-mode/skills/recursive-debugging/SKILL.md`
+- `packages/pi-role-model/src/extension.ts`
+- `packages/pi-role-model/src/commands.ts`
+- `packages/pi-role-model/src/downstream-openai.ts`
+- `packages/pi-role-model/src/provider-registration.ts`
+- `packages/pi-role-model/src/runtime-discovery.ts`
+- `packages/pi-role-model/src/config.ts`
+- `packages/pi-role-model/src/types.ts`
+- `packages/pi-role-model/test/fixtures.ts`
+- `packages/pi-role-model/test/commands.test.ts`
+- `packages/pi-role-model/test/downstream-openai.test.ts`
+- `packages/pi-role-model/test/extension.test.ts`
+- `packages/pi-role-model/README.md`
+- `packages/pi-role-model/skills/role-model/SKILL.md`
+- `apps/docs-site/content/docs/integrations/pi.mdx`
+- Local Pi docs/types under `D:/pi/node_modules/@earendil-works/pi-coding-agent/**`
+- Real local runtime and Pi CLI observations captured on `2026-07-17`
+Outputs:
+- This file.
+Scope note: Reduce the run-75 command silence, model-id drift, and invalid endpoint/model error problems to their owning seams before Phase 2 planning and strict-TDD implementation.
+
+## TODO
+
+- [x] Re-read the locked requirements and Phase 1 AS-IS findings
+- [x] Reproduce each required symptom on the local runtime/Pi surface
+- [x] Trace the failure boundary for command output, model-id truth, and provider error handling
+- [x] Test alternative hypotheses against source and runtime evidence
+- [x] Record shared root causes and corrective direction
+- [x] Complete audited-phase gates
+
+## Audit Context
+
+- Audit Execution Mode: `self-audit`
+- Subagent Availability: `unavailable`
+- Subagent Capability Probe: no active route inventory exists in this worktree and the relevant evidence is local to this package plus the local Pi install/runtime.
+- Delegation Decision Basis: root cause depends on correlating this package's emission/provider seams with directly reproduced Pi behavior; that is best handled locally.
+- Delegation Override Reason: N/A
+- Audit Inputs Provided:
+  - locked requirements and worktree artifacts
+  - Phase 1 AS-IS findings
+  - current package source/tests/docs
+  - local Pi docs/type declarations
+  - live Pi/runtime reproductions
+
+## Effective Inputs Re-read
+
+- `00-requirements.md` fixes four non-negotiables for this phase: provider-relative ids are canonical for explicit provider calls, unsupported invocation modes must be documented instead of implied, deterministic base diagnostics must exist before any optional controller advisory, and upstream Pi Windows assertions remain out of scope.
+- `01-as-is.md` proves that:
+  - the explicit provider path works for `baseline.remote-only`
+  - `gpt-4o` under provider `role-model` fails generically
+  - print-mode slash commands produce no visible output
+  - docs/tests/examples drift on canonical ids
+  - the package does not currently use provider-owned error shaping seams
+- The recursive-debugging skill requires narrowing failures to the seam that actually owns the missing fact before implementation resumes.
+
+## Error Analysis
+
+The observed problems are not six unrelated bugs. They collapse into three shared ownership failures:
+
+1. command truth is being emitted through an interactive-only UI seam while docs imply broader support
+2. canonical model-id truth moved to provider-relative runtime ids, but docs/tests/examples did not move with it
+3. the supported provider prompt path delegates all invalid-model/downstream failures to generic Pi/runtime handling because the package never added a repo-owned validation or response-normalization layer there
+
+**Key Insight:** the runtime is not fundamentally unreachable and Role-Model routing is not fundamentally broken. The healthy `baseline.remote-only` provider prompt proves the integration core works. The run-75 defects are truth-boundary failures: wrong support claims, wrong canonical-id guidance, and missing error ownership.
+
+## Reproduction Verification
+
+1. `pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."`
+   - result: `ok.`
+   - implication: explicit provider path is healthy when given a valid Role-Model id
+2. `pi --no-session --provider role-model --model gpt-4o -p "Reply with ok."`
+   - result: Pi warning about custom id, then `400 no_eligible_target`
+   - implication: invalid-model failure is not being classified/helped by repo code
+3. `pi --no-session -p "/role-model status"`
+   - result: exit `0` with no output
+   - implication: repo command output is not visible on this path
+4. `pi --list-models role-model`
+   - result: provider-relative ids are listed, then a Windows assertion occurs
+   - implication: model-id truth is provider-relative; the assertion is a separate upstream issue
+5. Source inspection:
+   - command output is only `context?.ui?.notify(...)` (`extension.ts:133-135`)
+   - current package/provider types do not include `streamSimple` or `after_provider_response` (`types.ts:92-127`)
+   - docs-site still teaches `role-model/<alias>` (`pi.mdx:71-80`)
+
+**Reproducible:** Yes
+**Frequency:** Deterministic
+**Deterministic:** Yes
+
+## Recent Changes Analysis
+
+- The package already evolved far enough to discover the runtime, register the provider, keep auth fail-closed, preserve trust boundaries, and use provider-relative ids internally.
+- The remaining failures came from the last-mile UX surfaces not being updated to match that newer reality:
+  - command emission still assumes interactive UI
+  - docs/tests/examples still assume older prefixed-alias guidance
+  - provider prompt execution still uses a plain OpenAI-compatible registration without package-owned invalid-model shaping
+
+**Likely Culprit:** implementation effort previously focused on provider registration and alias discovery, but did not close the contract between those internal truths and the user-facing command/docs/error surfaces.
+
+## Evidence Gathering (Multi-Layer if applicable)
+
+**L1: runtime and discovery truth**
+- Live runtime discovery and model listing expose provider-relative ids and a recommended alias such as `baseline.remote-only`.
+- Status: healthy
+
+**L2: package command emission**
+- `/role-model` command results are computed as strings in `commands.ts`.
+- Final emission occurs only through `context?.ui?.notify(...)` in `extension.ts`.
+- Status: interactive-only
+
+**L3: package/provider registration**
+- Provider registration is a thin pass-through to `pi.registerProvider(...)`.
+- Local package types only model static provider config fields, not custom stream or provider-response hooks.
+- Status: incomplete for run-75 diagnostics
+
+**L4: docs/tests/examples**
+- docs-site and tests still carry prefixed-id assumptions.
+- Status: stale
+
+**L5: live Pi verification**
+- Valid provider id works, foreign id fails generically, print-mode slash command is silent, Windows assertion occurs after useful output.
+- Status: mixed; enough to localize ownership
+LockedAt: `2026-07-17T07:13:08Z`
+LockHash: `cd81eed11a1058cbf4ec79711b432cbd73da32ec8ee8eec08937b117ab7f739d`
+
+**Failure Boundary:** the missing facts are lost at the package's outward boundary, not in Role-Model routing. Command results are lost when they leave `commands.ts` and only `notify`; canonical ids are lost when internal provider-relative truth is translated into stale docs/examples; provider error meaning is lost because the package never owns prompt-path invalid-model classification.
+
+## Data Flow Trace
+
+### Trace 1: slash-command output
+
+1. `commands.ts` computes a `RoleModelCommandResult`.
+2. `extension.ts` receives that result and calls `context?.ui?.notify(...)`.
+3. In interactive mode this is visible.
+4. In print/noninteractive mode there is no supported visible output channel in the current package path.
+5. The command path can therefore appear to succeed while showing nothing.
+
+**Root cause:** command computation and command visibility are separated by an interactive-only emission seam, but the repo's docs/usage expectations were not constrained to that seam.
+
+### Trace 2: canonical model-id guidance
+
+1. Live runtime discovery exposes provider-relative ids.
+2. Provider registration maps those ids directly and live `--list-models` shows them.
+3. Command outputs such as alias list/recommended expose raw discovery ids.
+4. Docs-site and fixture/test examples still teach prefixed ids such as `role-model/<alias>` or `role-model/auto`.
+5. Users and agents therefore attempt foreign or stale ids on the supported provider path.
+
+**Root cause:** canonical model-id truth moved in the runtime/provider surfaces, but repo documentation and test fixtures did not update as a single contract.
+
+### Trace 3: invalid model/provider error ownership
+
+1. Pi accepts `--provider role-model --model gpt-4o` as a custom id even when it is not in the provider catalog.
+2. The package does not preflight that id against discovered Role-Model ids before the request is sent.
+3. The package also does not currently use provider custom-stream or provider-response seams to normalize runtime 400s into repo-owned help.
+4. The raw runtime/Pi failure reaches the user as `400 no_eligible_target`.
+
+**Root cause:** the supported provider prompt path has no repo-owned validation/normalization layer for invalid model ids or downstream routing-class failures.
+
+## Pattern Analysis
+
+| Concern | Healthy pattern | Broken current pattern |
+| --- | --- | --- |
+| command support | prove one invocation mode, emit visibly there, mark others unsupported | compute command result but emit only through `ui.notify` while docs imply broader support |
+| canonical ids | use one primary form across runtime, docs, tests, and examples | provider-relative truth internally, prefixed examples externally |
+| invalid-model UX | classify before or around provider execution and return recovery guidance | allow generic Pi/runtime 400 to escape unchanged |
+| endpoint diagnostics | classify once and reuse on every user-visible path | classify only on discovery/command paths |
+| QA truth | verify from the worktree-local installed package | local Pi still points at another worktree install |
+
+## Hypothesis Testing
+
+### Hypothesis 1
+**Statement:** Role-Model routing itself is broken.
+**Result:** Rejected.
+**Evidence:** valid provider-relative prompt execution succeeds today.
+
+### Hypothesis 2
+**Statement:** `pi -p "/role-model status"` is a valid supported command path and the package merely forgot to print one line.
+**Result:** Rejected.
+**Evidence:** local Pi documents extension command context actions as interactive-only, and the package only emits through `ui.notify`. Even if command computation occurs, the current path is not a truthful supported surface.
+
+### Hypothesis 3
+**Statement:** only the docs are wrong; package internals still canonically use `role-model/<alias>`.
+**Result:** Rejected.
+**Evidence:** live runtime discovery, `createPiModelSelection(...)`, `mapDiscoveryToProviderConfig(...)`, and live `pi --list-models role-model` all use provider-relative ids.
+
+### Hypothesis 4
+**Statement:** invalid foreign-model errors can only be fixed in the runtime.
+**Result:** Rejected.
+**Evidence:** the package can already discover valid ids and local Pi exposes provider custom-stream/response seams; current package simply does not use those seams yet.
+
+### Hypothesis 5
+**Statement:** the Windows assertion after `pi list` and `--list-models` proves the Role-Model provider path is unusable.
+**Result:** Rejected.
+**Evidence:** useful output is printed before the assertion, and valid provider prompting succeeds.
+
+## Root Cause Summary
+
+**Root Cause:** run-75 symptoms come from missing repo-owned truth contracts at three boundaries: command output boundary, canonical model-id boundary, and provider prompt error-ownership boundary.
+
+**Locations:** `src/extension.ts` command emission; docs/tests/examples that still encode prefixed ids; `src/types.ts` + provider registration seam that currently stop at static OpenAI-compatible provider config with no package-owned invalid-model normalization.
+
+**Fix Strategy:** constrain repo-supported command usage to the interactive path and make that explicit in output/docs; align all repo guidance/tests/examples on provider-relative ids; add a deterministic package-owned invalid endpoint/model classification layer for the supported provider prompt path while preserving runtime authority and the healthy valid-id path.
+
+**Test Plan:** strict RED tests for canonical id guidance, command diagnostics, invalid model classification, invalid endpoint classification, and any provider-stream/response normalization layer before production edits.
+
+## Root Causes
+
+1. **RC1: command results are emitted only through an interactive UI notification seam.**
+   - Maps to `R1`, `R2`, `R6`, `R7`
+   - Evidence: `packages/pi-role-model/src/extension.ts:131-136`, local Pi interactive-only command-context contract
+
+2. **RC2: canonical model-id truth changed to provider-relative ids, but repo guidance and fixtures did not update atomically.**
+   - Maps to `R3`, `R4`, `R7`, `R9`
+   - Evidence: `packages/pi-role-model/src/downstream-openai.ts:126-182`, `apps/docs-site/content/docs/integrations/pi.mdx:71-80`, tests/fixtures using `role-model/auto`
+
+3. **RC3: the provider prompt path has no repo-owned invalid-model/downstream-error normalization layer.**
+   - Maps to `R4`, `R5`, `R6`, `R8`
+   - Evidence: generic `gpt-4o` failure reproduction, `packages/pi-role-model/src/provider-registration.ts:10-16`, `packages/pi-role-model/src/types.ts:92-127`, Pi `streamSimple` docs
+
+4. **RC4: endpoint and mode diagnostics are classified only on the command/discovery path, not on every user-visible path.**
+   - Maps to `R6`, `R8`
+   - Evidence: `packages/pi-role-model/src/runtime-discovery.ts`, `packages/pi-role-model/src/commands.ts`
+
+5. **RC5: real Pi QA is not yet tied to this worktree install.**
+   - Maps to `R9`
+   - Evidence: `pi list` currently points to worktree `59-observe-taxonomy-analytics-completion`
+
+## Corrective Direction
+
+1. Make the supported command path explicit and non-silent by targeting interactive slash-command use only, then state unsupported print-mode slash-command behavior in package docs and diagnostics.
+2. Align docs, skill guidance, README content, tests, and fixtures around provider-relative ids such as `baseline.remote-only`, with any `role-model/<alias>` form treated as compatibility-only.
+3. Add deterministic invalid-model and invalid-endpoint help on the supported provider prompt path using repo-owned validation/normalization, not controller-only prose.
+4. Expand `status` and `doctor` to surface canonical id guidance, recommended alias, invocation-mode truth, and failure-class remediation.
+5. Reinstall the package from this worktree during Phase 5 so final Pi QA exercises the actual run-75 implementation.
+
+## Traceability
+
+- `RC1` -> `R1`, `R2`, `R6`, `R7`
+- `RC2` -> `R3`, `R4`, `R7`, `R9`
+- `RC3` -> `R4`, `R5`, `R6`, `R8`
+- `RC4` -> `R6`, `R8`
+- `RC5` -> `R9`
+
+## Gaps Found
+
+None beyond the Phase 1 AS-IS inventory. The AS-IS artifact already captured all user-visible gaps; this root-cause phase reduces them to shared ownership boundaries.
+
+## Repair Work Performed
+
+None. This artifact records root cause only.
+
+## Earlier Phase Reconciliation
+
+- Locked requirements remain valid and require no scope changes.
+- Phase 1 AS-IS findings remain authoritative and are narrowed here, not contradicted.
+- The worktree baseline and diff basis remain unchanged.
+
+## Subagent Contribution Verification
+
+- No subagent was used for this phase.
+- Main-agent verification consisted of direct source/runtime reconciliation.
+- Acceptance Decision: N/A
+- Repair Performed After Verification: none
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `788c18eec021230a5c0c925931d610875993f65c`
+- Comparison reference: `working-tree`
+- Normalized baseline: `788c18eec021230a5c0c925931d610875993f65c`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 788c18eec021230a5c0c925931d610875993f65c`
+- Planned or claimed changed files: Phase 1 and 1.5 artifacts only
+- Unexplained drift: none
+
+## Requirement Completion Status
+
+- `R1` | Status: deferred | Rationale: RC1 must be addressed in implementation/docs/QA | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R2` | Status: deferred | Rationale: RC1 must be addressed in implementation/docs/QA | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R3` | Status: deferred | Rationale: RC2 requires synchronized source/docs/test changes | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R4` | Status: deferred | Rationale: RC2 and RC3 require deterministic invalid-model guidance on supported paths | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R5` | Status: deferred | Rationale: RC3 must preserve the valid provider path while adding error ownership | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R6` | Status: deferred | Rationale: RC1, RC3, and RC4 require richer diagnostics | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R7` | Status: deferred | Rationale: RC1 and RC2 require docs/skill truth updates | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R8` | Status: deferred | Rationale: RC3 and RC4 require endpoint/model classification on provider prompt surfaces | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+- `R9` | Status: deferred | Rationale: RC5 requires worktree-local real Pi QA | Deferred By: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md`
+
+## Audit Verdict
+
+Audit: PASS
+
+The run-75 failures reduce cleanly to five shared root causes with clear owning seams. No symptom requires changing Role-Model routing semantics or treating the upstream Windows assertion as a repo-owned blocker.
+
+## Coverage Gate
+
+- [x] Every reproduced symptom maps to a shared root cause
+- [x] Alternative hypotheses about runtime failure and doc-only drift were rejected with evidence
+- [x] The healthy valid-id provider path remains explicitly separated from the failing invalid-id and unsupported command paths
+- [x] No repair was attempted before root-cause completion
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] Root causes are specific enough for strict RED-first implementation
+- [x] Corrective direction stays within repo-owned boundaries
+- [x] Phase 2 planning can proceed without scope ambiguity
+
+Approval: PASS

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/02-to-be-plan.md
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/02-to-be-plan.md
@@ -1,0 +1,291 @@
+Run: `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/`
+Phase: `02 TO-BE Plan`
+Status: `LOCKED`
+LockedAt: `2026-07-17T07:22:52Z`
+LockHash: `dc5c188e338eae39588278f2295a3ad25eb81e4cb906fe45649f0c4929973dee`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-requirements.md` (LOCKED)
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/00-worktree.md` (LOCKED)
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01-as-is.md` (LOCKED)
+- `/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/01.5-root-cause.md` (LOCKED)
+- `/.recursive/STATE.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/memory/MEMORY.md`
+- `packages/pi-role-model/src/**`
+- `packages/pi-role-model/test/**`
+- `packages/pi-role-model/README.md`
+- `packages/pi-role-model/skills/role-model/SKILL.md`
+- `apps/docs-site/content/docs/integrations/pi.mdx`
+- Local Pi docs/types under `D:/pi/node_modules/@earendil-works/pi-coding-agent/**`
+Outputs:
+- This file.
+
+Scope note: This artifact defines the run-75 repair plan for truthful Pi command guidance, canonical provider-relative model-id guidance, and deterministic invalid endpoint/model diagnostics while preserving the currently healthy explicit provider prompt path.
+
+## TODO
+
+- [x] Re-read locked requirements, AS-IS, and root-cause artifacts
+- [x] Reconcile the plan with prior Pi package runs
+- [x] Map each requirement to implementation, verification, and QA surfaces
+- [x] Define RED-first implementation slices
+- [x] Define docs and real-Pi QA work
+- [x] Confirm the plan stays inside repo-owned boundaries
+- [x] Complete audited-phase gates
+
+## Audit Context
+
+- Audit Execution Mode: `self-audit`
+- Subagent Availability: `unavailable`
+- Subagent Capability Probe: no delegated route inventory is active in this worktree and this phase is planning-only.
+- Delegation Decision Basis: self-audit is sufficient because the plan is bounded to the locked run-75 package/docs surfaces.
+- Delegation Override Reason: N/A
+- Audit Inputs Provided:
+  - locked run-75 requirements, worktree, AS-IS, and root-cause artifacts
+  - current package source/tests/docs
+  - local Pi docs/type declarations
+
+## Effective Inputs Re-read
+
+- `00-requirements.md` fixes the target behavior: provider-relative ids are canonical for explicit provider calls, unsupported noninteractive slash-command paths must be documented rather than implied, deterministic base diagnostics must exist without controller help, and live Pi QA is mandatory.
+- `01-as-is.md` proves the current matrix: interactive command path only, valid provider path healthy, foreign-id provider failures generic, docs/tests still prefixed-id-heavy, and current local Pi install not yet worktree-local.
+- `01.5-root-cause.md` reduces the run to five root causes: interactive-only command emission, canonical-id drift, missing provider-prompt error ownership, command-only endpoint/mode diagnostics, and non-worktree-local Pi QA.
+
+## Prior Recursive Evidence Reviewed
+
+- `/.recursive/run/55-pi-role-model-package/02-to-be-plan.md` — original package/runtime ownership boundary, initial command surfaces, and external-runtime scope limits remain valid.
+- `/.recursive/run/56-pi-role-model-gap-closure/02-to-be-plan.md` — trust/auth fail-closed behavior, richer discovery, and provider registration patterns remain valid; run 75 builds on them rather than replacing them.
+- `/.recursive/run/59-observe-taxonomy-analytics-completion/01.5-root-cause.md` — relevant only for local environment context because the current Pi install still points at that worktree path and must be replaced in Phase 5.
+
+## Requirement Mapping
+
+- `R1` | Coverage: direct | Source Quote: Establish the real Pi command and provider surface matrix | Implementation Surface: `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/README.md`, `packages/pi-role-model/skills/role-model/SKILL.md`, `apps/docs-site/content/docs/integrations/pi.mdx` | Verification Surface: `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/docs-and-safety.test.ts` | QA Surface: interactive slash-command transcript plus unsupported `pi -p "/role-model status"` proof
+- `R2` | Coverage: direct | Source Quote: Repo-owned command paths must be truthful and non-silent | Implementation Surface: `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/src/types.ts`, `packages/pi-role-model/README.md`, `packages/pi-role-model/skills/role-model/SKILL.md`, `apps/docs-site/content/docs/integrations/pi.mdx` | Verification Surface: `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/docs-and-safety.test.ts` | QA Surface: interactive command transcript showing visible output and docs proving noninteractive slash-command path unsupported
+- `R3` | Coverage: direct | Source Quote: Canonical Role-Model model-id guidance must be consistent | Implementation Surface: `packages/pi-role-model/src/downstream-openai.ts`, `packages/pi-role-model/test/fixtures.ts`, `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/downstream-openai.test.ts`, `packages/pi-role-model/test/extension.test.ts`, `packages/pi-role-model/README.md`, `packages/pi-role-model/skills/role-model/SKILL.md`, `apps/docs-site/content/docs/integrations/pi.mdx` | Verification Surface: unit tests plus docs assertions | QA Surface: `pi --list-models role-model` and valid provider prompt using provider-relative id
+- `R4` | Coverage: direct | Source Quote: Invalid model selection must fail with actionable guidance | Implementation Surface: `packages/pi-role-model/src/extension.ts`, `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/src/types.ts`, `packages/pi-role-model/test/extension.test.ts`, `packages/pi-role-model/test/commands.test.ts` | Verification Surface: focused unit tests for unknown id, foreign id, and known-alias/no-eligible-target formatting | QA Surface: invalid foreign-id prompt transcript
+- `R5` | Coverage: direct | Source Quote: The working provider execution path must remain healthy | Implementation Surface: `packages/pi-role-model/src/extension.ts`, `packages/pi-role-model/src/downstream-openai.ts` | Verification Surface: unit tests proving valid provider-relative requests continue through existing seams | QA Surface: valid provider prompt transcript and runtime receipt cross-check
+- `R6` | Coverage: direct | Source Quote: `status` and `doctor` diagnostics must expose a minimum actionable fact set | Implementation Surface: `packages/pi-role-model/src/commands.ts` | Verification Surface: `packages/pi-role-model/test/commands.test.ts` | QA Surface: `status` and `doctor` transcripts proving canonical id guidance, recommended alias, invocation-mode truth, and remediation categories
+- `R7` | Coverage: direct | Source Quote: Docs and skill guidance must match real behavior | Implementation Surface: `packages/pi-role-model/README.md`, `packages/pi-role-model/skills/role-model/SKILL.md`, `apps/docs-site/content/docs/integrations/pi.mdx` | Verification Surface: `packages/pi-role-model/test/docs-and-safety.test.ts` | QA Surface: docs diff review plus manual command/prompt usage against updated instructions
+- `R8` | Coverage: direct | Source Quote: Invalid endpoint and model selections must fail with actionable guidance | Implementation Surface: `packages/pi-role-model/src/config.ts`, `packages/pi-role-model/src/runtime-discovery.ts`, `packages/pi-role-model/src/extension.ts`, `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/test/runtime-discovery.test.ts`, `packages/pi-role-model/test/extension.test.ts`, `packages/pi-role-model/test/commands.test.ts` | Verification Surface: `packages/pi-role-model/test/runtime-discovery.test.ts`, `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/extension.test.ts` | QA Surface: invalid endpoint transcript plus invalid model transcript
+- `R9` | Coverage: direct | Source Quote: Real Pi QA must cover both command truth and prompt truth | Implementation Surface: `05-manual-qa.md` and Phase-5 evidence | Verification Surface: worktree-local install proof, Pi transcripts, runtime receipts | QA Surface: real local Pi reinstall and end-to-end command/prompt checks
+
+## Plan Drift Check
+
+- The plan stays inside repo-owned surfaces: package source, tests, package docs/skill guidance, docs-site guidance, and run artifacts.
+- No upstream Pi core fix is planned.
+- No Role-Model routing semantics change is planned.
+- No raw HTTP fallback is promoted to the primary supported path.
+- The healthy provider-relative prompt path remains the reference success case.
+- Optional controller-generated help remains out of the critical path.
+
+## Planned Changes by File
+
+- `packages/pi-role-model/src/types.ts`
+  - Expand local Pi event/context typings to cover command mode, event context model access, and any message-end hook usage needed by the package.
+- `packages/pi-role-model/src/commands.ts`
+  - Add canonical provider-call model-id guidance and recommended alias output.
+  - Add explicit supported command-path and prompt-path guidance.
+  - Add richer doctor/status remediation categories, including unsupported noninteractive slash-command usage and stale/removed alias states.
+  - Improve alias selection error text for unknown/foreign ids.
+- `packages/pi-role-model/src/downstream-openai.ts`
+  - Keep provider-relative ids authoritative.
+  - Add helper(s) for canonical provider-call model examples if needed.
+- `packages/pi-role-model/src/extension.ts`
+  - Integrate provider-request validation before Role-Model provider calls are sent.
+  - Integrate provider error-message normalization for known alias/no-eligible-target and related provider-owned failures if Pi hook behavior permits.
+  - Keep taxonomy intent injection only for valid Role-Model provider requests.
+- `packages/pi-role-model/src/config.ts`
+  - Reuse existing endpoint-trust classification helpers in improved diagnostics.
+- `packages/pi-role-model/src/runtime-discovery.ts`
+  - Preserve existing typed discovery failures and expose them through improved command/provider diagnostics.
+- `packages/pi-role-model/test/fixtures.ts`
+  - Update canonical sample ids to provider-relative forms.
+- `packages/pi-role-model/test/commands.test.ts`
+  - Add RED coverage for status/doctor command-path truth, canonical id guidance, and unsupported-mode guidance.
+- `packages/pi-role-model/test/downstream-openai.test.ts`
+  - Update canonical id expectations to provider-relative ids.
+- `packages/pi-role-model/test/extension.test.ts`
+  - Add RED coverage for provider-request validation and error normalization integration.
+- `packages/pi-role-model/test/docs-and-safety.test.ts`
+  - Assert docs/skill mention provider-relative ids, interactive command path, unsupported `pi -p "/role-model ..."` path, and debug-only raw HTTP fallback.
+- `packages/pi-role-model/README.md`
+  - State the supported interactive command path, supported provider prompt path, canonical provider-relative ids, compatibility-only prefixed ids, and debug-only raw HTTP fallback.
+- `packages/pi-role-model/skills/role-model/SKILL.md`
+  - Align troubleshooting and command/prompt guidance with real behavior.
+- `apps/docs-site/content/docs/integrations/pi.mdx`
+  - Replace prefixed-id primary guidance with provider-relative guidance and document unsupported print-mode slash-command use.
+
+## Implementation Steps
+
+1. **Slice 1: Canonical model-id and fixture alignment**
+   - Write failing tests that expect provider-relative ids in downstream mapping, command output, and extension integration.
+   - Update fixtures/tests first, then update any code paths that still assume prefixed canonical ids.
+2. **Slice 2: Command-path truth and diagnostics**
+   - Write failing tests for `status` / `doctor` minimum fact set, supported command-path guidance, unsupported print-mode guidance, and alias-state diagnostics.
+   - Update `commands.ts` and any minimal supporting types/helpers.
+3. **Slice 3: Provider prompt preflight validation**
+   - Write failing tests for provider-request rejection of unknown and foreign model ids using the existing `before_provider_request` seam and event context model/provider.
+   - Implement deterministic repo-owned error formatting with recommended alias recovery guidance.
+4. **Slice 4: Provider error normalization for known aliases**
+   - Write failing tests for rewriting or classifying known-alias `no_eligible_target` failures and stale/removed alias diagnostics when the provider path or current selection is otherwise valid.
+   - Implement the smallest seam that works: message-end rewrite first, only escalating to a custom provider stream wrapper if RED proves hooks are insufficient.
+5. **Slice 5: Docs and skill truth**
+   - Write failing docs assertions.
+   - Update README, skill, and docs-site page together.
+6. **Slice 6: Final package checks and Phase 5 setup**
+   - Run full package build/tests.
+   - Prepare worktree-local Pi reinstall and transcript plan for Phase 5.
+
+## Implementation Sub-phases
+
+- Sub-phase 1: provider-relative canonical-id contract (`R3`, supporting `R4`, `R7`)
+- Sub-phase 2: command-path truth and rich diagnostics (`R1`, `R2`, `R6`)
+- Sub-phase 3: provider prompt invalid-model and provider-error help (`R4`, `R5`, `R8`)
+- Sub-phase 4: docs/skill alignment (`R7`)
+- Sub-phase 5: real Pi reinstall and QA (`R9`)
+
+## Testing Strategy
+
+- TDD Mode: `strict`
+- No production edits before a failing targeted test exists for the next slice.
+- Favor focused package tests during RED/GREEN, then run the full package suite at the end of Phase 3.
+- Separate unit tests for pure classification/formatting helpers from integration-style extension tests.
+
+## Playwright Plan (if applicable)
+
+Not applicable. This run validates CLI command and provider behavior through package tests plus real Pi CLI transcripts in Phase 5, not browser automation.
+
+## Focused RED/GREEN Commands
+
+```powershell
+corepack pnpm --filter @try-works/pi-role-model test -- test/downstream-openai.test.ts
+corepack pnpm --filter @try-works/pi-role-model test -- test/commands.test.ts
+corepack pnpm --filter @try-works/pi-role-model test -- test/extension.test.ts
+corepack pnpm --filter @try-works/pi-role-model test -- test/runtime-discovery.test.ts
+corepack pnpm --filter @try-works/pi-role-model test -- test/docs-and-safety.test.ts
+```
+
+Final package checks:
+
+```powershell
+corepack pnpm --filter @try-works/pi-role-model build
+corepack pnpm --filter @try-works/pi-role-model test
+```
+
+## Manual QA Scenarios
+
+- Scenario 1: Interactive Pi command path
+  - Run `/role-model status`, `/role-model doctor`, `/role-model alias list`, `/role-model alias recommended` in interactive Pi.
+  - Verify visible output, canonical provider-relative guidance, recommended alias, and invocation-mode truth.
+- Scenario 2: Unsupported noninteractive slash-command path
+  - Run `pi --no-session -p "/role-model status"`.
+  - Verify the docs now mark this unsupported and do not teach it as a supported diagnostic path.
+- Scenario 3: Valid provider prompt path
+  - Run `pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."`
+  - Verify success and runtime receipt correlation.
+- Scenario 4: Invalid foreign-id provider prompt path
+  - Run `pi --no-session --provider role-model --model gpt-4o -p "Reply with ok."`
+  - Verify deterministic repo-owned guidance references valid alias discovery and recommended alias.
+- Scenario 5: Invalid endpoint path
+  - Point the package at a blocked, malformed, or unavailable endpoint.
+  - Verify `status`/`doctor` classify the failure and provide concrete remediation.
+- Scenario 6: Worktree-local Pi install proof
+  - Reinstall the local package from `D:\DEV\role-model\.worktrees\75-pi-role-model-cli-ux-and-model-id-hardening\packages\pi-role-model`.
+  - Verify `pi list` shows this worktree path before final transcripts are collected.
+
+## Idempotence and Recovery
+
+- Canonical provider-relative id guidance is idempotent because it derives from live discovery and recommended alias state.
+- Provider-request preflight validation is read-only and can block invalid requests without mutating runtime or auth state.
+- If message-end normalization proves insufficient for provider failures, the plan allows escalation to a custom provider stream wrapper without widening scope; that decision must still start with RED.
+- If local Pi reinstall fails in Phase 5, the package must not claim QA completion; the run returns to remediation or environment-fix evidence.
+
+## Gaps Found
+
+None. The locked Phase 1 and 1.5 artifacts already close the analysis problem. The remaining work is implementation and verification.
+
+## Earlier Phase Reconciliation
+
+- `00-requirements.md`, `00-worktree.md`, `01-as-is.md`, and `01.5-root-cause.md` are all locked and mutually consistent.
+- No new scope was introduced while planning.
+
+## Subagent Contribution Verification
+
+- No subagent was used for this phase.
+- Main-agent verification consisted of direct reconciliation against the locked earlier-phase artifacts and current source/docs.
+- Acceptance Decision: N/A
+- Repair Performed After Verification: none
+
+## Repair Work Performed
+
+- No production code was changed in this phase.
+- This artifact defines the implementation plan only.
+
+## Requirement Completion Status
+
+- `R1` | Status: planned | Implementation Surface: `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/README.md`, `packages/pi-role-model/skills/role-model/SKILL.md`, `apps/docs-site/content/docs/integrations/pi.mdx` | Verification Surface: `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/docs-and-safety.test.ts` | QA Surface: interactive command transcript plus unsupported print-mode proof
+- `R2` | Status: planned | Implementation Surface: `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/src/types.ts` | Verification Surface: `packages/pi-role-model/test/commands.test.ts` | QA Surface: visible interactive output and truthful unsupported-path docs
+- `R3` | Status: planned | Implementation Surface: `packages/pi-role-model/src/downstream-openai.ts`, `packages/pi-role-model/test/fixtures.ts`, `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/downstream-openai.test.ts`, `packages/pi-role-model/test/extension.test.ts`, `packages/pi-role-model/README.md`, `packages/pi-role-model/skills/role-model/SKILL.md`, `apps/docs-site/content/docs/integrations/pi.mdx` | Verification Surface: `packages/pi-role-model/test/downstream-openai.test.ts`, `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/extension.test.ts`, `packages/pi-role-model/test/docs-and-safety.test.ts` | QA Surface: provider-relative `--list-models` and valid provider prompt transcript
+- `R4` | Status: planned | Implementation Surface: `packages/pi-role-model/src/extension.ts`, `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/src/types.ts`, `packages/pi-role-model/test/extension.test.ts`, `packages/pi-role-model/test/commands.test.ts` | Verification Surface: focused invalid-model tests plus extension integration tests | QA Surface: invalid foreign-id prompt transcript
+- `R5` | Status: planned | Implementation Surface: `packages/pi-role-model/src/extension.ts`, `packages/pi-role-model/src/downstream-openai.ts` | Verification Surface: extension/downstream tests | QA Surface: valid provider prompt transcript and runtime receipt cross-check
+- `R6` | Status: planned | Implementation Surface: `packages/pi-role-model/src/commands.ts` | Verification Surface: `packages/pi-role-model/test/commands.test.ts` | QA Surface: `status` and `doctor` transcript review
+- `R7` | Status: planned | Implementation Surface: `packages/pi-role-model/README.md`, `packages/pi-role-model/skills/role-model/SKILL.md`, `apps/docs-site/content/docs/integrations/pi.mdx`, `packages/pi-role-model/test/docs-and-safety.test.ts` | Verification Surface: `packages/pi-role-model/test/docs-and-safety.test.ts` | QA Surface: manual instruction-following check against updated docs
+- `R8` | Status: planned | Implementation Surface: `packages/pi-role-model/src/config.ts`, `packages/pi-role-model/src/runtime-discovery.ts`, `packages/pi-role-model/src/extension.ts`, `packages/pi-role-model/src/commands.ts`, `packages/pi-role-model/test/runtime-discovery.test.ts`, `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/extension.test.ts` | Verification Surface: `packages/pi-role-model/test/runtime-discovery.test.ts`, `packages/pi-role-model/test/commands.test.ts`, `packages/pi-role-model/test/extension.test.ts` | QA Surface: invalid endpoint and invalid model transcripts
+- `R9` | Status: planned | Implementation Surface: `05-manual-qa.md` and Phase-5 evidence | Verification Surface: worktree-local install proof and transcripts | QA Surface: real local Pi reinstall and end-to-end validation
+
+## Traceability
+
+- `R1`, `R2`, `R6`, `R7` -> `RC1` command-path truth
+- `R3`, `R4`, `R7`, `R9` -> `RC2` canonical-id alignment
+- `R4`, `R5`, `R6`, `R8` -> `RC3` provider prompt error ownership
+- `R6`, `R8` -> `RC4` endpoint/mode diagnostic coverage
+- `R9` -> `RC5` worktree-local Pi QA
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `788c18eec021230a5c0c925931d610875993f65c`
+- Comparison reference: `working-tree`
+- Normalized baseline: `788c18eec021230a5c0c925931d610875993f65c`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 788c18eec021230a5c0c925931d610875993f65c`
+- Planned or claimed changed files:
+  - `packages/pi-role-model/src/types.ts`
+  - `packages/pi-role-model/src/commands.ts`
+  - `packages/pi-role-model/src/downstream-openai.ts`
+  - `packages/pi-role-model/src/extension.ts`
+  - `packages/pi-role-model/src/config.ts`
+  - `packages/pi-role-model/src/runtime-discovery.ts`
+  - `packages/pi-role-model/test/fixtures.ts`
+  - `packages/pi-role-model/test/commands.test.ts`
+  - `packages/pi-role-model/test/downstream-openai.test.ts`
+  - `packages/pi-role-model/test/extension.test.ts`
+  - `packages/pi-role-model/test/docs-and-safety.test.ts`
+  - `packages/pi-role-model/README.md`
+  - `packages/pi-role-model/skills/role-model/SKILL.md`
+  - `apps/docs-site/content/docs/integrations/pi.mdx`
+- Actual changed files reviewed: none (planning-only phase)
+- Unexplained drift: none
+
+## Audit Verdict
+
+Audit: PASS
+
+The TO-BE plan maps every run-75 requirement to concrete package, test, doc, and live-Pi QA surfaces while keeping the implementation smaller than a speculative custom-provider rewrite.
+
+## Coverage Gate
+
+- [x] Every in-scope requirement is mapped to implementation, verification, and QA surfaces
+- [x] The plan stays inside repo-owned boundaries and preserves the healthy valid-id provider path
+- [x] Strict TDD slices are defined before Phase 3
+- [x] Worktree-local Pi reinstall is explicitly required before final QA
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] The plan is specific enough for Phase 3 implementation
+- [x] No unresolved plan gaps remain
+- [x] Audit passed
+
+Approval: PASS

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/00-requirements.receipt.json
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/00-requirements.receipt.json
@@ -1,0 +1,9 @@
+{
+  "artifact": "00-requirements.md",
+  "artifact_hash": "2cd2aec61bb37be5839189b80583f92d73e87f264b2a382c96134a9765b28032",
+  "artifact_path": "D:\\DEV\\role-model\\.recursive\\run\\75-pi-role-model-cli-ux-and-model-id-hardening\\00-requirements.md",
+  "locked_at": "2026-07-17T06:40:42Z",
+  "prerequisite_hashes": {},
+  "previous_receipt_hash": null,
+  "receipt_hash": "a06074a3a13845421eafac9172ec8f9006b8836cbbe3e9045898b6173671e19a"
+}

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/00-worktree.receipt.json
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/00-worktree.receipt.json
@@ -1,0 +1,11 @@
+{
+  "artifact": "00-worktree.md",
+  "artifact_hash": "bc6675ce8be942466c9633d75ad93813aeb7a7265915a023bf1e8e457b4d93ac",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\75-pi-role-model-cli-ux-and-model-id-hardening\\.recursive\\run\\75-pi-role-model-cli-ux-and-model-id-hardening\\00-worktree.md",
+  "locked_at": "2026-07-17T06:59:32Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "2cd2aec61bb37be5839189b80583f92d73e87f264b2a382c96134a9765b28032"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "de2eaa90eca66b0628ffe292feece264fb2aa9bb5ba9509aad308d5ca99b95d7"
+}

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/01-as-is.receipt.json
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/01-as-is.receipt.json
@@ -1,0 +1,12 @@
+{
+  "artifact": "01-as-is.md",
+  "artifact_hash": "45ff7bf466d98f8d31055dd4bdfca5bc56c826bfe75bc8f692519d5c44cf4181",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\75-pi-role-model-cli-ux-and-model-id-hardening\\.recursive\\run\\75-pi-role-model-cli-ux-and-model-id-hardening\\01-as-is.md",
+  "locked_at": "2026-07-17T07:12:35Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "2cd2aec61bb37be5839189b80583f92d73e87f264b2a382c96134a9765b28032",
+    "00-worktree.md": "bc6675ce8be942466c9633d75ad93813aeb7a7265915a023bf1e8e457b4d93ac"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "195690f358cbf0accc8e5a623c3de525e74aa5a6bf7ee350050484a4275b5c45"
+}

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/01.5-root-cause.receipt.json
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/01.5-root-cause.receipt.json
@@ -1,0 +1,13 @@
+{
+  "artifact": "01.5-root-cause.md",
+  "artifact_hash": "cd81eed11a1058cbf4ec79711b432cbd73da32ec8ee8eec08937b117ab7f739d",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\75-pi-role-model-cli-ux-and-model-id-hardening\\.recursive\\run\\75-pi-role-model-cli-ux-and-model-id-hardening\\01.5-root-cause.md",
+  "locked_at": "2026-07-17T07:13:08Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "2cd2aec61bb37be5839189b80583f92d73e87f264b2a382c96134a9765b28032",
+    "00-worktree.md": "bc6675ce8be942466c9633d75ad93813aeb7a7265915a023bf1e8e457b4d93ac",
+    "01-as-is.md": "45ff7bf466d98f8d31055dd4bdfca5bc56c826bfe75bc8f692519d5c44cf4181"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "9be6ca09b5cbb5ab6407a7f8483afa86a51d12af84ddcaa7e3906eb35e4578e2"
+}

--- a/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/02-to-be-plan.receipt.json
+++ b/.recursive/run/75-pi-role-model-cli-ux-and-model-id-hardening/locks/02-to-be-plan.receipt.json
@@ -1,0 +1,14 @@
+{
+  "artifact": "02-to-be-plan.md",
+  "artifact_hash": "dc5c188e338eae39588278f2295a3ad25eb81e4cb906fe45649f0c4929973dee",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\75-pi-role-model-cli-ux-and-model-id-hardening\\.recursive\\run\\75-pi-role-model-cli-ux-and-model-id-hardening\\02-to-be-plan.md",
+  "locked_at": "2026-07-17T07:22:52Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "2cd2aec61bb37be5839189b80583f92d73e87f264b2a382c96134a9765b28032",
+    "00-worktree.md": "bc6675ce8be942466c9633d75ad93813aeb7a7265915a023bf1e8e457b4d93ac",
+    "01-as-is.md": "45ff7bf466d98f8d31055dd4bdfca5bc56c826bfe75bc8f692519d5c44cf4181",
+    "01.5-root-cause.md": "cd81eed11a1058cbf4ec79711b432cbd73da32ec8ee8eec08937b117ab7f739d"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "5bec43c66f6c482c6ad0543fa8e5eaf69ebf5958d3c6a39b3a23e3b9459a4516"
+}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Inside Pi, run:
 
 ```text
 /role-model setup
+/role-model status
 /role-model doctor
 /role-model alias list
 /role-model alias choose
@@ -96,6 +97,8 @@ Inside Pi, run:
 /role-model explain latest
 ```
 
+Use those slash commands only from an interactive Pi session. `pi -p "/role-model status"` is unsupported because Pi print mode does not currently invoke extension commands.
+
 By default the package connects to `http://127.0.0.1:3456` and registers Role-Model as the
 `role-model` provider using `/api/role-model/downstream/openai`. Set `ROLE_MODEL_ENDPOINT`
 before starting Pi to use a different local runtime. Remote endpoints require explicit
@@ -103,6 +106,14 @@ trusted `allowRemote` behavior, and runtimes that report `authentication.require
 closed unless a future supported token source is configured. For local development installs
 and the full command reference, see
 [`packages/pi-role-model/README.md`](packages/pi-role-model/README.md).
+
+For explicit provider prompts, use the provider-relative Role-Model alias that Pi lists for provider `role-model`, for example:
+
+```bash
+pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"
+```
+
+`baseline.remote-only` is the canonical provider-relative form. `role-model/<alias>` is compatibility-only for Pi surfaces that explicitly require a qualified id. Raw HTTP `curl` calls to the runtime are debug-only fallback tools, not the primary supported Pi workflow.
 
 ## Develop from source
 

--- a/apps/docs-site/content/docs/integrations/pi.mdx
+++ b/apps/docs-site/content/docs/integrations/pi.mdx
@@ -43,7 +43,7 @@ copy, print, or sync Pi auth files.
 
 ## Setup commands
 
-Inside Pi, run:
+Inside an interactive Pi session, run:
 
 ```text
 /role-model setup
@@ -57,6 +57,8 @@ downstream OpenAI discovery endpoint.
 `/role-model doctor` checks runtime health, version discovery, downstream discovery, alias discovery, and
 provider registration state.
 
+`pi -p "/role-model status"` is unsupported. Pi print mode does not currently invoke package slash commands, so treat that as an upstream Pi bug or limitation rather than as a Role-Model routing failure.
+
 ## Alias commands
 
 Use aliases to select the Role-Model routing posture Pi should use:
@@ -68,15 +70,24 @@ Use aliases to select the Role-Model routing posture Pi should use:
 /role-model alias use <alias>
 ```
 
-`/role-model alias use <alias>` stores the selected alias and asks Pi to switch the active model to the
-matching `role-model/<alias>` model when Pi exposes active model selection to the package.
+`/role-model alias use <alias>` stores the selected alias and asks Pi to switch the active model when Pi exposes active model selection to the package.
+
+For explicit provider prompts, use the provider-relative Role-Model alias that Pi lists for provider `role-model`, for example:
+
+```bash
+pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"
+```
+
+`baseline.remote-only` is the canonical provider-relative form for explicit provider calls. `role-model/<alias>` is compatibility-only for Pi surfaces that explicitly require a qualified id.
+
+If a user tries a foreign id such as `gpt-4o` under provider `role-model`, send them back to `/role-model alias list` and `/role-model alias recommended`.
 
 ## What gets registered
 
 The package registers:
 
 - provider id: `role-model`
-- model ids shaped as `role-model/<alias>`
+- canonical model ids shaped as provider-relative aliases such as `baseline.remote-only`
 - OpenAI-compatible downstream base URL from `/api/role-model/downstream/openai`
 
 Role-Model remains the routing authority. Pi sends model requests to the Role-Model downstream endpoint, and
@@ -112,6 +123,8 @@ The Pi package is intentionally narrow:
 
 It does not manage runtime lifecycle, install runtime binaries, copy Pi credentials, run benchmarks, or change
 Role-Model provider account setup.
+
+Raw HTTP `curl` calls to the runtime remain debug-only fallback tools when diagnosing Pi or runtime issues. They are not the primary supported integration path when the Pi provider path is healthy.
 
 ## Read next
 

--- a/packages/pi-role-model/README.md
+++ b/packages/pi-role-model/README.md
@@ -22,7 +22,7 @@ ROLE_MODEL_ENDPOINT=http://127.0.0.1:4567 pi
 
 Remote endpoints are blocked by default. Enable remote runtime access only for a trusted endpoint and trusted project context with explicit `allowRemote` behavior, for example by setting `ROLE_MODEL_ALLOW_REMOTE=1` when launching Pi. A runtime whose downstream discovery reports `authentication.required` fails closed unless a future explicit supported token source is added; the package does not read Pi auth files.
 
-Then use these Pi commands:
+Use slash commands only from an interactive Pi session. Supported command path:
 
 ```text
 /role-model setup
@@ -38,10 +38,32 @@ Then use these Pi commands:
 /role-model explain <request-id|latest>
 ```
 
+Unsupported noninteractive slash-command path:
+
+```text
+pi -p "/role-model status"
+```
+
+Pi print mode currently does not invoke package slash commands. Treat that as an upstream Pi limitation, not as a Role-Model routing failure.
+
 The package registers a Pi provider named `role-model` from Role-Model's downstream OpenAI discovery endpoint at `/api/role-model/downstream/openai`.
 
-`/role-model alias use <alias>` stores the selected alias and asks Pi to make that exact Role-Model model id active when Pi exposes active model selection in the command context. The command accepts either the canonical runtime alias id or a convenience unprefixed alias when the runtime exposes prefixed ids. If Pi rejects the model switch, the command reports that the active model was not changed.
+For explicit provider prompts, use the provider-relative Role-Model id that Pi lists for provider `role-model`, for example:
+
+```bash
+pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"
+```
+
+Canonical explicit-provider ids are provider-relative aliases such as `baseline.remote-only`. The qualified form `role-model/<alias>` is compatibility-only for Pi surfaces that explicitly require a qualified id for storage or display.
+
+`/role-model alias list` shows the exact ids you can pass to Pi. `/role-model alias recommended` shows the current default. If someone tries a foreign id such as `gpt-4o` under provider `role-model`, the recovery path is to inspect the alias list and retry with the recommended Role-Model alias.
+
+`/role-model alias use <alias>` stores the selected alias and asks Pi to make that exact Role-Model model id active when Pi exposes active model selection in the command context. If Pi rejects the model switch, the command reports that the active model was not changed.
 
 `/role-model requests` and `/role-model explain <request-id|latest>` read the runtime-owned structured request inspection and router decision surfaces. They report routing reason codes, selected endpoint/model, and Observe request links from the runtime without claiming that the Pi package computes benchmark or telemetry analytics itself.
 
 This package does not install, start, stop, or update the Role-Model runtime. It also does not copy or sync Pi provider credentials. Start Role-Model outside Pi, then run `/role-model setup`.
+
+If Pi prints successful output and then exits with a Windows assertion, that is an upstream Pi bug rather than a package-owned routing failure.
+
+Direct `curl` calls to the Role-Model `/v1/chat/completions` endpoint remain debug-only fallback tools when diagnosing Pi or runtime issues. They are not the primary supported integration path.

--- a/packages/pi-role-model/skills/role-model/SKILL.md
+++ b/packages/pi-role-model/skills/role-model/SKILL.md
@@ -9,9 +9,13 @@ Use this skill when the user wants Pi to use Role-Model as the routing provider.
 
 Role-Model is the routing authority. Pi sends requests to the `role-model` provider, and the external Role-Model runtime decides which endpoint or alias should handle the request. The Pi package only discovers the runtime, registers provider models, exposes diagnostics, and helps choose aliases.
 
-First check `/role-model status`. If setup has not completed, run `/role-model setup`, then use `/role-model doctor` to verify the endpoint, runtime version, auth state, endpoint trust, provider state, and downstream discovery contract.
+Use slash commands only from an interactive Pi session. `pi -p "/role-model status"` is unsupported because Pi print mode does not currently invoke package slash commands; treat that as an upstream Pi limitation, not as proof that Role-Model routing is broken.
 
-For model selection, use `/role-model alias list` to inspect available aliases, `/role-model alias recommended` to show the runtime recommendation, and `/role-model alias use <alias>` or `/role-model alias choose <alias>` to select the alias Pi should use. Use `/role-model alias refresh` after the Role-Model runtime catalog changes.
+First check `/role-model status`. If setup has not completed, run `/role-model setup`, then use `/role-model doctor` to verify the endpoint, runtime version, auth state, endpoint trust, provider state, downstream discovery contract, and the current canonical provider-relative alias guidance.
+
+For explicit provider prompts, use the provider-relative Role-Model id that Pi lists for provider `role-model`, for example `pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"`. The provider-relative alias is canonical. `role-model/<alias>` is compatibility-only for Pi surfaces that explicitly require a qualified id.
+
+For model selection, use `/role-model alias list` to inspect available aliases, `/role-model alias recommended` to show the runtime recommendation, and `/role-model alias use <alias>` or `/role-model alias choose <alias>` to select the alias Pi should use. Use `/role-model alias refresh` after the Role-Model runtime catalog changes. If someone tries a foreign id such as `gpt-4o` under provider `role-model`, send them back to `/role-model alias list` and `/role-model alias recommended`.
 
 For runtime-owned request diagnostics, use `/role-model requests` to inspect recent runtime requests and `/role-model explain <request-id|latest>` to read the runtime's structured request detail and router decision detail for that request. Use those commands when the user asks why Role-Model chose a route, what reason codes were recorded, or whether benchmark/telemetry advisory signals showed up in the runtime diagnostics.
 
@@ -26,3 +30,5 @@ Role-Model benchmarks, routing decisions, endpoint eligibility, fallback, and te
 If the user explicitly asks to install or launch the external Role-Model router runtime, point them to the Role-Model repository README for those instructions and make it clear that this is external runtime setup, not a side effect of installing the Pi package.
 
 Security boundaries: remote endpoints require explicit trust, runtimes reporting `authentication.required` must fail closed unless an explicit supported token source exists, and the package must not manage the runtime lifecycle. Do not read, print, copy, or sync Pi auth files.
+
+Raw HTTP calls to the runtime are debug-only fallback tools when diagnosing Pi or runtime issues. They are not the primary supported workflow when the Pi provider path is available.

--- a/packages/pi-role-model/src/commands.ts
+++ b/packages/pi-role-model/src/commands.ts
@@ -1,8 +1,15 @@
 import { createPiModelSelection } from "./downstream-openai.js";
+import {
+  formatInvalidRoleModelModelId,
+  formatRoleModelInvocationGuidance,
+  normalizeRoleModelModelId,
+  recommendedRoleModelModelId,
+} from "./model-guidance.js";
 import { RoleModelDiscoveryError } from "./runtime-discovery.js";
 import type { RoleModelRecentRequest, RoleModelRequestInspection } from "./runtime-inspection.js";
 import type {
   DiscoveryResult,
+  PiModelRef,
   PiCommandContext,
   PiModelSelection,
   RoleModelCommandResult,
@@ -154,18 +161,6 @@ function resolveAliasId(result: DiscoveryResult, rawAlias: string): string | nul
   return match?.id ?? null;
 }
 
-function formatDiscoveryError(error: unknown): string {
-  if (error instanceof RoleModelDiscoveryError) {
-    return [
-      `Role-Model runtime unavailable: ${error.message}`,
-      `state: ${error.state}`,
-      `endpoint: ${error.endpoint}`,
-      `remediation: ${error.remediation}`,
-    ].join("\n");
-  }
-  return `Role-Model runtime unavailable: ${error instanceof Error ? error.message : String(error)}`;
-}
-
 function versionText(result: DiscoveryResult): string {
   return typeof result.version?.version === "string" ? result.version.version : "unknown";
 }
@@ -189,18 +184,26 @@ function runtimeBuildText(result: DiscoveryResult): string | null {
   return buildVersion;
 }
 
-function currentPiRoleModelAlias(context?: Pick<PiCommandContext, "getModel">): string | null {
-  const model = context?.getModel?.();
+function modelFromContext(
+  context?: Pick<PiCommandContext, "getModel" | "model">,
+): PiModelRef | undefined {
+  return context?.model ?? context?.getModel?.();
+}
+
+function currentPiRoleModelAlias(
+  context?: Pick<PiCommandContext, "getModel" | "model">,
+): string | null {
+  const model = modelFromContext(context);
   if (!model || model.provider !== "role-model" || typeof model.id !== "string") {
     return null;
   }
-  return model.id.startsWith("role-model/") ? model.id.slice("role-model/".length) : model.id;
+  return normalizeRoleModelModelId(model.id);
 }
 
 async function selectedAliasText(
   result: DiscoveryResult,
   readSelectedAlias?: () => Promise<string | null>,
-  context?: Pick<PiCommandContext, "getModel">,
+  context?: Pick<PiCommandContext, "getModel" | "model">,
 ): Promise<string> {
   return (
     currentPiRoleModelAlias(context) ??
@@ -210,10 +213,78 @@ async function selectedAliasText(
   );
 }
 
+function discoveryRuntimeReached(state: RoleModelDiscoveryError["state"]): "yes" | "no" {
+  switch (state) {
+    case "auth-required":
+    case "incompatible":
+      return "yes";
+    default:
+      return "no";
+  }
+}
+
+function discoveryCheck(state: RoleModelDiscoveryError["state"]): string {
+  switch (state) {
+    case "malformed":
+      return "endpoint format";
+    case "blocked-remote":
+      return "endpoint trust";
+    case "timeout":
+    case "unavailable":
+      return "endpoint reachability";
+    case "incompatible":
+      return "runtime compatibility";
+    case "auth-required":
+      return "runtime authentication";
+  }
+}
+
+function formatDiscoveryFailure(
+  error: unknown,
+  commandName: "status" | "doctor",
+): string {
+  if (error instanceof RoleModelDiscoveryError) {
+    return [
+      `${commandName}: fail`,
+      `check: ${discoveryCheck(error.state)}`,
+      `classification: ${error.state}`,
+      `runtime reached: ${discoveryRuntimeReached(error.state)}`,
+      `input endpoint: ${error.endpoint}`,
+      `reason: ${error.message}`,
+      `remediation: ${error.remediation}`,
+      ...formatRoleModelInvocationGuidance(null),
+    ].join("\n");
+  }
+  return [
+    `${commandName}: fail`,
+    "check: runtime discovery",
+    "classification: unavailable",
+    "runtime reached: no",
+    `reason: ${error instanceof Error ? error.message : String(error)}`,
+    ...formatRoleModelInvocationGuidance(null),
+  ].join("\n");
+}
+
+function aliasState(result: DiscoveryResult, alias: string | null): string | null {
+  if (!alias || alias === "none") {
+    return null;
+  }
+  return aliasRecords(result).some((model) => model.id === alias)
+    ? "discoverable"
+    : "removed or no longer discoverable";
+}
+
+function formatAliasSelectionError(result: DiscoveryResult, requestedAlias: string): string {
+  return formatInvalidRoleModelModelId(result.discovery, requestedAlias, "yes").replace(
+    "invalid Role-Model model id:",
+    "invalid Role-Model alias:",
+  );
+}
+
 export function createRoleModelCommandHandler(dependencies: RoleModelCommandDependencies) {
   return async function handleRoleModelCommand(
     args = "",
-    context?: Pick<PiCommandContext, "getModel">,
+    context?: Pick<PiCommandContext, "getModel" | "model">,
   ): Promise<RoleModelCommandResult> {
     const [command = "help", subcommand, ...rest] = args.trim().split(/\s+/).filter(Boolean);
 
@@ -225,7 +296,7 @@ export function createRoleModelCommandHandler(dependencies: RoleModelCommandDepe
     try {
       result = await dependencies.discover();
     } catch (error) {
-      return fail(formatDiscoveryError(error));
+      return fail(formatDiscoveryFailure(error, command === "doctor" ? "doctor" : "status"));
     }
 
     if (command === "setup") {
@@ -243,25 +314,34 @@ export function createRoleModelCommandHandler(dependencies: RoleModelCommandDepe
     if (command === "status") {
       const storedAlias = await dependencies.readSelectedAlias?.();
       const activeAlias = currentPiRoleModelAlias(context);
-      const selected = await selectedAliasText(result, dependencies.readSelectedAlias, context);
+      const selected =
+        activeAlias ?? storedAlias ?? recommendedRoleModelModelId(result.discovery) ?? "none";
       const aliases = aliasRecords(result);
+      const recommendedAlias = recommendedRoleModelModelId(result.discovery);
       return ok(
         [
           result.discovery.displayName,
           `state: ${result.state ?? "ready"}`,
           `endpoint: ${result.discovery.baseUrl}`,
+          "runtime reachability: reachable",
           `runtime version: ${runtimeDisplayVersionText(result)}`,
           ...(runtimeBuildText(result) ? [`runtime build: ${runtimeBuildText(result)}`] : []),
           `aliases: ${aliases.length}`,
           `selected alias: ${selected}`,
+          `selected alias state: ${aliasState(result, selected) ?? "none"}`,
+          `recommended alias: ${recommendedAlias ?? "none"}`,
           activeAlias && storedAlias && activeAlias !== storedAlias
             ? `stored alias: ${storedAlias}`
+            : null,
+          storedAlias && activeAlias !== storedAlias
+            ? `stored alias state: ${aliasState(result, storedAlias) ?? "none"}`
             : null,
           `provider: ${result.providerRegistered === false ? "not registered" : "registered"}`,
           `auth: ${result.discovery.authentication.required ? "required" : "placeholder"}`,
           `endpoint trust: ${result.discovery.baseUrl.startsWith("http://127.0.0.1") || result.discovery.baseUrl.startsWith("http://localhost") ? "local" : "remote"}`,
           `fallback: ${(result.state ?? "ready") === "fallback" ? "yes" : "no"}`,
           `warnings: ${result.warnings && result.warnings.length > 0 ? result.warnings.join("; ") : "none"}`,
+          ...formatRoleModelInvocationGuidance(recommendedAlias),
         ]
           .filter((line): line is string => line !== null)
           .join("\n"),
@@ -271,9 +351,13 @@ export function createRoleModelCommandHandler(dependencies: RoleModelCommandDepe
     if (command === "doctor") {
       const aliases = aliasRecords(result);
       const degraded = (result.modelDiagnostics ?? []).filter((diagnostic) => diagnostic.degraded);
+      const recommendedAlias = recommendedRoleModelModelId(result.discovery);
       return ok(
         [
           "doctor: ok",
+          "check: endpoint reachability",
+          "classification: ready",
+          "runtime reached: yes",
           `endpoint: ${result.discovery.baseUrl}`,
           "health: ok",
           `runtime version: ${versionText(result) === "unknown" ? "unknown" : "ok"}`,
@@ -285,7 +369,7 @@ export function createRoleModelCommandHandler(dependencies: RoleModelCommandDepe
           `aliases: ${aliases.length > 0 ? "ok" : "missing"}`,
           `degraded models: ${degraded.length > 0 ? degraded.map((diagnostic) => diagnostic.id).join(", ") : "none"}`,
           `models: ${result.discovery.models.length}`,
-          `recommended alias: ${result.discovery.setup.recommendedModel ?? "none"}`,
+          ...formatRoleModelInvocationGuidance(recommendedAlias),
         ].join("\n"),
       );
     }
@@ -352,7 +436,7 @@ export function createRoleModelCommandHandler(dependencies: RoleModelCommandDepe
       }
       const alias = resolveAliasId(result, requestedAlias);
       if (!alias) {
-        return fail(`Unknown Role-Model alias: ${requestedAlias}`);
+        return fail(formatAliasSelectionError(result, requestedAlias));
       }
       await dependencies.writeSelectedAlias?.(alias);
       const model = createPiModelSelection(result.discovery, alias);

--- a/packages/pi-role-model/src/extension.ts
+++ b/packages/pi-role-model/src/extension.ts
@@ -1,6 +1,7 @@
 import { createFileAliasStore } from "./alias-store.js";
 import { type RoleModelCommandDependencies, createRoleModelCommandHandler } from "./commands.js";
 import { createRoleModelConfig } from "./config.js";
+import { findRoleModelDiscoveryModel, formatInvalidRoleModelModelId } from "./model-guidance.js";
 import { registerRoleModelProvider } from "./provider-registration.js";
 import { injectRoleModelIntentIntoPayloadWithRuntimeTasks } from "./request-intent.js";
 import { discoverRoleModelRuntime } from "./runtime-discovery.js";
@@ -30,8 +31,10 @@ export function createRoleModelExtension(options: RoleModelExtensionOptions = {}
       ...(options.endpoint === undefined ? {} : { endpoint: options.endpoint }),
     }).endpoint;
     const roleModelModelIds = new Set<string>();
+    let latestDiscovery: DownstreamOpenAIDiscovery | undefined;
     let effectiveTaxonomy: CompactTaxonomy | undefined;
     const rememberRoleModelModels = (discovery: DownstreamOpenAIDiscovery) => {
+      latestDiscovery = discovery;
       roleModelModelIds.clear();
       for (const model of discovery.models) {
         roleModelModelIds.add(model.id);
@@ -118,15 +121,29 @@ export function createRoleModelExtension(options: RoleModelExtensionOptions = {}
           endpoint: runtimeEndpoint,
         }));
 
-    pi.on?.("before_provider_request", (event) =>
-      injectRoleModelIntentIntoPayloadWithRuntimeTasks(
+    pi.on?.("before_provider_request", async (event, context) => {
+      const payload =
+        typeof event.payload === "object" && event.payload !== null
+          ? (event.payload as Record<string, unknown>)
+          : null;
+      const payloadModel = typeof payload?.model === "string" ? payload.model : null;
+      if (
+        context?.model?.provider === "role-model" &&
+        latestDiscovery &&
+        payloadModel &&
+        !findRoleModelDiscoveryModel(latestDiscovery, payloadModel)
+      ) {
+        throw new Error(formatInvalidRoleModelModelId(latestDiscovery, payloadModel, "yes"));
+      }
+
+      return injectRoleModelIntentIntoPayloadWithRuntimeTasks(
         event.payload,
         roleModelModelIds,
         effectiveTaxonomy,
         fetchRuntimeTaskChunk,
         readRuntimeRoleSummaries,
-      ),
-    );
+      );
+    });
 
     pi.registerCommand("role-model", {
       description: "Configure and inspect the Role-Model provider for Pi.",

--- a/packages/pi-role-model/src/model-guidance.ts
+++ b/packages/pi-role-model/src/model-guidance.ts
@@ -1,0 +1,115 @@
+import type { DownstreamOpenAIDiscovery, DownstreamOpenAIModelRecord } from "./types.js";
+
+const LIKELY_FOREIGN_PROVIDER_MODEL_PATTERNS = [
+  /^[a-z0-9_-]+\/[a-z0-9._-]+$/i,
+  /^gpt-/i,
+  /^o\d/i,
+  /^claude-/i,
+  /^gemini-/i,
+  /^deepseek-/i,
+  /^kimi-/i,
+  /^qwen-/i,
+  /^llama-/i,
+  /^mistral-/i,
+  /^grok-/i,
+] as const;
+
+export type InvalidRoleModelModelClassification =
+  | "foreign-provider-model"
+  | "unknown-model-id";
+
+export interface InvalidRoleModelModelDiagnostic {
+  classification: InvalidRoleModelModelClassification;
+  requestedModelId: string;
+  normalizedModelId: string;
+  recommendedModelId: string | null;
+  reason: string;
+}
+
+export function normalizeRoleModelModelId(modelId: string): string {
+  return modelId.startsWith("role-model/") ? modelId.slice("role-model/".length) : modelId;
+}
+
+export function findRoleModelDiscoveryModel(
+  discovery: DownstreamOpenAIDiscovery,
+  requestedModelId: string,
+): DownstreamOpenAIModelRecord | undefined {
+  const normalizedModelId = normalizeRoleModelModelId(requestedModelId);
+  return discovery.models.find(
+    (model) => model.id === requestedModelId || model.id === normalizedModelId,
+  );
+}
+
+export function recommendedRoleModelModelId(
+  discovery: DownstreamOpenAIDiscovery,
+): string | null {
+  return discovery.setup.recommendedModel ?? discovery.models[0]?.id ?? null;
+}
+
+export function formatSupportedRoleModelPromptPath(modelId: string | null): string {
+  const displayModelId = modelId ?? "<role-model-alias>";
+  return `pi --no-session --provider role-model --model ${displayModelId} -p "<prompt>"`;
+}
+
+export function formatRoleModelInvocationGuidance(modelId: string | null): readonly string[] {
+  return [
+    `recommended alias: ${modelId ?? "none"}`,
+    `canonical provider model id: ${modelId ?? "none"}`,
+    `supported prompt path: ${formatSupportedRoleModelPromptPath(modelId)}`,
+    "command invocation: interactive slash commands only",
+    'unsupported noninteractive path: pi -p "/role-model ..."',
+  ];
+}
+
+function isLikelyForeignProviderModelId(modelId: string): boolean {
+  return LIKELY_FOREIGN_PROVIDER_MODEL_PATTERNS.some((pattern) => pattern.test(modelId));
+}
+
+export function classifyInvalidRoleModelModelId(
+  discovery: DownstreamOpenAIDiscovery,
+  requestedModelId: string,
+): InvalidRoleModelModelDiagnostic {
+  const normalizedModelId = normalizeRoleModelModelId(requestedModelId);
+  const classification: InvalidRoleModelModelClassification = isLikelyForeignProviderModelId(
+    requestedModelId,
+  )
+    ? "foreign-provider-model"
+    : "unknown-model-id";
+  const reason =
+    classification === "foreign-provider-model"
+      ? "foreign provider ids are not valid under provider role-model unless they appear in the discovered Role-Model alias catalog."
+      : "the requested model id is not present in the discovered Role-Model alias catalog.";
+  return {
+    classification,
+    requestedModelId,
+    normalizedModelId,
+    recommendedModelId: recommendedRoleModelModelId(discovery),
+    reason,
+  };
+}
+
+export function formatInvalidRoleModelModelId(
+  discovery: DownstreamOpenAIDiscovery,
+  requestedModelId: string,
+  runtimeReached: "yes" | "no" = "yes",
+): string {
+  const diagnostic = classifyInvalidRoleModelModelId(discovery, requestedModelId);
+  return [
+    `invalid Role-Model model id: ${diagnostic.requestedModelId}`,
+    `classification: ${diagnostic.classification}`,
+    "provider: role-model",
+    `runtime reached: ${runtimeReached}`,
+    `reason: ${diagnostic.reason}`,
+    diagnostic.recommendedModelId
+      ? `Recommended Role-Model alias: ${diagnostic.recommendedModelId}`
+      : "Recommended Role-Model alias: none",
+    "Run /role-model alias list to inspect valid aliases.",
+    "Run /role-model alias recommended to inspect the current default.",
+    diagnostic.recommendedModelId
+      ? `Use --provider role-model --model ${diagnostic.recommendedModelId}`
+      : null,
+    "Compatibility note: role-model/<alias> is accepted only when a Pi API explicitly requires a qualified id.",
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}

--- a/packages/pi-role-model/src/runtime-discovery.ts
+++ b/packages/pi-role-model/src/runtime-discovery.ts
@@ -8,6 +8,7 @@ import {
   CONSERVATIVE_MAX_TOKENS,
   validateDownstreamOpenAIDiscovery,
 } from "./downstream-openai.js";
+import { normalizeRoleModelModelId } from "./model-guidance.js";
 import type {
   DiscoveryResult,
   DownstreamOpenAIDiscovery,
@@ -99,6 +100,7 @@ function createFallbackModelRecord(
   ) {
     return undefined;
   }
+  const normalizedModelId = normalizeRoleModelModelId(record.id);
   const roleModel = isObject(record.role_model) ? record.role_model : {};
   const contextWindow =
     typeof record.context_window === "number"
@@ -119,13 +121,13 @@ function createFallbackModelRecord(
     ? record.endpoint_ids.filter((item): item is string => typeof item === "string")
     : [];
   return {
-    id: record.id,
+    id: normalizedModelId,
     object: "model",
     owned_by: "role-model",
     endpoint_ids: endpointIds,
     type: roleModel.type === "model" ? "model" : "alias",
-    targetModelIds: [record.id],
-    canonicalModelIds: [record.id],
+    targetModelIds: [normalizedModelId],
+    canonicalModelIds: [normalizedModelId],
     providerIds: ["role-model"],
     limits: {
       safeContextWindow: contextWindow,
@@ -148,8 +150,8 @@ function createFallbackModelRecord(
       structuredOutput: { supported: false },
       caching: { promptRead: null, promptWrite: null, source: "unknown" },
     },
-    declared: { modelIds: [record.id], endpointIds },
-    routable: { modelIds: [record.id], endpointIds },
+    declared: { modelIds: [normalizedModelId], endpointIds },
+    routable: { modelIds: [normalizedModelId], endpointIds },
     piMapping: {
       contextWindow: contextWindow ?? CONSERVATIVE_CONTEXT_WINDOW,
       maxTokens: maxTokens ?? CONSERVATIVE_MAX_TOKENS,

--- a/packages/pi-role-model/src/types.ts
+++ b/packages/pi-role-model/src/types.ts
@@ -104,24 +104,39 @@ export interface ProviderRegistration {
   modelDiagnostics: RoleModelModelDiagnostic[];
 }
 
+export interface PiModelRef {
+  id: string;
+  provider: string;
+}
+
+export type PiExtensionMode = "tui" | "rpc" | "json" | "print";
+
+export interface PiExtensionContext {
+  ui?: {
+    notify?: (message: string, level?: "info" | "error") => void;
+  };
+  mode?: PiExtensionMode;
+  model?: PiModelRef;
+  isProjectTrusted?: () => boolean;
+}
+
 export interface PiExtensionAPI {
   registerProvider(name: string, config: PiProviderConfig): void;
   registerCommand(name: string, config: { description: string; handler: PiCommandHandler }): void;
   on?: (
     event: "before_provider_request",
-    handler: (event: { type: "before_provider_request"; payload: unknown }) =>
+    handler: (
+      event: { type: "before_provider_request"; payload: unknown },
+      context?: PiExtensionContext,
+    ) =>
       | unknown
       | Promise<unknown>,
   ) => void;
   setModel?: (model: PiModelSelection) => Promise<boolean>;
 }
 
-export interface PiCommandContext {
-  ui?: {
-    notify?: (message: string, level?: "info" | "error") => void;
-  };
-  isProjectTrusted?: () => boolean;
-  getModel?: () => PiModelSelection | undefined;
+export interface PiCommandContext extends PiExtensionContext {
+  getModel?: () => PiModelRef | undefined;
 }
 
 export type PiCommandHandler = (args?: string, context?: PiCommandContext) => Promise<void>;

--- a/packages/pi-role-model/test/commands.test.ts
+++ b/packages/pi-role-model/test/commands.test.ts
@@ -25,7 +25,7 @@ const discovery: DownstreamOpenAIDiscovery = {
   },
   models: [
     {
-      id: "role-model/auto",
+      id: "baseline.remote-only",
       object: "model",
       owned_by: "role-model",
       endpoint_ids: ["local"],
@@ -51,7 +51,7 @@ const discovery: DownstreamOpenAIDiscovery = {
       sources: ["runtime"],
     },
   ],
-  setup: { recommendedModel: "role-model/auto", notes: [] },
+  setup: { recommendedModel: "baseline.remote-only", notes: [] },
   freshness: {
     generatedAt: "2026-06-22T00:00:00Z",
     catalogVersion: "test",
@@ -118,7 +118,7 @@ describe("role-model command dispatcher", () => {
 
     await expect(handler("setup")).resolves.toMatchObject({
       ok: true,
-      text: expect.stringContaining("role-model/auto"),
+      text: expect.stringContaining("baseline.remote-only"),
     });
     await expect(handler("ui")).resolves.toMatchObject({
       ok: true,
@@ -126,11 +126,11 @@ describe("role-model command dispatcher", () => {
     });
     await expect(handler("alias recommended")).resolves.toMatchObject({
       ok: true,
-      text: expect.stringContaining("role-model/auto"),
+      text: expect.stringContaining("baseline.remote-only"),
     });
-    await expect(handler("alias use role-model/auto")).resolves.toMatchObject({
+    await expect(handler("alias use baseline.remote-only")).resolves.toMatchObject({
       ok: true,
-      text: expect.stringContaining("role-model/auto"),
+      text: expect.stringContaining("baseline.remote-only"),
     });
     await expect(handler("alias refresh")).resolves.toMatchObject({
       ok: true,
@@ -138,7 +138,7 @@ describe("role-model command dispatcher", () => {
     });
 
     expect(refreshed).toEqual(["http://127.0.0.1:3456", "http://127.0.0.1:3456"]);
-    expect(selectedAlias).toBe("role-model/auto");
+    expect(selectedAlias).toBe("baseline.remote-only");
   });
 
   test("lists recent runtime requests and explains the latest routing decision", async () => {
@@ -214,11 +214,11 @@ describe("role-model command dispatcher", () => {
 
     await expect(handler("alias list")).resolves.toMatchObject({
       ok: true,
-      text: expect.stringContaining("role-model/auto"),
+      text: expect.stringContaining("baseline.remote-only"),
     });
-    await expect(handler("alias choose role-model/auto")).resolves.toMatchObject({
+    await expect(handler("alias choose baseline.remote-only")).resolves.toMatchObject({
       ok: true,
-      text: expect.stringContaining("role-model/auto"),
+      text: expect.stringContaining("baseline.remote-only"),
     });
     await expect(handler("alias current")).resolves.toMatchObject({
       ok: true,
@@ -237,7 +237,7 @@ describe("role-model command dispatcher", () => {
         providerRegistered: true,
         modelDiagnostics: [],
       }),
-      readSelectedAlias: async () => "role-model/auto",
+      readSelectedAlias: async () => "baseline.remote-only",
     });
 
     await expect(handler("status")).resolves.toMatchObject({
@@ -246,11 +246,36 @@ describe("role-model command dispatcher", () => {
     });
     const result = await handler("status");
     expect(result.text).toContain("aliases: 1");
-    expect(result.text).toContain("selected alias: role-model/auto");
+    expect(result.text).toContain("selected alias: baseline.remote-only");
     expect(result.text).toContain("provider: registered");
     expect(result.text).toContain("auth: placeholder");
     expect(result.text).toContain("endpoint trust: local");
     expect(result.text).toContain("fallback: no");
+  });
+
+  test("status reports canonical provider-relative prompt guidance and invocation-mode truth", async () => {
+    const handler = createRoleModelCommandHandler({
+      discover: async () => ({
+        discovery: createDiscovery(),
+        version: { version: "0.0.0-test" },
+        health: { status: "healthy" },
+        state: "ready",
+        warnings: [],
+        providerRegistered: true,
+        modelDiagnostics: [],
+      }),
+      readSelectedAlias: async () => "baseline.remote-only",
+    });
+
+    const result = await handler("status");
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain("recommended alias: baseline.remote-only");
+    expect(result.text).toContain("canonical provider model id: baseline.remote-only");
+    expect(result.text).toContain(
+      'supported prompt path: pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"',
+    );
+    expect(result.text).toContain("command invocation: interactive slash commands only");
+    expect(result.text).toContain('unsupported noninteractive path: pi -p "/role-model ..."');
   });
 
   test("status prefers the live Pi role-model selection over a stale stored alias", async () => {
@@ -296,7 +321,10 @@ describe("role-model command dispatcher", () => {
 
     const result = await handler("doctor");
     expect(result.ok).toBe(false);
-    expect(result.text).toContain("state: blocked-remote");
+    expect(result.text).toContain("check: endpoint trust");
+    expect(result.text).toContain("classification: blocked-remote");
+    expect(result.text).toContain("runtime reached: no");
+    expect(result.text).toContain("input endpoint: https://role-model.example.test");
     expect(result.text).toContain("remediation: Enable allowRemote");
   });
 
@@ -307,15 +335,15 @@ describe("role-model command dispatcher", () => {
         state: "fallback",
         warnings: ["using compact /v1/models fallback"],
         modelDiagnostics: [
-          { id: "role-model/auto", degraded: true, reasons: ["missing piMapping.maxTokens"] },
+          { id: "baseline.remote-only", degraded: true, reasons: ["missing piMapping.maxTokens"] },
         ],
       }),
-      readSelectedAlias: async () => "role-model/auto",
+      readSelectedAlias: async () => "baseline.remote-only",
     });
 
     const result = await handler("alias list");
     expect(result.ok).toBe(true);
-    expect(result.text).toContain("role-model/auto");
+    expect(result.text).toContain("baseline.remote-only");
     expect(result.text).toContain("recommended");
     expect(result.text).toContain("selected");
     expect(result.text).toContain("ready");
@@ -341,16 +369,16 @@ describe("role-model command dispatcher", () => {
       },
     });
 
-    const result = await handler("alias use role-model/auto");
+    const result = await handler("alias use baseline.remote-only");
     expect(result.ok).toBe(true);
-    expect(selectedAlias).toBe("role-model/auto");
+    expect(selectedAlias).toBe("baseline.remote-only");
     expect(activeSelections).toEqual([
       expect.objectContaining({
         provider: "role-model",
-        id: "role-model/auto",
+        id: "baseline.remote-only",
       }),
     ]);
-    expect(result.text).toContain("active model: role-model/auto");
+    expect(result.text).toContain("active model: baseline.remote-only");
   });
 
   test("alias use reports active-model failure without claiming Pi switched models", async () => {
@@ -365,13 +393,13 @@ describe("role-model command dispatcher", () => {
       setActiveModel: async () => false,
     });
 
-    const result = await handler("alias use role-model/auto");
+    const result = await handler("alias use baseline.remote-only");
     expect(result.ok).toBe(false);
-    expect(result.text).toContain("selected alias: role-model/auto");
+    expect(result.text).toContain("selected alias: baseline.remote-only");
     expect(result.text).toContain("active model: not changed");
   });
 
-  test("alias use accepts unprefixed alias ids and stores the canonical runtime alias", async () => {
+  test("alias use accepts compatibility-prefixed ids and stores the canonical runtime alias", async () => {
     let selectedAlias: string | null = null;
     const handler = createRoleModelCommandHandler({
       discover: async () => ({
@@ -386,9 +414,27 @@ describe("role-model command dispatcher", () => {
       setActiveModel: async () => true,
     });
 
-    const result = await handler("alias use auto");
+    const result = await handler("alias use role-model/baseline.remote-only");
     expect(result.ok).toBe(true);
-    expect(selectedAlias).toBe("role-model/auto");
-    expect(result.text).toContain("selected alias: role-model/auto");
+    expect(selectedAlias).toBe("baseline.remote-only");
+    expect(result.text).toContain("selected alias: baseline.remote-only");
+  });
+
+  test("alias use explains how to recover from a foreign model id", async () => {
+    const handler = createRoleModelCommandHandler({
+      discover: async () => ({
+        discovery: createDiscovery(),
+        state: "ready",
+        warnings: [],
+        modelDiagnostics: [],
+      }),
+    });
+
+    const result = await handler("alias use gpt-4o");
+    expect(result.ok).toBe(false);
+    expect(result.text).toContain("invalid Role-Model alias: gpt-4o");
+    expect(result.text).toContain("foreign provider ids are not valid under provider role-model");
+    expect(result.text).toContain("Run /role-model alias list");
+    expect(result.text).toContain("Recommended Role-Model alias: baseline.remote-only");
   });
 });

--- a/packages/pi-role-model/test/docs-and-safety.test.ts
+++ b/packages/pi-role-model/test/docs-and-safety.test.ts
@@ -28,10 +28,19 @@ describe("Pi installation docs, skill, and safety guardrails", () => {
     const skill = await readFile(join(packageRoot, "skills", "role-model", "SKILL.md"), "utf8");
     const readme = await readFile(join(repoRoot, "README.md"), "utf8");
     const packageReadme = await readFile(join(packageRoot, "README.md"), "utf8");
+    const docsSite = await readFile(
+      join(repoRoot, "apps", "docs-site", "content", "docs", "integrations", "pi.mdx"),
+      "utf8",
+    );
 
     expect(skill).toContain("role-model");
     expect(skill).toContain("/role-model status");
     expect(skill).toContain("/role-model alias use");
+    expect(skill).toContain("interactive Pi session");
+    expect(skill).toContain('pi -p "/role-model status"');
+    expect(skill).toContain("unsupported");
+    expect(skill).toContain("baseline.remote-only");
+    expect(skill).toContain("--provider role-model --model baseline.remote-only");
     expect(readme).toContain("## Installation for Pi");
     expect(readme).toContain("ROLE_MODEL_ENDPOINT");
     expect(readme).toContain("allowRemote");
@@ -41,6 +50,10 @@ describe("Pi installation docs, skill, and safety guardrails", () => {
     expect(readme).toContain("/role-model doctor");
     expect(readme).toContain("/role-model alias choose");
     expect(readme).toContain("/role-model alias use");
+    expect(readme).toContain("baseline.remote-only");
+    expect(readme).toContain('pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"');
+    expect(readme).toContain('pi -p "/role-model status"');
+    expect(readme).toContain("debug-only");
     expect(packageReadme).toContain("pi install npm:@try-works/pi-role-model");
     expect(packageReadme).toContain("pi install ./packages/pi-role-model");
     expect(packageReadme).toContain("/role-model alias recommended");
@@ -49,6 +62,16 @@ describe("Pi installation docs, skill, and safety guardrails", () => {
     expect(packageReadme).toContain("ROLE_MODEL_ENDPOINT");
     expect(packageReadme).toContain("allowRemote");
     expect(packageReadme).toContain("active model");
+    expect(packageReadme).toContain("baseline.remote-only");
+    expect(packageReadme).toContain('pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"');
+    expect(packageReadme).toContain('pi -p "/role-model status"');
+    expect(packageReadme).toContain("compatibility-only");
+    expect(packageReadme).toContain("debug-only");
+    expect(docsSite).toContain("baseline.remote-only");
+    expect(docsSite).toContain('pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"');
+    expect(docsSite).toContain('pi -p "/role-model status"');
+    expect(docsSite).toContain("compatibility-only");
+    expect(docsSite).toContain("upstream Pi bug");
     expect(skill).toContain("Role-Model repository README");
     expect(skill).toContain("aliases");
     expect(skill).toContain("routing authority");

--- a/packages/pi-role-model/test/downstream-openai.test.ts
+++ b/packages/pi-role-model/test/downstream-openai.test.ts
@@ -28,7 +28,7 @@ const discovery: DownstreamOpenAIDiscovery = {
   },
   models: [
     {
-      id: "role-model/auto",
+      id: "baseline.remote-only",
       object: "model",
       owned_by: "role-model",
       endpoint_ids: ["local"],
@@ -54,7 +54,7 @@ const discovery: DownstreamOpenAIDiscovery = {
       sources: ["runtime"],
     },
   ],
-  setup: { recommendedModel: "role-model/auto", notes: ["Use discovery"] },
+  setup: { recommendedModel: "baseline.remote-only", notes: ["Use discovery"] },
   freshness: {
     generatedAt: "2026-06-22T00:00:00Z",
     catalogVersion: "test",
@@ -78,7 +78,7 @@ describe("downstream OpenAI discovery mapping", () => {
     expect(provider.config.apiKey).toBe("role-model-local");
     expect(provider.config.models).toEqual([
       expect.objectContaining({
-        id: "role-model/auto",
+        id: "baseline.remote-only",
         contextWindow: 120000,
         maxTokens: 8000,
       }),
@@ -139,7 +139,7 @@ describe("downstream OpenAI discovery mapping", () => {
       },
     };
 
-    expect(createPiModelSelection(discoveryWithCompat, "role-model/auto")).toEqual(
+    expect(createPiModelSelection(discoveryWithCompat, "baseline.remote-only")).toEqual(
       expect.objectContaining({
         compat: expect.objectContaining({
           supportsDeveloperRole: false,
@@ -191,7 +191,7 @@ describe("downstream OpenAI discovery mapping", () => {
     );
     expect(provider.modelDiagnostics).toEqual([
       expect.objectContaining({
-        id: "role-model/auto",
+        id: "baseline.remote-only",
         degraded: true,
         reasons: expect.arrayContaining([
           "missing piMapping.contextWindow",

--- a/packages/pi-role-model/test/extension.test.ts
+++ b/packages/pi-role-model/test/extension.test.ts
@@ -8,6 +8,11 @@ type RegisteredCommandConfig = {
   handler: (args?: string, context?: PiCommandContext) => Promise<void>;
 };
 
+type BeforeProviderRequestCallback = (
+  event: { type: "before_provider_request"; payload: unknown },
+  context?: { model?: PiModelSelection },
+) => unknown;
+
 describe("Pi extension registration", () => {
   test("uses ROLE_MODEL_ENDPOINT for runtime request commands when no explicit endpoint is passed", async () => {
     const commands: Array<{ name: string; config: RegisteredCommandConfig }> = [];
@@ -118,7 +123,7 @@ describe("Pi extension registration", () => {
       },
     });
 
-    await commands[0]?.config.handler("alias use role-model/auto", {
+    await commands[0]?.config.handler("alias use baseline.remote-only", {
       ui: { notify: () => undefined },
       isProjectTrusted: () => true,
     });
@@ -126,7 +131,7 @@ describe("Pi extension registration", () => {
     expect(activeModels).toEqual([
       expect.objectContaining({
         provider: "role-model",
-        id: "role-model/auto",
+        id: "baseline.remote-only",
       }),
     ]);
   });
@@ -177,9 +182,7 @@ describe("Pi extension registration", () => {
     ]);
   });
   test("injects provider requests with the resolved runtime taxonomy when available", async () => {
-    const callbacks: Array<
-      (event: { type: "before_provider_request"; payload: unknown }) => unknown
-    > = [];
+    const callbacks: BeforeProviderRequestCallback[] = [];
     const runtimeTaxonomy = {
       ...loadCompactTaxonomy(),
       manifest: {
@@ -217,7 +220,7 @@ describe("Pi extension registration", () => {
     const payload = await callbacks[0]?.({
       type: "before_provider_request",
       payload: {
-        model: "role-model/auto",
+        model: "baseline.remote-only",
         messages: [{ role: "user", content: "Implement this small bug fix." }],
       },
     });
@@ -234,9 +237,7 @@ describe("Pi extension registration", () => {
   });
 
   test("loads runtime task chunks for request candidate roles before injecting intent", async () => {
-    const callbacks: Array<
-      (event: { type: "before_provider_request"; payload: unknown }) => unknown
-    > = [];
+    const callbacks: BeforeProviderRequestCallback[] = [];
     const packageTaxonomy = loadCompactTaxonomy();
     const taskChunkRequests: string[] = [];
     const extension = createRoleModelExtension({
@@ -296,7 +297,7 @@ describe("Pi extension registration", () => {
     const payload = await callbacks[0]?.({
       type: "before_provider_request",
       payload: {
-        model: "role-model/auto",
+        model: "baseline.remote-only",
         messages: [
           { role: "user", content: "Implement this small bug fix and add a regression test." },
         ],
@@ -319,9 +320,7 @@ describe("Pi extension registration", () => {
   });
 
   test("loads runtime task chunks on the default endpoint path without requiring explicit endpoint config", async () => {
-    const callbacks: Array<
-      (event: { type: "before_provider_request"; payload: unknown }) => unknown
-    > = [];
+    const callbacks: BeforeProviderRequestCallback[] = [];
     const taskChunkRequests: string[] = [];
     const extension = createRoleModelExtension({
       discover: async () => ({
@@ -352,7 +351,7 @@ describe("Pi extension registration", () => {
     await callbacks[0]?.({
       type: "before_provider_request",
       payload: {
-        model: "role-model/auto",
+        model: "baseline.remote-only",
         messages: [
           { role: "user", content: "Implement this small bug fix and add a regression test." },
         ],
@@ -365,9 +364,7 @@ describe("Pi extension registration", () => {
   });
 
   test("refreshes effective taxonomy during command setup and alias refresh", async () => {
-    const callbacks: Array<
-      (event: { type: "before_provider_request"; payload: unknown }) => unknown
-    > = [];
+    const callbacks: BeforeProviderRequestCallback[] = [];
     const commands: Array<{ name: string; config: RegisteredCommandConfig }> = [];
     let contentRevision = "startup-taxonomy";
     const extension = createRoleModelExtension({
@@ -416,7 +413,7 @@ describe("Pi extension registration", () => {
     const payload = await callbacks[0]?.({
       type: "before_provider_request",
       payload: {
-        model: "role-model/auto",
+        model: "baseline.remote-only",
         messages: [{ role: "user", content: "Implement this small bug fix." }],
       },
     });
@@ -433,9 +430,7 @@ describe("Pi extension registration", () => {
   });
 
   test("injects provider requests for direct Role-Model model records", async () => {
-    const callbacks: Array<
-      (event: { type: "before_provider_request"; payload: unknown }) => unknown
-    > = [];
+    const callbacks: BeforeProviderRequestCallback[] = [];
     const extension = createRoleModelExtension({
       discover: async () => ({
         discovery: createDiscovery({
@@ -488,5 +483,52 @@ describe("Pi extension registration", () => {
         }),
       }),
     );
+  });
+
+  test("rejects foreign provider ids before sending Role-Model provider requests", async () => {
+    const callbacks: BeforeProviderRequestCallback[] = [];
+    const extension = createRoleModelExtension({
+      discover: async () => ({
+        discovery: createDiscovery(),
+        state: "ready",
+        warnings: [],
+        modelDiagnostics: [],
+      }),
+      fetchRuntimeTaskChunk: async () => [],
+      fetchRuntimeRoleSummaries: async () => [],
+    });
+
+    await extension({
+      registerProvider() {
+        // registered during startup discovery
+      },
+      registerCommand() {
+        // registered below startup discovery
+      },
+      on(event, callback) {
+        if (event === "before_provider_request") callbacks.push(callback);
+      },
+    });
+
+    await expect(
+      callbacks[0]?.(
+        {
+          type: "before_provider_request",
+          payload: {
+            model: "gpt-4o",
+            messages: [{ role: "user", content: "Reply with ok." }],
+          },
+        },
+        {
+          model: {
+            provider: "role-model",
+            id: "gpt-4o",
+            api: "openai-completions",
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          },
+        },
+      ),
+    ).rejects.toThrow(/foreign provider ids are not valid under provider role-model/i);
   });
 });

--- a/packages/pi-role-model/test/fixtures.ts
+++ b/packages/pi-role-model/test/fixtures.ts
@@ -4,7 +4,7 @@ export function createModelRecord(
   overrides: Partial<DownstreamOpenAIModelRecord> = {},
 ): DownstreamOpenAIModelRecord {
   return {
-    id: "role-model/auto",
+    id: "baseline.remote-only",
     object: "model",
     owned_by: "role-model",
     endpoint_ids: ["local"],
@@ -65,7 +65,7 @@ export function createDiscovery(
       note: "placeholder only",
     },
     models: [createModelRecord()],
-    setup: { recommendedModel: "role-model/auto", notes: ["Use discovery"] },
+    setup: { recommendedModel: "baseline.remote-only", notes: ["Use discovery"] },
     freshness: {
       generatedAt: "2026-06-22T00:00:00Z",
       catalogVersion: "test",

--- a/packages/pi-role-model/test/runtime-discovery.test.ts
+++ b/packages/pi-role-model/test/runtime-discovery.test.ts
@@ -74,7 +74,7 @@ describe("Role-Model runtime discovery", () => {
             object: "list",
             data: [
               {
-                id: "role-model/auto",
+                id: "role-model/baseline.remote-only",
                 object: "model",
                 owned_by: "role-model",
                 endpoint_ids: ["local"],
@@ -93,7 +93,8 @@ describe("Role-Model runtime discovery", () => {
     expect(calls).toContain("http://127.0.0.1:3456/v1/models");
     expect(result.state).toBe("fallback");
     expect(result.warnings?.join("\n")).toContain("compact /v1/models fallback");
-    expect(result.discovery.models[0]?.id).toBe("role-model/auto");
+    expect(result.discovery.models[0]?.id).toBe("baseline.remote-only");
+    expect(result.discovery.setup.recommendedModel).toBe("baseline.remote-only");
   });
 
   test("reports malformed rich discovery as incompatible without fallback", async () => {


### PR DESCRIPTION
## Summary
- improve `pi-role-model` command diagnostics and provider guidance so interactive slash commands and explicit provider prompts are documented truthfully
- make provider-relative Role-Model ids such as `baseline.remote-only` the canonical explicit-provider form while keeping `role-model/<alias>` compatibility-only
- add repo-owned invalid-model and invalid-endpoint diagnostics, plus lock the run-75 recursive planning artifacts for the implementation work

## Why
Users were hitting silent or misleading Pi behavior around `/role-model` commands, foreign model ids like `gpt-4o`, and fallback discovery ids. The package needed to own the help text and validation boundary instead of letting those failures fall through to generic runtime errors.

## Impact
- `status` and `doctor` now surface supported command mode, supported prompt path, canonical model-id guidance, and classified remediation
- foreign ids under `--provider role-model` now emit repo-owned help before Pi falls through to the runtime error path
- compact fallback discovery now normalizes qualified ids to provider-relative ids
- README, skill, and docs-site guidance now match actual Pi behavior

## Validation
- `corepack pnpm --filter @try-works/pi-role-model build`
- `corepack pnpm --filter @try-works/pi-role-model test`
- live Pi QA from the run-75 worktree:
  - interactive `/role-model status`, `/role-model doctor`, `/role-model setup`, `/role-model alias list`, `/role-model alias recommended`
  - `pi --list-models role-model`
  - `pi --no-session --provider role-model --model baseline.remote-only -p "Reply with ok."`
  - `pi --no-session --provider role-model --model gpt-4o -p "Reply with ok."`
  - `pi --no-session -p "/role-model status"`
  - interactive invalid-endpoint probe using `ROLE_MODEL_ENDPOINT=http://127.0.0.1:1`

## Notes
- Pi on Windows still asserts after successful `pi list` output; that remains an upstream Pi defect.
- During late live QA on Friday, July 17, 2026, the external runtime stopped answering `/healthz`, so the final request-history receipt cross-check remained runtime-state-limited rather than package-limited.