### PR TITLE
fix pi role-model lint regressions

### DIFF
--- a/packages/pi-role-model/src/commands.ts
+++ b/packages/pi-role-model/src/commands.ts
@@ -9,8 +9,8 @@ import { RoleModelDiscoveryError } from "./runtime-discovery.js";
 import type { RoleModelRecentRequest, RoleModelRequestInspection } from "./runtime-inspection.js";
 import type {
   DiscoveryResult,
-  PiModelRef,
   PiCommandContext,
+  PiModelRef,
   PiModelSelection,
   RoleModelCommandResult,
   RoleModelModelDiagnostic,
@@ -239,10 +239,7 @@ function discoveryCheck(state: RoleModelDiscoveryError["state"]): string {
   }
 }
 
-function formatDiscoveryFailure(
-  error: unknown,
-  commandName: "status" | "doctor",
-): string {
+function formatDiscoveryFailure(error: unknown, commandName: "status" | "doctor"): string {
   if (error instanceof RoleModelDiscoveryError) {
     return [
       `${commandName}: fail`,

--- a/packages/pi-role-model/src/model-guidance.ts
+++ b/packages/pi-role-model/src/model-guidance.ts
@@ -14,9 +14,7 @@ const LIKELY_FOREIGN_PROVIDER_MODEL_PATTERNS = [
   /^grok-/i,
 ] as const;
 
-export type InvalidRoleModelModelClassification =
-  | "foreign-provider-model"
-  | "unknown-model-id";
+export type InvalidRoleModelModelClassification = "foreign-provider-model" | "unknown-model-id";
 
 export interface InvalidRoleModelModelDiagnostic {
   classification: InvalidRoleModelModelClassification;
@@ -40,9 +38,7 @@ export function findRoleModelDiscoveryModel(
   );
 }
 
-export function recommendedRoleModelModelId(
-  discovery: DownstreamOpenAIDiscovery,
-): string | null {
+export function recommendedRoleModelModelId(discovery: DownstreamOpenAIDiscovery): string | null {
   return discovery.setup.recommendedModel ?? discovery.models[0]?.id ?? null;
 }
 

--- a/packages/pi-role-model/src/types.ts
+++ b/packages/pi-role-model/src/types.ts
@@ -128,9 +128,7 @@ export interface PiExtensionAPI {
     handler: (
       event: { type: "before_provider_request"; payload: unknown },
       context?: PiExtensionContext,
-    ) =>
-      | unknown
-      | Promise<unknown>,
+    ) => unknown | Promise<unknown>,
   ) => void;
   setModel?: (model: PiModelSelection) => Promise<boolean>;
 }

--- a/packages/pi-role-model/test/docs-and-safety.test.ts
+++ b/packages/pi-role-model/test/docs-and-safety.test.ts
@@ -51,7 +51,9 @@ describe("Pi installation docs, skill, and safety guardrails", () => {
     expect(readme).toContain("/role-model alias choose");
     expect(readme).toContain("/role-model alias use");
     expect(readme).toContain("baseline.remote-only");
-    expect(readme).toContain('pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"');
+    expect(readme).toContain(
+      'pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"',
+    );
     expect(readme).toContain('pi -p "/role-model status"');
     expect(readme).toContain("debug-only");
     expect(packageReadme).toContain("pi install npm:@try-works/pi-role-model");
@@ -63,12 +65,16 @@ describe("Pi installation docs, skill, and safety guardrails", () => {
     expect(packageReadme).toContain("allowRemote");
     expect(packageReadme).toContain("active model");
     expect(packageReadme).toContain("baseline.remote-only");
-    expect(packageReadme).toContain('pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"');
+    expect(packageReadme).toContain(
+      'pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"',
+    );
     expect(packageReadme).toContain('pi -p "/role-model status"');
     expect(packageReadme).toContain("compatibility-only");
     expect(packageReadme).toContain("debug-only");
     expect(docsSite).toContain("baseline.remote-only");
-    expect(docsSite).toContain('pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"');
+    expect(docsSite).toContain(
+      'pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"',
+    );
     expect(docsSite).toContain('pi -p "/role-model status"');
     expect(docsSite).toContain("compatibility-only");
     expect(docsSite).toContain("upstream Pi bug");


### PR DESCRIPTION
## Summary
- apply the missing Biome formatting and import ordering fixes for the pi role-model follow-up
- keep the hotfix limited to the four files that caused the failed CI lint step on main
- verify the fix locally with ci:check and runtime:test-router before opening this PR

## Testing
- corepack pnpm run ci:check
- corepack pnpm run runtime:test-router