### PR TITLE
run-76: auto-reassign controller on eject

### DIFF
--- a/.recursive/run/76-configured-model-membership-authority-and-eject-convergence/addenda/02-to-be-plan.controller-auto-reassignment-on-eject.addendum-01.md
+++ b/.recursive/run/76-configured-model-membership-authority-and-eject-convergence/addenda/02-to-be-plan.controller-auto-reassignment-on-eject.addendum-01.md
@@ -1,0 +1,272 @@
+Run: `/.recursive/run/76-configured-model-membership-authority-and-eject-convergence/`
+Phase: `02 TO-BE Plan`
+Status: `DRAFT`
+Addendum: `01`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/76-configured-model-membership-authority-and-eject-convergence/00-requirements.md`
+- `/.recursive/run/76-configured-model-membership-authority-and-eject-convergence/02-to-be-plan.md`
+- `/.recursive/STATE.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/memory/domains/runtime-routing-and-provider-capabilities.md`
+- current controller and eject implementation in:
+  - `role-model-router/apps/runtime-host-bridge/src/configured-model-membership.ts`
+  - `role-model-router/apps/runtime-host-bridge/src/index.ts`
+  - `role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts`
+  - `role-model-router/apps/runtime-host-bridge/test/remove-account-model.test.ts`
+  - `role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts`
+  - `role-model-router/apps/runtime-ui/app/lib/runtime-api.test.ts`
+Outputs:
+- this addendum
+Scope note: Expand run 76 so ejecting a configured model that is explicitly referenced by `controller` no longer fails when the controller can be resolved deterministically from the post-eject runtime state. The fix must extend the configured-membership authority contract rather than adding a one-off controller branch, remain provider-agnostic, use strict TDD, and keep account-managed and runtime-config-managed eject behavior aligned.
+
+## TODO
+
+- [x] Record the controller-conflict gap left by run 76
+- [x] Define a systematic reference-resolution extension instead of a special case
+- [x] Define deterministic controller replacement and clear semantics
+- [x] Keep account-managed and config-managed eject flows aligned
+- [x] Define strict RED/GREEN implementation slices
+- [x] Complete Coverage Gate and Approval Gate
+
+## Problem Addendum
+
+Run 76 correctly established that configured-model membership is authoritative and that explicit references must be handled deterministically before eject mutates membership. The remaining gap is that `controller` was classified only as an unconditional blocking explicit reference.
+
+That is too strict. `controller` is backend-mediated runtime control-plane state with a deterministic convergence path. When the ejected model is the current controller, the runtime should resolve that explicit reference against the post-eject projected world instead of failing with `configured_model_reference_conflict: controller` and requiring a separate manual mutation first.
+
+This addendum must refine the explicit-reference contract without weakening it:
+
+- custom aliases remain explicit blocking references
+- `difficultyClassifier` remains an explicit blocking reference
+- `controller` becomes a resolved explicit reference with a documented reassignment-or-clear policy
+
+## Fixed Decisions
+
+1. `controller` is no longer an unconditional `block` reference during eject.
+2. Explicit references now use a policy-driven resolution contract rather than a boolean blocking split.
+3. `controller` is the first explicit reference to use `auto-reassign-or-clear`.
+4. Replacement selection is derived from the post-eject projected registry and membership state.
+5. If no surviving valid controller candidate exists, controller state is cleared and eject still succeeds.
+6. The change must remain provider-agnostic and must not create separate account-managed versus config-managed semantics.
+
+## Addendum Requirements
+
+### `A1` Controller-backed eject must converge automatically
+
+Description:
+Eject should no longer fail solely because the target model is the active controller.
+
+Acceptance criteria:
+- eject of a controller-backed configured model does not fail solely because `controller` points at that model
+- if a valid replacement exists after removal, controller is reassigned during the same lifecycle mutation
+- if no valid replacement exists after removal, controller is cleared during the same lifecycle mutation
+- no success result leaves the removed model still referenced by controller state
+
+### `A2` Controller resolution must be projected from post-eject truth
+
+Description:
+Controller reassignment must be computed from the world that will exist after the configured membership is removed, not from stale pre-eject state.
+
+Acceptance criteria:
+- replacement selection excludes the target `{providerAccountId, modelId}` endpoints before resolution
+- replacement selection reads from the surviving effective registry and controller-eligibility rules
+- restart and rebuild after success preserve the reassigned or cleared controller outcome instead of resurrecting the removed model
+
+### `A3` Replacement selection must be deterministic and reusable
+
+Description:
+The backend must expose one deterministic controller-resolution helper rather than embedding ad hoc ordering at individual call sites.
+
+Acceptance criteria:
+- the same projected state always yields the same controller resolution result
+- the selection rule is documented and test-covered
+- the helper is reusable by future explicit references that may need reassignment semantics
+
+### `A4` Account-managed and runtime-config-managed eject must share the same resolution semantics
+
+Description:
+Both owner types must use the same explicit-reference resolution contract, with owner-specific persistence only at the commit boundary.
+
+Acceptance criteria:
+- both eject flows resolve controller outcome through the same projected-state helper
+- rollback restores prior controller state if the owner mutation fails before commit
+- post-success reads and receipts are consistent across both owner types
+
+### `A5` The explicit-reference contract must remain extension-safe
+
+Description:
+This change must strengthen the run 76 framework instead of carving out a controller-only exception.
+
+Acceptance criteria:
+- explicit references support policies `block`, `auto-prune`, and `auto-reassign-or-clear`
+- `controller` is implemented through that framework
+- custom aliases still block and `difficultyClassifier` still blocks unless a later addendum changes them
+- no provider-specific or endpoint-family-specific logic is introduced
+
+## Reference-Resolution Contract Extension
+
+Configured-model reference policies become:
+
+- `block`
+- `auto-prune`
+- `auto-reassign-or-clear`
+
+Policy meanings:
+
+- `block`: eject fails before mutation
+- `auto-prune`: backend-owned derived state is removed as part of convergence
+- `auto-reassign-or-clear`: explicit state is rewritten against the post-eject projected state; if no valid replacement exists, clear the reference
+
+Initial mapping under this addendum:
+
+- custom alias -> `block`
+- `difficultyClassifier` -> `block`
+- `controller` -> `auto-reassign-or-clear`
+
+## Deterministic Controller Resolution Contract
+
+Controller resolution runs against the post-eject projected state:
+
+1. build the projected surviving registry and endpoint set after removing the target `{providerAccountId, modelId}` endpoints
+2. filter to controller-eligible endpoints under the existing execution-mode compatibility rules
+3. choose:
+   - the existing default-controller guidance endpoint if it still survives and remains eligible
+   - otherwise the first surviving eligible endpoint in effective registry order
+   - otherwise clear controller
+
+This intentionally reuses the runtime's existing controller fallback semantics instead of introducing a second ranking model.
+
+## Planned Changes by File
+
+- `role-model-router/apps/runtime-host-bridge/src/configured-model-membership.ts`
+  - extend reference descriptors and helpers so explicit references can declare policy-driven resolution instead of only blocking behavior
+
+- `role-model-router/apps/runtime-host-bridge/src/index.ts`
+  - add projected-state controller-resolution helper
+  - integrate `auto-reassign-or-clear` into configured-model eject preflight and owner mutation planning
+  - keep non-controller explicit blockers unchanged
+
+- `role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts`
+  - add helper support to rewrite or clear controller config in config-managed eject mutations
+
+- `role-model-router/apps/runtime-host-bridge/test/remove-account-model.test.ts`
+  - add account-managed controller auto-reassignment coverage
+  - add account-managed controller clear-on-last coverage
+  - preserve negative controls for sibling accounts and non-controller eject behavior
+
+- `role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts`
+  - add config-managed controller auto-reassignment coverage
+  - add config-managed controller clear-on-last coverage
+  - preserve blocking behavior for `difficultyClassifier` and custom aliases
+
+- `role-model-router/apps/runtime-ui/app/lib/runtime-api.test.ts`
+  - update client expectations so controller-backed eject success is no longer surfaced as a 409 conflict
+
+## Implementation Steps
+
+1. Extend the configured-membership reference contract so explicit references can declare policy-driven resolution behavior.
+2. Add RED tests proving controller-backed eject currently blocks and should instead reassign or clear.
+3. Implement one backend helper that computes projected post-eject controller outcome.
+4. Thread that helper through both account-managed and runtime-config-managed eject flows.
+5. Preserve blocking behavior for custom aliases and `difficultyClassifier`.
+6. Run focused host and UI suites, then broader affected test floors.
+
+## Implementation Sub-phases
+
+### SP-A - Reference policy extension
+
+- Requirements: `A3`, `A5`
+- RED: pure or ownership tests fail because explicit references cannot express `auto-reassign-or-clear`
+- GREEN: extend the configured-membership reference contract to support policy-driven explicit-reference resolution
+- Gate: reference policy tests pass with no eject behavior changed yet
+
+### SP-B - Account-managed controller-backed eject
+
+- Requirements: `A1`, `A2`, `A3`, `A4`
+- RED: account-managed eject of the active controller fails with `configured_model_reference_conflict`, does not reassign when a surviving candidate exists, and does not clear when no candidate exists
+- GREEN: implement projected controller resolution in the account-managed eject path
+- Gate: focused `remove-account-model` tests pass
+
+### SP-C - Runtime-config-managed controller-backed eject
+
+- Requirements: `A1`, `A2`, `A4`, `A5`
+- RED: config-managed eject of the active controller still blocks or preserves stale `controller` config
+- GREEN: implement the same projected controller resolution semantics in config-managed eject and rollback paths
+- Gate: focused `backend-unified-runtime-config` tests pass
+
+### SP-D - API and restart truth
+
+- Requirements: `A1`, `A2`, `A4`
+- RED: client parsing and post-restart truth still reflect conflict or stale controller state
+- GREEN: align API/client behavior and restart truth with the resolved controller outcome
+- Gate: focused runtime API and affected host restart coverage pass
+
+## Testing Strategy
+
+- TDD Mode: `strict`
+- Every production edit requires a preceding failing owning test and separate RED/GREEN evidence.
+
+Focused RED/GREEN commands:
+
+```powershell
+corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/remove-account-model.test.ts
+corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/backend-unified-runtime-config.test.ts
+corepack pnpm --filter @role-model-router/runtime-ui exec vitest run app/lib/runtime-api.test.ts
+```
+
+Broader verification:
+
+```powershell
+corepack pnpm --filter @role-model-router/runtime-host-bridge test
+corepack pnpm --filter @role-model-router/runtime-ui test
+corepack pnpm run runtime:test-critical
+```
+
+## Manual QA Addendum
+
+1. Start with two configured models where model A is the current controller.
+2. Eject model A through the real UI/API path.
+3. Verify:
+   - eject succeeds
+   - model A disappears from configured inventory
+   - controller moves to model B
+4. Restart twice and verify model A stays absent and model B remains controller.
+5. Repeat with one configured controller-backed model only and verify:
+   - eject succeeds
+   - controller becomes unassigned
+   - restart preserves the unassigned state
+6. Run a blocker control where a custom alias still references the target model and verify eject still returns 409.
+
+## Requirement Mapping
+
+- `R2`, `A1`, `A4` -> authoritative eject convergence plus owner-aligned controller resolution
+- `R3`, `A2` -> rebuild/restart preserve the resolved controller outcome without membership resurrection
+- `R4`, `A5` -> explicit-reference contract is strengthened systematically instead of bypassed
+- `R6` -> API/UI truth reflects reassigned or cleared controller state immediately
+- `R8`, `A3` -> strict RED/GREEN coverage around deterministic reusable controller resolution
+
+## Earlier Phase Reconciliation
+
+- `00-requirements.md` remains valid: configured membership stays authoritative and eject remains a durable lifecycle mutation.
+- `02-to-be-plan.md` remains valid except for its prior classification of `controller` as an unconditional explicit blocker.
+- This addendum refines only the explicit-reference resolution contract for `controller`; it does not relax custom alias or `difficultyClassifier` blockers and does not change the configured-membership authority contract.
+
+## Coverage Gate
+
+- [x] The controller-conflict gap is explicit
+- [x] The fix is systematic rather than a one-off controller branch
+- [x] Deterministic replacement and no-candidate clear behavior are defined
+- [x] Account-managed and config-managed paths are both covered
+- [x] Strict TDD slices and verification commands are explicit
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] Scope is limited to controller-backed eject behavior within run 76
+- [x] The design remains provider-agnostic and future-proof
+- [x] Blocking behavior for other explicit references remains explicit
+- [x] The implementation path is testable and bounded
+
+Approval: PASS

--- a/role-model-router/apps/runtime-host-bridge/src/configured-model-membership.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/configured-model-membership.ts
@@ -7,7 +7,7 @@ export interface ConfiguredModelReferenceDescriptor {
   readonly kind: string;
   readonly owner: string;
   readonly path: string;
-  readonly policy: "block" | "auto-prune";
+  readonly policy: "block" | "auto-prune" | "auto-reassign-or-clear";
   readonly providerAccountId?: string;
   readonly modelId?: string;
   readonly endpointId?: string;
@@ -28,25 +28,68 @@ export function configuredModelKey(value: ConfiguredModelKey): string {
   return `${value.providerAccountId}\u0000${value.modelId}`;
 }
 
+function matchesConfiguredModelReferenceTarget(input: {
+  readonly target: ConfiguredModelKey;
+  readonly suppliedBySibling: boolean;
+  readonly reference: ConfiguredModelReferenceDescriptor;
+  readonly targetEndpointIds?: ReadonlySet<string>;
+}): boolean {
+  return (
+    (input.reference.providerAccountId === input.target.providerAccountId &&
+      input.reference.modelId === input.target.modelId) ||
+    (input.reference.providerAccountId === undefined &&
+      !input.suppliedBySibling &&
+      input.reference.modelId === input.target.modelId) ||
+    (input.reference.endpointId !== undefined &&
+      input.targetEndpointIds?.has(input.reference.endpointId) === true)
+  );
+}
+
+function computeSuppliedBySibling(
+  configuredKeys: readonly ConfiguredModelKey[],
+  target: ConfiguredModelKey,
+): boolean {
+  return configuredKeys.some(
+    (entry) =>
+      entry.modelId === target.modelId && entry.providerAccountId !== target.providerAccountId,
+  );
+}
+
 export function findConfiguredModelBlockingReferences(input: {
   readonly target: ConfiguredModelKey;
   readonly configuredKeys: readonly ConfiguredModelKey[];
   readonly references: readonly ConfiguredModelReferenceDescriptor[];
   readonly targetEndpointIds?: ReadonlySet<string>;
 }): ConfiguredModelReferenceDescriptor[] {
-  const suppliedBySibling = input.configuredKeys.some(
-    (entry) =>
-      entry.modelId === input.target.modelId &&
-      entry.providerAccountId !== input.target.providerAccountId,
-  );
+  const suppliedBySibling = computeSuppliedBySibling(input.configuredKeys, input.target);
   return input.references.filter(
     (reference) =>
       reference.policy === "block" &&
-      ((reference.providerAccountId === input.target.providerAccountId &&
-        reference.modelId === input.target.modelId) ||
-        (reference.providerAccountId === undefined &&
-          !suppliedBySibling &&
-          reference.modelId === input.target.modelId) ||
-        (reference.endpointId !== undefined && input.targetEndpointIds?.has(reference.endpointId))),
+      matchesConfiguredModelReferenceTarget({
+        target: input.target,
+        suppliedBySibling,
+        reference,
+        targetEndpointIds: input.targetEndpointIds,
+      }),
+  );
+}
+
+export function findConfiguredModelReferencesByPolicy(input: {
+  readonly target: ConfiguredModelKey;
+  readonly configuredKeys: readonly ConfiguredModelKey[];
+  readonly references: readonly ConfiguredModelReferenceDescriptor[];
+  readonly policy: ConfiguredModelReferenceDescriptor["policy"];
+  readonly targetEndpointIds?: ReadonlySet<string>;
+}): ConfiguredModelReferenceDescriptor[] {
+  const suppliedBySibling = computeSuppliedBySibling(input.configuredKeys, input.target);
+  return input.references.filter(
+    (reference) =>
+      reference.policy === input.policy &&
+      matchesConfiguredModelReferenceTarget({
+        target: input.target,
+        suppliedBySibling,
+        reference,
+        targetEndpointIds: input.targetEndpointIds,
+      }),
   );
 }

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -66,6 +66,7 @@ import {
   clearAllObservedBenchmarkData,
   clearBenchmarkRunArtifacts,
   clearObservedBenchmarkDataForEndpoint,
+  deleteRuntimeControllerAssignment,
   initializeSqliteMemory,
   insertSwapEvent,
   listProviderAccounts,
@@ -162,7 +163,10 @@ import {
   readLatestBenchmarkSummary,
   writeBenchmarkPreferences,
 } from "./benchmark-summary.js";
-import { findConfiguredModelBlockingReferences } from "./configured-model-membership.js";
+import {
+  findConfiguredModelBlockingReferences,
+  findConfiguredModelReferencesByPolicy,
+} from "./configured-model-membership.js";
 import { looksLikeInlineApiKey, resolveEnvCredentialRef } from "./credential-ref-env.js";
 import {
   buildAccountEndpointRoleBindings,
@@ -236,6 +240,7 @@ import {
   removeUnifiedRuntimeConfigProviderModel,
   renderUnifiedRuntimeConfigText,
   resolveUnifiedRuntimeObservedDataConfig,
+  rewriteUnifiedRuntimeConfigController,
 } from "./unified-runtime-config.js";
 
 interface OpenAIChatCompletionsTool {
@@ -18953,8 +18958,9 @@ export async function createRuntimeBridgeBackend(
       listener(event);
     }
   };
-  const getDefaultControllerAssignment = (): BridgeControllerAssignment | null => {
-    const effectiveRegistry = getRouterEffectiveRegistry();
+  const resolveDefaultControllerAssignment = (
+    effectiveRegistry: EndpointRegistryResult,
+  ): BridgeControllerAssignment | null => {
     const guidance = summarizeRouterGuidance({
       routingModel,
       routableEndpointIds: effectiveRegistry.endpoints.map(
@@ -18973,11 +18979,71 @@ export async function createRuntimeBridgeBackend(
     }
     return toControllerAssignmentFromEndpoint(fallbackEndpoint);
   };
+  const getDefaultControllerAssignment = (): BridgeControllerAssignment | null =>
+    resolveDefaultControllerAssignment(getRouterEffectiveRegistry());
+  const resolveProjectedControllerAssignment = (
+    excludedEndpointIds: ReadonlySet<string>,
+  ): BridgeControllerAssignment | null => {
+    const effectiveRegistry = getRouterEffectiveRegistry();
+    const candidates = effectiveRegistry.endpoints
+      .filter((endpoint) => !excludedEndpointIds.has(endpoint.identity.endpoint_id))
+      .map((endpoint) => toControllerAssignmentFromEndpoint(endpoint));
+    const candidateByEndpointId = new Map(
+      candidates.map((candidate) => [candidate.endpointId, candidate]),
+    );
+    for (const endpoint of runtimeEndpoints) {
+      if (
+        excludedEndpointIds.has(endpoint.endpointId) ||
+        candidateByEndpointId.has(endpoint.endpointId)
+      ) {
+        continue;
+      }
+      candidates.push({
+        scope: "global",
+        endpointId: endpoint.endpointId,
+        modelId: endpoint.modelId,
+        sourceType: telemetrySourceTypeFromEndpointKind(endpoint.endpointKind),
+      });
+      candidateByEndpointId.set(endpoint.endpointId, candidates[candidates.length - 1]);
+    }
+    const guidance = summarizeRouterGuidance({
+      routingModel,
+      routableEndpointIds: candidates.map((candidate) => candidate.endpointId),
+    });
+    if (guidance.endpointId) {
+      const guided = candidateByEndpointId.get(guidance.endpointId);
+      if (guided) {
+        return guided;
+      }
+    }
+    return candidates[0] ?? null;
+  };
   const readPersistedControllerAssignment = () =>
     readRuntimeControllerAssignment({
       databasePath: initialization.databasePath,
       scope: "global",
     });
+  const writeResolvedControllerAssignment = (
+    controller: BridgeControllerAssignment | null,
+  ): void => {
+    if (controller) {
+      upsertRuntimeControllerAssignment({
+        databasePath: initialization.databasePath,
+        assignment: {
+          scope: "global",
+          endpointId: controller.endpointId,
+          modelId: controller.modelId,
+          sourceType: controller.sourceType,
+          updatedAtMs: Date.now(),
+        },
+      });
+      return;
+    }
+    deleteRuntimeControllerAssignment({
+      databasePath: initialization.databasePath,
+      scope: "global",
+    });
+  };
   const asObjectRecord = (value: unknown): Record<string, unknown> | null =>
     typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
   const asStringValue = (value: unknown): string | null =>
@@ -22404,14 +22470,20 @@ export async function createRuntimeBridgeBackend(
         return configuredModelEjectResult("absent", false, true, {}, false);
       }
       return withUnifiedConfigMutationLock(async () => {
-        const targetEndpointIds = new Set(
-          runtimeEndpoints
+        const targetEndpointIds = new Set([
+          ...runtimeEndpoints
             .filter(
               (endpoint) =>
                 endpoint.providerAccountId === providerAccountId && endpoint.modelId === modelId,
             )
             .map((endpoint) => endpoint.endpointId),
-        );
+          ...currentRegistrySources.cloud
+            .filter(
+              (endpoint) =>
+                endpoint.providerAccountId === providerAccountId && endpoint.modelId === modelId,
+            )
+            .map((endpoint) => endpoint.endpointId),
+        ]);
         const explicitReferences = [
           ...(currentUnifiedRuntimeConfig?.modelAliases ?? [])
             .filter(
@@ -22431,7 +22503,7 @@ export async function createRuntimeBridgeBackend(
                   kind: "controller",
                   owner: "unified-runtime-config",
                   path: "controller",
-                  policy: "block" as const,
+                  policy: "auto-reassign-or-clear" as const,
                   modelId: currentUnifiedRuntimeConfig.controller.modelId ?? undefined,
                   endpointId: currentUnifiedRuntimeConfig.controller.endpointId ?? undefined,
                 },
@@ -22451,15 +22523,23 @@ export async function createRuntimeBridgeBackend(
               ]
             : []),
         ];
+        const configuredKeys = currentAccounts.flatMap((account) =>
+          account.allowedModels.map((configuredModelId) => ({
+            providerAccountId: account.providerAccountId,
+            modelId: configuredModelId,
+          })),
+        );
         const blockingReferences = findConfiguredModelBlockingReferences({
           target: { providerAccountId, modelId },
-          configuredKeys: currentAccounts.flatMap((account) =>
-            account.allowedModels.map((configuredModelId) => ({
-              providerAccountId: account.providerAccountId,
-              modelId: configuredModelId,
-            })),
-          ),
+          configuredKeys,
           references: explicitReferences,
+          targetEndpointIds,
+        });
+        const controllerReferences = findConfiguredModelReferencesByPolicy({
+          target: { providerAccountId, modelId },
+          configuredKeys,
+          references: explicitReferences,
+          policy: "auto-reassign-or-clear",
           targetEndpointIds,
         });
         const modelSuppliedBySibling = currentAccounts.some(
@@ -22475,10 +22555,28 @@ export async function createRuntimeBridgeBackend(
         if (blockingReferences.length > 0) {
           throw new ConfiguredModelReferenceConflictError(blockingReferences);
         }
+        const resolvedControllerAssignment =
+          controllerReferences.length > 0
+            ? resolveProjectedControllerAssignment(targetEndpointIds)
+            : null;
+        const nextUnifiedRuntimeConfig =
+          currentUnifiedRuntimeConfig && controllerReferences.length > 0
+            ? rewriteUnifiedRuntimeConfigController(
+                currentUnifiedRuntimeConfig,
+                resolvedControllerAssignment
+                  ? {
+                      endpointId: resolvedControllerAssignment.endpointId,
+                      modelId: resolvedControllerAssignment.modelId,
+                      sourceType: resolvedControllerAssignment.sourceType,
+                    }
+                  : null,
+              )
+            : currentUnifiedRuntimeConfig;
         const configOwnsAccount =
           currentUnifiedRuntimeConfig?.liteLLM.providers.some(
             (provider) => `${provider.providerId}.litellm` === providerAccountId,
           ) ?? false;
+        const previousPersistedController = readPersistedControllerAssignment();
         if (configOwnsAccount && currentUnifiedRuntimeConfig) {
           if (!currentUnifiedRuntimeConfig) {
             throw new Error("Runtime config disappeared while waiting for its mutation lock.");
@@ -22488,6 +22586,14 @@ export async function createRuntimeBridgeBackend(
             providerAccountId,
             modelId,
           );
+          const nextConfig =
+            mutation.removed && nextUnifiedRuntimeConfig
+              ? removeUnifiedRuntimeConfigProviderModel(
+                  nextUnifiedRuntimeConfig,
+                  providerAccountId,
+                  modelId,
+                ).config
+              : mutation.config;
           if (!mutation.removed) {
             return configuredModelEjectResult(
               "runtime-config-managed",
@@ -22512,7 +22618,7 @@ export async function createRuntimeBridgeBackend(
           const previousEndpoints = runtimeEndpoints.filter(
             (endpoint) => endpoint.providerAccountId === providerAccountId,
           );
-          const nextText = renderUnifiedRuntimeConfigText(mutation.config);
+          const nextText = renderUnifiedRuntimeConfigText(nextConfig);
           try {
             await writeConfigTextAtomically(options.unifiedRuntimeConfigPath, nextText);
             persistOperatorIntent(operatorIntentLocation, (intent) =>
@@ -22521,8 +22627,9 @@ export async function createRuntimeBridgeBackend(
             deleteRuntimeEndpointsByModelId(initialization.databasePath, modelId, [
               providerAccountId,
             ]);
+            writeResolvedControllerAssignment(resolvedControllerAssignment);
             const projectedModelIds =
-              mutation.config.liteLLM.providers
+              nextConfig.liteLLM.providers
                 .find((provider) => `${provider.providerId}.litellm` === providerAccountId)
                 ?.modelMappings.map((mapping) => mapping.modelId) ?? [];
             const projectedAccount = currentAccounts.find(
@@ -22542,11 +22649,23 @@ export async function createRuntimeBridgeBackend(
                 },
               });
             }
-            await applyUnifiedRuntimeConfigState(mutation.config);
+            await applyUnifiedRuntimeConfigState(nextConfig);
           } catch (error) {
             try {
               await writeConfigTextAtomically(options.unifiedRuntimeConfigPath, previousText);
               await applyUnifiedRuntimeConfigState(previousConfig);
+              writeResolvedControllerAssignment(
+                previousPersistedController
+                  ? {
+                      scope: "global",
+                      endpointId: previousPersistedController.endpointId,
+                      modelId: previousPersistedController.modelId,
+                      sourceType:
+                        previousPersistedController.sourceType === "remote" ? "remote" : "local",
+                      updatedAtMs: previousPersistedController.updatedAtMs,
+                    }
+                  : null,
+              );
               if (previousAccount) {
                 upsertSqliteProviderAccount({
                   databasePath: initialization.databasePath,
@@ -22662,6 +22781,14 @@ export async function createRuntimeBridgeBackend(
           (endpoint) =>
             endpoint.providerAccountId === providerAccountId && endpoint.modelId === modelId,
         );
+        const runtimeConfigChanged =
+          nextUnifiedRuntimeConfig !== null &&
+          nextUnifiedRuntimeConfig !== currentUnifiedRuntimeConfig;
+        const previousConfig = currentUnifiedRuntimeConfig;
+        const previousConfigText =
+          runtimeConfigChanged && options.unifiedRuntimeConfigPath
+            ? await readFile(options.unifiedRuntimeConfigPath, "utf8")
+            : null;
         try {
           persistOperatorIntent(operatorIntentLocation, (intent) =>
             removeRemoteActivationsByConfiguredModel(intent, providerAccountId, modelId),
@@ -22669,6 +22796,17 @@ export async function createRuntimeBridgeBackend(
           deleteRuntimeEndpointsByModelId(initialization.databasePath, modelId, [
             providerAccountId,
           ]);
+          if (
+            runtimeConfigChanged &&
+            nextUnifiedRuntimeConfig &&
+            options.unifiedRuntimeConfigPath
+          ) {
+            await writeConfigTextAtomically(
+              options.unifiedRuntimeConfigPath,
+              renderUnifiedRuntimeConfigText(nextUnifiedRuntimeConfig),
+            );
+            writeResolvedControllerAssignment(resolvedControllerAssignment);
+          }
           if (!validatedAccount) {
             deleteProviderAccountsById(initialization.databasePath, [providerAccountId]);
           } else {
@@ -22677,7 +22815,11 @@ export async function createRuntimeBridgeBackend(
               account: validatedAccount,
             });
           }
-          rebuildCurrentState();
+          if (runtimeConfigChanged && nextUnifiedRuntimeConfig) {
+            await applyUnifiedRuntimeConfigState(nextUnifiedRuntimeConfig);
+          } else {
+            rebuildCurrentState();
+          }
           return configuredModelEjectResult("account-managed", validatedAccount === null, false, {
             modelRoleBindings:
               (existingAccount.modelRoleBindings?.length ?? 0) - nextModelRoleBindings.length,
@@ -22704,7 +22846,29 @@ export async function createRuntimeBridgeBackend(
             } else {
               await rm(resolveOperatorIntentPath(operatorIntentLocation), { force: true });
             }
-            rebuildCurrentState();
+            if (
+              runtimeConfigChanged &&
+              previousConfigText &&
+              previousConfig &&
+              options.unifiedRuntimeConfigPath
+            ) {
+              await writeConfigTextAtomically(options.unifiedRuntimeConfigPath, previousConfigText);
+              writeResolvedControllerAssignment(
+                previousPersistedController
+                  ? {
+                      scope: "global",
+                      endpointId: previousPersistedController.endpointId,
+                      modelId: previousPersistedController.modelId,
+                      sourceType:
+                        previousPersistedController.sourceType === "remote" ? "remote" : "local",
+                      updatedAtMs: previousPersistedController.updatedAtMs,
+                    }
+                  : null,
+              );
+              await applyUnifiedRuntimeConfigState(previousConfig);
+            } else {
+              rebuildCurrentState();
+            }
           } catch (rollbackError) {
             throw new ConfiguredModelEjectMutationError(
               "configured_model_eject_indeterminate",

--- a/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/unified-runtime-config.ts
@@ -234,6 +234,27 @@ export function removeUnifiedRuntimeConfigProviderModel(
   };
 }
 
+export function rewriteUnifiedRuntimeConfigController(
+  config: UnifiedRuntimeConfig,
+  controller: Pick<UnifiedRuntimeControllerConfig, "endpointId" | "modelId" | "sourceType"> | null,
+): UnifiedRuntimeConfig {
+  if (controller === null) {
+    const { controller: _controller, ...rest } = config;
+    return rest;
+  }
+
+  return {
+    ...config,
+    controller: {
+      enabled: config.controller?.enabled ?? true,
+      sourceType: controller.sourceType,
+      endpointId: controller.endpointId,
+      modelId: controller.modelId,
+      timeoutMs: config.controller?.timeoutMs ?? DEFAULT_UNIFIED_RUNTIME_CONTROLLER_TIMEOUT_MS,
+    },
+  };
+}
+
 interface RawLlamaSwapModel {
   readonly path?: string;
   readonly capabilities?: readonly string[];

--- a/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
@@ -104,6 +104,198 @@ litellm_proxy:
     await restarted.shutdown();
   });
 
+  test("reassigns the controller when config-owned eject removes the active controller model", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "role-model-run76-config-controller-reassign-"),
+    );
+    tempRoots.push(tempRoot);
+    const runtimeStateRoot = path.join(tempRoot, "state");
+    const unifiedRuntimeConfigPath = path.join(tempRoot, "runtime-config.yaml");
+    await writeFile(
+      unifiedRuntimeConfigPath,
+      `
+version: "1.0"
+execution_mode: remote_only
+controller:
+  enabled: true
+  source_type: remote
+  endpoint_id: moonshot.litellm.global.moonshot-kimi-k2-5
+  model_id: moonshot/kimi-k2.5
+  timeout_ms: 15000
+litellm_proxy:
+  providers:
+    moonshot:
+      api_key: "\${MOONSHOT_API_KEY}"
+      model_list:
+        - model_name: moonshot/kimi-k2.5
+          litellm_params: { model: moonshot/kimi-k2.5 }
+        - model_name: moonshot/kimi-k2.6
+          litellm_params: { model: moonshot/kimi-k2.6 }
+`,
+      "utf8",
+    );
+
+    const seed = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot: testFixtureRoot,
+      runtimeStateRoot,
+      scopeId: "run76-config-controller-reassign",
+    });
+    await seed.upsertProviderAccount({
+      providerAccountId: "moonshot.litellm",
+      providerId: "moonshot",
+      providerKind: "provider-openai",
+      orgScope: "personal",
+      accountScope: "workspace-default",
+      credentialRef: { backend: "env", ref: "MOONSHOT_API_KEY" },
+      authMode: "api-key-static",
+      regionPolicy: { mode: "prefer", regions: ["global"] },
+      baseUrlOverride: "https://api.moonshot.ai/v1",
+      allowedModels: ["moonshot/kimi-k2.5", "moonshot/kimi-k2.6"],
+      deniedModels: [],
+      entitlementTags: ["chat"],
+      budgetPolicyRef: "budget.default",
+      quotaPolicyRef: "quota.default",
+      status: "active",
+      healthStatus: "healthy",
+      rotationState: "stable",
+    });
+    await seed.shutdown();
+
+    const backend = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot: testFixtureRoot,
+      runtimeStateRoot,
+      scopeId: "run76-config-controller-reassign",
+      unifiedRuntimeConfigPath,
+      runtimeVendorStartup: "disabled",
+    });
+    await backend.updateControllerAssignment({
+      endpointId: "moonshot.litellm.global.moonshot-kimi-k2-5",
+    });
+
+    await expect(
+      backend.removeProviderAccountModel("moonshot.litellm", "moonshot/kimi-k2.5"),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        removedAccount: false,
+        alreadyAbsent: false,
+      }),
+    );
+
+    await expect(backend.readControllerAssignment()).resolves.toEqual(
+      expect.objectContaining({
+        endpointId: "moonshot.litellm.global.moonshot-kimi-k2-6",
+        modelId: "moonshot/kimi-k2.6",
+        sourceType: "remote",
+      }),
+    );
+    await expect(backend.readRuntimeConfig()).resolves.toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          controller: expect.objectContaining({
+            endpointId: "moonshot.litellm.global.moonshot-kimi-k2-6",
+            modelId: "moonshot/kimi-k2.6",
+            sourceType: "remote",
+          }),
+        }),
+      }),
+    );
+
+    await backend.shutdown();
+  });
+
+  test("clears the controller when config-owned eject removes the last controller-backed model", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "role-model-run76-config-controller-clear-"),
+    );
+    tempRoots.push(tempRoot);
+    const runtimeStateRoot = path.join(tempRoot, "state");
+    const unifiedRuntimeConfigPath = path.join(tempRoot, "runtime-config.yaml");
+    await writeFile(
+      unifiedRuntimeConfigPath,
+      `
+version: "1.0"
+execution_mode: remote_only
+controller:
+  enabled: true
+  source_type: remote
+  endpoint_id: moonshot.litellm.global.moonshot-kimi-k2-5
+  model_id: moonshot/kimi-k2.5
+  timeout_ms: 15000
+litellm_proxy:
+  providers:
+    moonshot:
+      api_key: "\${MOONSHOT_API_KEY}"
+      model_list:
+        - model_name: moonshot/kimi-k2.5
+          litellm_params: { model: moonshot/kimi-k2.5 }
+`,
+      "utf8",
+    );
+
+    const seed = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot: testFixtureRoot,
+      runtimeStateRoot,
+      scopeId: "run76-config-controller-clear",
+    });
+    await seed.upsertProviderAccount({
+      providerAccountId: "moonshot.litellm",
+      providerId: "moonshot",
+      providerKind: "provider-openai",
+      orgScope: "personal",
+      accountScope: "workspace-default",
+      credentialRef: { backend: "env", ref: "MOONSHOT_API_KEY" },
+      authMode: "api-key-static",
+      regionPolicy: { mode: "prefer", regions: ["global"] },
+      baseUrlOverride: "https://api.moonshot.ai/v1",
+      allowedModels: ["moonshot/kimi-k2.5"],
+      deniedModels: [],
+      entitlementTags: ["chat"],
+      budgetPolicyRef: "budget.default",
+      quotaPolicyRef: "quota.default",
+      status: "active",
+      healthStatus: "healthy",
+      rotationState: "stable",
+    });
+    await seed.shutdown();
+
+    const backend = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot: testFixtureRoot,
+      runtimeStateRoot,
+      scopeId: "run76-config-controller-clear",
+      unifiedRuntimeConfigPath,
+      runtimeVendorStartup: "disabled",
+    });
+    await backend.updateControllerAssignment({
+      endpointId: "moonshot.litellm.global.moonshot-kimi-k2-5",
+    });
+
+    await expect(
+      backend.removeProviderAccountModel("moonshot.litellm", "moonshot/kimi-k2.5"),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        removedAccount: true,
+        alreadyAbsent: false,
+      }),
+    );
+
+    await expect(backend.readControllerAssignment()).resolves.toBeNull();
+    await expect(backend.readRuntimeConfig()).resolves.toEqual(
+      expect.objectContaining({
+        config: expect.not.objectContaining({
+          controller: expect.anything(),
+        }),
+      }),
+    );
+
+    await backend.shutdown();
+  });
+
   test("router candidates expose every configured endpoint and mark current execution-mode eligibility", async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-run49-candidates-"));
     tempRoots.push(tempRoot);

--- a/role-model-router/apps/runtime-host-bridge/test/remove-account-model.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/remove-account-model.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,7 +28,7 @@ afterEach(async () => {
   );
 });
 
-async function createBackend(scopeId: string) {
+async function createBackend(scopeId: string, unifiedRuntimeConfigPath?: string) {
   const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-remove-model-"));
   runtimeStateRoots.push(runtimeStateRoot);
   const backend = await bridge.createRuntimeBridgeBackend({
@@ -36,6 +36,7 @@ async function createBackend(scopeId: string) {
     fixtureRoot,
     runtimeStateRoot,
     scopeId,
+    ...(unifiedRuntimeConfigPath ? { unifiedRuntimeConfigPath } : {}),
   });
   return { backend, runtimeStateRoot };
 }
@@ -223,5 +224,212 @@ describe("removeProviderAccountModel", () => {
       (entry) => entry.providerAccountId === "moonshot.personal.primary",
     );
     expect(removedEndpoints).toEqual([]);
+  });
+
+  test("reassigns the controller to a surviving manual-account model during eject", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-remove-model-controller-"));
+    runtimeStateRoots.push(tempRoot);
+    const unifiedRuntimeConfigPath = path.join(tempRoot, "runtime-config.yaml");
+    await writeFile(
+      unifiedRuntimeConfigPath,
+      `
+version: "1.0"
+execution_mode: remote_only
+controller:
+  enabled: true
+  source_type: remote
+  endpoint_id: moonshot.personal.primary.global.kimi-k2.5
+  model_id: moonshot/kimi-k2.5
+  timeout_ms: 15000
+`,
+      "utf8",
+    );
+    const { backend, runtimeStateRoot } = await createBackend(
+      "runtime-remove-model-controller-reassign",
+      unifiedRuntimeConfigPath,
+    );
+    const databasePath = resolveSqliteMemoryLocation({
+      runtimeStateRoot,
+      scopeId: "runtime-remove-model-controller-reassign",
+    });
+
+    await backend.upsertProviderAccount({
+      providerAccountId: "moonshot.personal.primary",
+      providerId: "moonshot",
+      providerKind: "provider-openai",
+      orgScope: "personal",
+      accountScope: "workspace-default",
+      credentialRef: { backend: "env", ref: "MOONSHOT_API_KEY" },
+      authMode: "api-key-static",
+      regionPolicy: { mode: "prefer", regions: ["global"] },
+      baseUrlOverride: "https://api.moonshot.ai/v1",
+      allowedModels: ["moonshot/kimi-k2.5", "moonshot/kimi-k2.7-code"],
+      deniedModels: [],
+      entitlementTags: ["chat"],
+      budgetPolicyRef: "budget.default",
+      quotaPolicyRef: "quota.default",
+      status: "active",
+      healthStatus: "healthy",
+      rotationState: "stable",
+    });
+
+    upsertRuntimeEndpoint({
+      databasePath,
+      endpoint: {
+        endpointId: "moonshot.personal.primary.global.kimi-k2.5",
+        providerAccountId: "moonshot.personal.primary",
+        modelId: "moonshot/kimi-k2.5",
+        region: "global",
+        endpointKind: "remote-openai-compatible",
+        servingSource: "remote-service",
+        lifecycleState: "active",
+        healthStatus: "healthy",
+      },
+    });
+    upsertRuntimeEndpoint({
+      databasePath,
+      endpoint: {
+        endpointId: "moonshot.personal.primary.global.kimi-k2.7-code",
+        providerAccountId: "moonshot.personal.primary",
+        modelId: "moonshot/kimi-k2.7-code",
+        region: "global",
+        endpointKind: "remote-openai-compatible",
+        servingSource: "remote-service",
+        lifecycleState: "active",
+        healthStatus: "healthy",
+      },
+    });
+    await backend.shutdown();
+    const restartedBackend = await bridge.createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot,
+      runtimeStateRoot,
+      scopeId: "runtime-remove-model-controller-reassign",
+      unifiedRuntimeConfigPath,
+    });
+    await expect(
+      restartedBackend.removeProviderAccountModel(
+        "moonshot.personal.primary",
+        "moonshot/kimi-k2.5",
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        removedAccount: false,
+        alreadyAbsent: false,
+      }),
+    );
+
+    await expect(restartedBackend.readControllerAssignment()).resolves.toEqual(
+      expect.objectContaining({
+        endpointId: "moonshot.personal.primary.global.kimi-k2.7-code",
+        modelId: "moonshot/kimi-k2.7-code",
+        sourceType: "remote",
+      }),
+    );
+    await expect(restartedBackend.readRuntimeConfig()).resolves.toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          controller: expect.objectContaining({
+            endpointId: "moonshot.personal.primary.global.kimi-k2.7-code",
+            modelId: "moonshot/kimi-k2.7-code",
+            sourceType: "remote",
+          }),
+        }),
+      }),
+    );
+  });
+
+  test("clears the controller when eject removes the last surviving controller-backed manual-account model", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "role-model-remove-model-controller-clear-"),
+    );
+    runtimeStateRoots.push(tempRoot);
+    const unifiedRuntimeConfigPath = path.join(tempRoot, "runtime-config.yaml");
+    await writeFile(
+      unifiedRuntimeConfigPath,
+      `
+version: "1.0"
+execution_mode: remote_only
+controller:
+  enabled: true
+  source_type: remote
+  endpoint_id: moonshot.personal.primary.global.kimi-k2.5
+  model_id: moonshot/kimi-k2.5
+  timeout_ms: 15000
+`,
+      "utf8",
+    );
+    const { backend, runtimeStateRoot } = await createBackend(
+      "runtime-remove-model-controller-clear",
+      unifiedRuntimeConfigPath,
+    );
+    const databasePath = resolveSqliteMemoryLocation({
+      runtimeStateRoot,
+      scopeId: "runtime-remove-model-controller-clear",
+    });
+
+    await backend.upsertProviderAccount({
+      providerAccountId: "moonshot.personal.primary",
+      providerId: "moonshot",
+      providerKind: "provider-openai",
+      orgScope: "personal",
+      accountScope: "workspace-default",
+      credentialRef: { backend: "env", ref: "MOONSHOT_API_KEY" },
+      authMode: "api-key-static",
+      regionPolicy: { mode: "prefer", regions: ["global"] },
+      baseUrlOverride: "https://api.moonshot.ai/v1",
+      allowedModels: ["moonshot/kimi-k2.5"],
+      deniedModels: [],
+      entitlementTags: ["chat"],
+      budgetPolicyRef: "budget.default",
+      quotaPolicyRef: "quota.default",
+      status: "active",
+      healthStatus: "healthy",
+      rotationState: "stable",
+    });
+
+    upsertRuntimeEndpoint({
+      databasePath,
+      endpoint: {
+        endpointId: "moonshot.personal.primary.global.kimi-k2.5",
+        providerAccountId: "moonshot.personal.primary",
+        modelId: "moonshot/kimi-k2.5",
+        region: "global",
+        endpointKind: "remote-openai-compatible",
+        servingSource: "remote-service",
+        lifecycleState: "active",
+        healthStatus: "healthy",
+      },
+    });
+    await backend.shutdown();
+    const restartedBackend = await bridge.createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot,
+      runtimeStateRoot,
+      scopeId: "runtime-remove-model-controller-clear",
+      unifiedRuntimeConfigPath,
+    });
+    await expect(
+      restartedBackend.removeProviderAccountModel(
+        "moonshot.personal.primary",
+        "moonshot/kimi-k2.5",
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        removedAccount: true,
+        alreadyAbsent: false,
+      }),
+    );
+
+    await expect(restartedBackend.readControllerAssignment()).resolves.toBeNull();
+    await expect(restartedBackend.readRuntimeConfig()).resolves.toEqual(
+      expect.objectContaining({
+        config: expect.not.objectContaining({
+          controller: expect.anything(),
+        }),
+      }),
+    );
   });
 });

--- a/role-model-router/packages/sqlite-memory/src/index.ts
+++ b/role-model-router/packages/sqlite-memory/src/index.ts
@@ -785,6 +785,11 @@ export interface ReadRuntimeControllerAssignmentInput {
   readonly scope: string;
 }
 
+export interface DeleteRuntimeControllerAssignmentInput {
+  readonly databasePath: string;
+  readonly scope: string;
+}
+
 export interface ExportRuntimeStateInput {
   readonly databasePath: string;
   readonly exportPath: string;
@@ -1891,6 +1896,14 @@ export function readRuntimeControllerAssignment(
   database.close();
 
   return row ? mapRuntimeControllerAssignmentRow(row) : null;
+}
+
+export function deleteRuntimeControllerAssignment(
+  input: DeleteRuntimeControllerAssignmentInput,
+): void {
+  const database = new DatabaseSync(input.databasePath);
+  database.prepare("DELETE FROM runtime_controller_assignments WHERE scope = ?").run(input.scope);
+  database.close();
 }
 
 export function upsertProviderDeviceAuthSession(input: UpsertProviderDeviceAuthSessionInput): void {


### PR DESCRIPTION
## Summary
- auto-reassign or clear the controller when ejecting a controller-backed configured model
- persist controller convergence across both account-managed and runtime-config-managed eject paths
- add run 76 addendum coverage plus TDD tests for controller reassignment and controller clearing

## Root cause
Configured model eject treated controller references as hard blockers instead of converging them to a surviving eligible endpoint or clearing them when none remained.

## Validation
- corepack pnpm run ci:check
