### PR TITLE
feat: add dev and stage delivery channels

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -17,6 +17,7 @@ Bridge guidance only:
 - If this file conflicts with `/.recursive/RECURSIVE.md`, follow `/.recursive/RECURSIVE.md`.
 - Control-plane docs live under `/.recursive/`.
 - Runs live under `/.recursive/run/<run-id>/`.
+- New `recursive/*` run branches start from and target `dev`; `stage` and `main` are promotion branches.
 - Durable memory lives under `/.recursive/memory/`.
 - If recursive-mode is invoked in a repo that does not yet contain the `/.recursive/` scaffold, bootstrap it automatically with the supported install script before continuing. Do not require the user to run a separate manual bootstrap step unless no supported runtime is available.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 ## Checklist
 
+- [ ] This PR targets `dev`, or it is an intentional `dev -> stage`, `stage -> main`, or reviewed `hotfix/* -> main` promotion.
+- [ ] I included a `Real behavior proof` section with exact commands, evidence, and untested scope.
 - [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
 - [ ] I have read [CLA version 1.0](../cla/CLA-v1.0.md).
 - [ ] I understand that checking these boxes does not sign the CLA by itself.

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -2,14 +2,29 @@ name: build-binaries
 
 on:
   workflow_dispatch:
+    inputs:
+      channel:
+        description: Runtime channel to package
+        required: true
+        default: development
+        type: choice
+        options:
+          - development
+          - stage
+          - production
   push:
     branches:
-      - main
+      - stage
     tags:
       - "v*"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ROLE_MODEL_BUILD_CHANNEL: ${{ github.ref_type == 'tag' && 'production' || (github.ref_name == 'stage' && 'stage' || inputs.channel || 'development') }}
+
+concurrency:
+  group: runtime-build-${{ github.ref }}-${{ inputs.channel || 'automatic' }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   build-runtime:
@@ -17,6 +32,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
+      actions: read
       contents: read
       attestations: write
       id-token: write
@@ -66,15 +82,80 @@ jobs:
       - name: Package SEA runtime
         run: pnpm run runtime:package-sea
 
+      - name: Verify channel manifest identity
+        id: runtime_identity
+        shell: pwsh
+        run: |
+          $manifestPath = "role-model-router/dist/release/${{ matrix.target }}/manifest.json"
+          $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+          foreach ($field in @("channel", "name", "endpoint", "source_tree", "executable_sha256", "core_payload_sha256")) {
+            if (-not $manifest.$field) { throw "Missing manifest field: $field" }
+          }
+          if ($manifest.channel -ne $env:ROLE_MODEL_BUILD_CHANNEL) {
+            throw "Manifest channel '$($manifest.channel)' does not match '$env:ROLE_MODEL_BUILD_CHANNEL'"
+          }
+          $expectedName = switch ($env:ROLE_MODEL_BUILD_CHANNEL) {
+            "production" { "role-model" }
+            "stage" { "role-model-stage" }
+            "development" { "role-model-dev" }
+          }
+          if ($manifest.name -ne $expectedName) {
+            throw "Manifest name '$($manifest.name)' does not match '$expectedName'"
+          }
+          "source_tree=$($manifest.source_tree)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "core_payload_sha256=$($manifest.core_payload_sha256)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Verify production core matches the tested stage candidate
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $artifactName = "role-model-stage-candidate-${{ steps.runtime_identity.outputs.source_tree }}-${{ matrix.target }}"
+          $headers = @{
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            Accept = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $listUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/artifacts?name=$artifactName&per_page=20"
+          $artifact = (Invoke-RestMethod -Headers $headers -Uri $listUrl).artifacts |
+            Where-Object { -not $_.expired } |
+            Sort-Object created_at -Descending |
+            Select-Object -First 1
+          if (-not $artifact) { throw "No tested stage candidate found for $artifactName" }
+          $outerZip = Join-Path $env:RUNNER_TEMP "stage-candidate.zip"
+          $outerDir = Join-Path $env:RUNNER_TEMP "stage-candidate"
+          $innerDir = Join-Path $env:RUNNER_TEMP "stage-package"
+          Invoke-WebRequest -Headers $headers -Uri $artifact.archive_download_url -OutFile $outerZip
+          Expand-Archive -LiteralPath $outerZip -DestinationPath $outerDir -Force
+          $archive = Get-ChildItem -LiteralPath $outerDir -File | Select-Object -First 1
+          if (-not $archive) { throw "Stage candidate artifact contains no archive" }
+          New-Item -ItemType Directory -Force -Path $innerDir | Out-Null
+          if ($archive.Extension -eq ".zip") {
+            Expand-Archive -LiteralPath $archive.FullName -DestinationPath $innerDir -Force
+          } else {
+            tar -xzf $archive.FullName -C $innerDir
+            if ($LASTEXITCODE -ne 0) { throw "Failed to extract stage candidate" }
+          }
+          $stageManifest = Get-ChildItem -LiteralPath $innerDir -Recurse -Filter manifest.json |
+            Select-Object -First 1 |
+            Get-Content -Raw |
+            ConvertFrom-Json
+          if ($stageManifest.core_payload_sha256 -ne "${{ steps.runtime_identity.outputs.core_payload_sha256 }}") {
+            throw "Production core payload does not match the tested stage candidate"
+          }
+
       - name: Verify Windows standalone package
         if: matrix.target == 'win32-x64'
         shell: pwsh
         run: |
           $packageDir = "role-model-router/dist/release/win32-x64"
+          $manifest = Get-Content -LiteralPath "$packageDir/manifest.json" -Raw | ConvertFrom-Json
           @(
-            "$packageDir/role-model-runtime.exe",
-            "$packageDir/role-model-launcher.exe",
-            "$packageDir/Role-Model.bat",
+            "$packageDir/manifest.json",
+            "$packageDir/$($manifest.executable)",
+            "$packageDir/$($manifest.name)-launcher.exe",
+            "$packageDir/$($manifest.name).bat",
             "$packageDir/build/client/index.html",
             "$packageDir/role-model-router/packages/vendor-litellm/data/model-prices.json",
             "$packageDir/role-model-router/packages/catalog/data/normalized-catalog.json"
@@ -119,8 +200,17 @@ jobs:
         if: matrix.target != 'win32-x64'
         run: |
           mkdir -p role-model-router/dist/archive
-          tar -czf "role-model-router/dist/archive/role-model-router-${{ matrix.target }}.tar.gz" \
+          manifest="role-model-router/dist/release/${{ matrix.target }}/manifest.json"
+          runtime_name="$(node -p "require('./${manifest}').name")"
+          short_sha="${GITHUB_SHA:0:12}"
+          if [[ "$ROLE_MODEL_BUILD_CHANNEL" == "production" ]]; then
+            archive_name="role-model-${{ matrix.target }}.tar.gz"
+          else
+            archive_name="${runtime_name}-${short_sha}-${{ matrix.target }}.tar.gz"
+          fi
+          tar -czf "role-model-router/dist/archive/${archive_name}" \
             -C "role-model-router/dist/release/${{ matrix.target }}" .
+          echo "ARCHIVE_PATH=role-model-router/dist/archive/${archive_name}" >> "$GITHUB_ENV"
 
       - name: Archive standalone package (Windows)
         if: matrix.target == 'win32-x64'
@@ -129,16 +219,16 @@ jobs:
           $archiveDir = "role-model-router/dist/archive"
           $packageDir = "role-model-router/dist/release/win32-x64"
           New-Item -ItemType Directory -Force -Path $archiveDir | Out-Null
-          Compress-Archive -Path "$packageDir\*" -DestinationPath "$archiveDir\role-model-router-win32-x64.zip" -Force
-
-      - name: Record archive path
-        shell: pwsh
-        run: |
-          if ("${{ matrix.target }}" -eq "win32-x64") {
-            "ARCHIVE_PATH=role-model-router/dist/archive/role-model-router-win32-x64.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $manifest = Get-Content -LiteralPath "$packageDir/manifest.json" -Raw | ConvertFrom-Json
+          $shortSha = $env:GITHUB_SHA.Substring(0, 12)
+          if ($env:ROLE_MODEL_BUILD_CHANNEL -eq "production") {
+            $archiveName = "role-model-win32-x64.zip"
           } else {
-            "ARCHIVE_PATH=role-model-router/dist/archive/role-model-router-${{ matrix.target }}.tar.gz" | Out-File -FilePath $env:GITHUB_ENV -Append
+            $archiveName = "$($manifest.name)-$shortSha-win32-x64.zip"
           }
+          $archivePath = "$archiveDir/$archiveName"
+          Compress-Archive -Path "$packageDir\*" -DestinationPath $archivePath -Force
+          "ARCHIVE_PATH=$archivePath" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Attest release archive (attempt 1)
         id: attest_release_archive_attempt_1
@@ -182,7 +272,7 @@ jobs:
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: role-model-runtime-${{ matrix.target }}
+          name: ${{ env.ROLE_MODEL_BUILD_CHANNEL == 'stage' && format('role-model-stage-candidate-{0}-{1}', steps.runtime_identity.outputs.source_tree, matrix.target) || format('role-model-runtime-{0}-{1}', env.ROLE_MODEL_BUILD_CHANNEL, matrix.target) }}
           path: ${{ env.ARCHIVE_PATH }}
 
       - name: Upload packaging diagnostics
@@ -198,7 +288,7 @@ jobs:
 
   publish-release:
     name: publish release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.ref_type == 'tag'
     needs: build-runtime
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,67 @@ name: CI
 
 on:
   push:
+    branches:
+      - dev
+      - stage
+      - main
   pull_request:
+    branches:
+      - dev
+      - stage
+      - main
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  validate:
+  promotion-guard:
+    name: promotion-guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate promotion source
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        shell: bash
+        run: |
+          if [[ "$BASE_REF" == "stage" && "$HEAD_REF" != "dev" ]]; then
+            echo "Invalid promotion source: stage only accepts dev."
+            exit 1
+          fi
+          if [[ "$BASE_REF" == "main" && "$HEAD_REF" != "stage" && "$HEAD_REF" != hotfix/* ]]; then
+            echo "Invalid promotion source: main only accepts stage or reviewed hotfix/* branches."
+            exit 1
+          fi
+
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm run schemas:validate
+
+  build-test:
+    name: build-test
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -20,28 +74,71 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run test
+
+  runtime-critical:
+    name: runtime-critical
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run runtime:test-critical
+
+  runtime-router:
+    name: runtime-router
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run runtime:test-router
+
+  rust:
+    name: rust
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
       - uses: dtolnay/rust-toolchain@stable
-      - name: Print toolchain versions
-        run: |
-          node --version
-          pnpm --version
-          rustc --version
-          cargo --version
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile=false
-      - name: Lint
-        run: pnpm run lint
-      - name: Validate schemas
-        run: pnpm run schemas:validate
-      - name: Build
-        run: pnpm run build
-      - name: Test
-        run: pnpm run test
-      - name: Runtime critical regression
-        run: pnpm run runtime:test-critical
-      - name: Runtime router regression
-        run: pnpm run runtime:test-router
-      - name: Test Rust
-        run: pnpm run test:rust
-      - name: Smoke
-        run: pnpm run smoke
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:rust
+
+  smoke:
+    name: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run smoke

--- a/.github/workflows/docs-site-deploy.yml
+++ b/.github/workflows/docs-site-deploy.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: build
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/main'
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -122,16 +122,14 @@ jobs:
         if: steps.cloudflare_ready.outputs.ready == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Select Pages branch
-        if: steps.cloudflare_ready.outputs.ready == 'true'
-        shell: bash
-        run: |
-          echo "PAGES_BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
-
       - name: Deploy docs site
         if: steps.cloudflare_ready.outputs.ready == 'true'
         run: |
           pnpm exec wrangler pages deploy apps/docs-site/build/client \
             --project-name role-model-dev \
-            --branch "$PAGES_BRANCH" \
+            --branch main \
             --commit-hash "${GITHUB_SHA}"
+
+      - name: Verify docs deployment
+        if: steps.cloudflare_ready.outputs.ready == 'true'
+        run: curl --fail --silent --show-error --retry 5 --retry-delay 5 https://role-model.dev/ > /dev/null

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md
@@ -1,0 +1,224 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `00 Requirements`
+Status: `LOCKED`
+LockedAt: `2026-07-18T23:33:39Z`
+LockHash: `210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- GitHub tracker `https://github.com/try-works/role-model/issues/61`
+- approved user proposal for `dev -> stage -> main` promotion
+- approved user requirement that development, stage, and production runtime builds run concurrently
+- user correction that the canonical product name is exactly `role-model`
+- `/.recursive/STATE.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/memory/MEMORY.md`
+- `/.recursive/memory/patterns/github-ci-and-release-workflow.md`
+- `/.recursive/memory/patterns/git-push-merge-workflow.md`
+Outputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+Scope note: Establish the repository, GitHub, deployment, release, and packaged-runtime contracts for an enforceable development-to-production promotion pipeline with concurrently runnable channel builds.
+
+## TODO
+
+- [x] Capture the approved tracker as the source requirement
+- [x] Define stable requirement identifiers and observable acceptance criteria
+- [x] Preserve the canonical `role-model` naming correction
+- [x] Define out-of-scope boundaries
+- [x] Record migration, safety, and verification constraints
+- [x] Complete the Coverage Gate
+- [x] Record the user's implementation approval
+
+## Goal
+
+Normal feature, fix, and recursive run branches enter through `dev`, are promoted as a tested release candidate to `stage`, and reach production only through `main`. The workflows and GitHub protections must enforce that path. Official packaged runtimes from all three channels must be installable and runnable together on one device without sharing ports, state, locks, logs, or process identity.
+
+## Fixed Decisions
+
+1. The long-lived promotion branches are `dev`, `stage`, and `main`.
+2. `dev` is the default integration and GitHub default branch; `main` remains production truth.
+3. Normal feature, fix, dependency, and `recursive/*` work branches from and targets `dev`.
+4. Normal PRs into `dev` use squash merge; `dev -> stage` and `stage -> main` promotions preserve ancestry with merge commits.
+5. Production hotfixes branch from `main`, land through a reviewed PR, and are forwarded to `stage` and `dev`.
+6. Production uses `role-model` on port `3456`; stage uses `role-model-stage` on `3457`; development uses `role-model-dev` on `3458`.
+7. The exact canonical product spelling is lowercase and hyphenated: `role-model`. New user-facing channel identities must not use `Role Model`.
+8. Channel identity is supplied explicitly by trusted build workflows, not inferred from mutable Git state at runtime.
+9. Core runtime payload identity should remain channel-neutral where practical; thin launch profiles may vary by channel, and promotion evidence must record the core payload hash.
+10. CI validation, deployment authorization, and release publication remain separate concerns.
+
+## Requirements
+
+### R1 — Establish the three-branch integration and promotion contract
+
+Acceptance criteria:
+
+- create `dev` from the approved current `main` migration baseline
+- bring `stage` to the same migration baseline before the first promotion
+- make `dev` the GitHub default branch
+- document and enforce that `feature/*`, `fix/*`, dependency, and `recursive/*` PRs target `dev`
+- document squash merge for ordinary work and merge-commit promotion for `dev -> stage -> main`
+- enable automatic deletion of merged short-lived branches
+- document stabilization and production-hotfix forward-merge behavior
+- preserve `main` as the production source of truth
+
+### R2 — Protect branches and enforce promotion sources
+
+Acceptance criteria:
+
+- protect `dev`, `stage`, and `main` from force pushes, deletion, and unreviewed direct changes
+- require pull requests, resolved conversations, and required CI checks
+- include administrators in enforcement
+- require the CLA where external contributions first enter `dev` without redundantly blocking promotions
+- add a required guard that rejects ordinary PRs to `stage` unless the head is `dev`
+- add a required guard that rejects ordinary PRs to `main` unless the head is `stage`
+- preserve an explicit, auditable emergency exception for approved `hotfix/*` work
+- require maintainer approval for stage and production promotions
+- make the configured GitHub rules match the repository documentation
+
+### R3 — Restructure CI into deliberate, diagnosable validation lanes
+
+Acceptance criteria:
+
+- PR validation targets PRs into `dev`, `stage`, and `main`
+- branch-push validation is limited to the long-lived branches where post-merge proof is useful
+- dependency installation uses `pnpm install --frozen-lockfile`
+- CI retains separately diagnosable quality, build/test, runtime-critical, runtime-router, Rust, and smoke responsibilities
+- expensive cross-platform packaging does not run on every feature-branch push
+- superseded runs cancel through explicit concurrency groups
+- workflows use least-privilege permissions and bounded timeouts
+- repo-owned workflow tests fail against the current topology before implementation and pass afterward
+- the local `ci:check` parity command remains available
+
+### R4 — Provide separated development, staging, and production docs deployments
+
+Acceptance criteria:
+
+- GitHub environments exist for `development`, `staging`, `production`, and `release`
+- docs builds run for relevant PRs without deployment credentials
+- successful `dev`, `stage`, and `main` pushes select the development, staging, and production deployment targets respectively
+- target names are `role-model-dev`, `role-model-stage`, and `role-model`
+- production and release use protected approval gates where GitHub supports them
+- deployment jobs expose explicit environment, branch, project, URL, and commit identity
+- missing deployment credentials produce a visible non-fatal skip for validation-only contexts
+- post-deployment health verification and rollback guidance are documented
+- Cloudflare project/config changes are made only through authenticated, inspectable commands; unavailable credentials are reported without inventing successful deployment state
+
+### R5 — Align binary candidate and production release promotion
+
+Acceptance criteria:
+
+- `stage` builds the full supported platform matrix and publishes unambiguous stage-candidate artifacts
+- production tags remain the only path that publishes a stable GitHub release
+- matrix jobs retain archive checks, checksums, attestations, retry behavior, and packaging diagnostics
+- dev artifacts, when explicitly requested or configured, are named with channel and commit identity
+- stage artifacts include channel and commit identity and cannot be mistaken for stable production artifacts
+- the verified channel-neutral core payload hash is recorded so production promotion can prove which code payload was tested on stage
+- release publication, installer scripts, checksum manifests, and recursive release notes remain aligned
+
+### R6 — Add an explicit packaged-runtime channel profile
+
+Acceptance criteria:
+
+- production defaults to name `role-model`, port `3456`, state root `role-model-runtime`, and scope id `standalone-runtime`
+- stage defaults to name `role-model-stage`, port `3457`, state root `role-model-runtime-stage`, and scope id `standalone-runtime-stage`
+- development defaults to name `role-model-dev`, port `3458`, state root `role-model-runtime-dev`, and scope id `standalone-runtime-dev`
+- the trusted packaging workflow passes the channel explicitly and rejects unsupported channel values
+- local packaging has a safe, documented default and supports an explicit channel override
+- the launcher derives runtime arguments, frontend URL, health polling, shutdown, and state location from the selected profile
+- channel-specific launch profiles isolate logs, PID/lock files, process identity, launcher/shortcut naming, artifact name, and child-service port allocation where those surfaces exist
+- the runtime health/version/control-plane response reports channel, commit/version identity, and effective endpoint
+- channel configuration does not change the Pi package's production default endpoint
+
+### R7 — Make channel identity visible and consistently named
+
+Acceptance criteria:
+
+- new display names, executables, launchers, shortcuts, artifacts, logs, and documentation use `role-model`, `role-model-stage`, or `role-model-dev`
+- no newly introduced user-facing string uses `Role Model`
+- artifact names clearly distinguish dev SHA builds, stage SHA/candidate builds, and production version builds
+- documentation shows explicit `ROLE_MODEL_ENDPOINT` examples for stage `http://127.0.0.1:3457` and dev `http://127.0.0.1:3458`
+- discovery and UI connections use the effective runtime endpoint instead of a second hard-coded port
+
+### R8 — Update repository policy and operations documentation
+
+Acceptance criteria:
+
+- `CONTRIBUTING.md` instructs contributors to branch from and target `dev`
+- the PR template asks authors to confirm the correct target branch and real-behavior evidence
+- recursive-run guidance targets `dev` for future run branches
+- CI/release operations documentation explains validation lanes, promotions, environments, releases, hotfixes, rollback, and branch resynchronization
+- release checklist reflects the `dev -> stage -> main` path and channel artifact evidence
+- documentation and workflow contract tests prevent silent drift back to direct-main development
+
+### R9 — Prove migration safety and concurrent runtime operation
+
+Acceptance criteria:
+
+- focused workflow, launcher, packaging, runtime-version, and documentation tests pass
+- repository lint/build/test validation required by the changed-path test matrix passes
+- a deliberate invalid promotion-source fixture is rejected by the guard tests
+- official or locally equivalent development, stage, and production packages start simultaneously on ports `3458`, `3457`, and `3456`
+- each channel returns the correct name, channel, commit/version, and endpoint
+- writes and restarts in one channel do not modify the other channels' state roots
+- stopping one channel leaves the other two healthy
+- each channel's UI and discovery surfaces point to its own endpoint
+- migration evidence records original and final default branch, branch tips, protections, environments, and workflow status
+- no direct push or destructive history rewrite is used to establish the branch topology
+
+## Out of Scope
+
+### OOS1 — Shared runtime state across channels
+
+Development, stage, and production must not share configuration, SQLite, logs, or lock state.
+
+### OOS2 — Automatic promotion after a failed or unapproved stage
+
+No workflow may silently promote a failed, skipped, or unapproved staging candidate.
+
+### OOS3 — Public API redesign unrelated to channel metadata
+
+The run may add channel/build metadata but does not otherwise redesign routing or OpenAI-compatible APIs.
+
+### OOS4 — New distribution ecosystems
+
+No npm, package-manager, container-registry, or app-store publishing channel is introduced solely for this migration.
+
+### OOS5 — Destructive rewrite of existing branch history
+
+Existing `main`, `stage`, tag, and release history is preserved.
+
+## Constraints
+
+- All product and workflow edits occur in the isolated run-78 worktree and feature branch.
+- Phase 3 follows RED-GREEN-REFACTOR for executable behavior; configuration-only changes use an explicit pragmatic TDD exception plus contract tests.
+- GitHub writes are applied only after the repository workflows and documentation defining them are validated.
+- Branch creation and protection changes must be recoverable without force pushing or deleting history.
+- Existing unrelated user changes in the controller checkout are not modified or staged.
+- Windows Node, Vite, Vitest, Playwright, Go, and packaging commands run from the real worktree path.
+- Cloudflare and GitHub configuration is inspected immediately before mutation so the final receipt records actual state rather than assumptions.
+- Product naming is exactly `role-model`; title-case variants are not accepted for newly introduced channel identity.
+
+## Coverage Gate
+
+- [x] R1 covers long-lived branches, default targeting, merge modes, and hotfix synchronization
+- [x] R2 covers protections, required checks, source guards, approvals, and emergency policy
+- [x] R3 covers CI trigger scope, frozen installs, lanes, concurrency, and testability
+- [x] R4 covers distinct deployment environments and Cloudflare targets
+- [x] R5 covers stage candidates, production releases, artifacts, checksums, and payload identity
+- [x] R6 covers channel profiles, ports, state, scope, launch behavior, and runtime metadata
+- [x] R7 covers canonical naming and endpoint selection
+- [x] R8 covers contribution, PR, recursive-run, operations, and release documentation
+- [x] R9 covers automated validation, GitHub migration receipts, and three-channel concurrency QA
+- [x] OOS1-OOS5 prevent shared state, unsafe promotion, unrelated API/distribution expansion, and history rewrites
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] GitHub tracker #61 was created before implementation as requested
+- [x] The user approved the proposal and then explicitly instructed implementation
+- [x] The port allocation and canonical lowercase `role-model` naming match the user's corrections
+- [x] Acceptance criteria distinguish repository changes from external GitHub/Cloudflare state
+- [x] No implementation code or repository settings were changed before this requirements artifact was created
+
+Approval: PASS
+

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md
@@ -1,0 +1,132 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `00 Worktree`
+Status: `LOCKED`
+LockedAt: `2026-07-18T23:35:41Z`
+LockHash: `4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- current git repository and worktree state
+Outputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+Scope note: Record the isolated execution context, clean baseline, and immutable diff basis for all run-78 audits.
+
+## TODO
+
+- [x] Confirm the ignored worktree location and isolation approach
+- [x] Confirm the base and worktree branches
+- [x] Install the workspace dependencies
+- [x] Run focused workflow, launcher, and schema baseline checks
+- [x] Record the corrected Go module-mode invocation
+- [x] Confirm the diff basis matches live git state
+- [x] Record router policy/discovery posture
+- [x] Complete Coverage and Approval gates
+
+## Directory Selection
+
+- Controller repository: `D:\DEV\role-model`
+- Worktree: `D:\DEV\role-model\.worktrees\78-dev-stage-main-cicd-runtime-channels`
+- Selection: existing project-local `.worktrees/` convention
+- Ignore verification: PASS; `git check-ignore -v .worktrees` resolves to `.gitignore:1:.worktrees/`.
+
+## Safety Verification
+
+- Controller branch: `main`
+- Controller status before creation: clean tracked tree with the pre-existing unrelated untracked `DIRECT_TRACK_B_UPDATE_TODO.audit-revision.tmp.md`
+- Base commit: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Worktree branch: `recursive/78-dev-stage-main-cicd-runtime-channels`
+- Isolation: PASS; product and recursive run edits exist only in the worktree.
+
+## Worktree Creation
+
+Command:
+
+```powershell
+git worktree add .worktrees/78-dev-stage-main-cicd-runtime-channels -b recursive/78-dev-stage-main-cicd-runtime-channels
+```
+
+Result: PASS. Git created the isolated branch at the current `main` commit.
+
+## Main Branch Protection
+
+- No implementation commands or product edits run from the controller checkout.
+- The run branch remains isolated until it is pushed and reviewed through the new integration path.
+- No local merge or direct push to `main` is authorized.
+
+## Project Setup
+
+Command:
+
+```powershell
+corepack pnpm install --frozen-lockfile
+```
+
+Result: PASS in approximately 21 seconds across 44 workspace projects using pnpm 10.6.5.
+
+## Test Baseline Verification
+
+Commands:
+
+```powershell
+node --test scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
+$env:GO111MODULE='off'; go test ./...
+corepack pnpm run schemas:validate
+```
+
+Results:
+
+- Existing workflow contract tests: PASS, 2 tests.
+- Launcher Go tests: PASS with `GO111MODULE=off`.
+- Schema validation: PASS, 37 schemas and 30 fixtures.
+- An initial `go test ./...` without `GO111MODULE=off` failed because the standalone launcher directory intentionally has no `go.mod`; repeating with the same module mode used by packaging passed. This is a command-context correction, not a baseline product failure.
+
+## Worktree Context
+
+- Base branch: `main`
+- Worktree branch: `recursive/78-dev-stage-main-cicd-runtime-channels`
+- Base commit: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- All Phase 1+ commands and edits run from `D:\DEV\role-model\.worktrees\78-dev-stage-main-cicd-runtime-channels`.
+
+## Diff Basis For Later Audits
+
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Base branch: `main`
+- Worktree branch: `recursive/78-dev-stage-main-cicd-runtime-channels`
+- Diff basis notes: the selected baseline is the exact `main` commit from which both the run branch and future `dev` migration baseline originate.
+
+## Router Policy Check
+
+- Routing config `/.recursive/config/recursive-router.json`: present.
+- Routing discovery `/.recursive/config/recursive-router-discovered.json`: absent in the fresh worktree.
+- Phase 0 requires no delegated role. Before a later delegated audit or review, discovery must be refreshed or synchronized and the effective route recorded.
+
+## Traceability
+
+- R1-R9 implementation has an isolated branch and executable baseline diff.
+- R9 baseline workflow, launcher, and schema tests pass before production changes.
+- The user's unrelated controller-checkout file remains untouched.
+
+## Coverage Gate
+
+- [x] Worktree location, branch context, and ignore verification are recorded
+- [x] Setup and focused clean baseline verification are recorded
+- [x] The one command-context correction is explicit
+- [x] Diff basis fields are complete and executable
+- [x] Later phases are constrained to the real worktree path
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] Requirements are locked before Phase 0 worktree closeout
+- [x] The isolated branch begins at the current production baseline
+- [x] Focused owning tests pass before implementation
+- [x] No unresolved setup or diff-basis inconsistency remains
+
+Approval: PASS
+

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md
@@ -1,0 +1,235 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `01 AS-IS`
+Status: `LOCKED`
+LockedAt: `2026-07-18T23:54:38Z`
+LockHash: `b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- `/.recursive/STATE.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/memory/MEMORY.md`
+- current repository, GitHub, and Cloudflare configuration
+Outputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+Scope note: This document captures the branch, workflow, release, docs deployment, and packaged-runtime behavior before changes.
+
+## TODO
+
+- [x] Re-read the locked Phase 0 artifacts and effective addendum
+- [x] Create novice-runnable reproduction steps
+- [x] Document current behavior for R1-R9
+- [x] Identify code and configuration pointers
+- [x] Record known unknowns and external-state evidence
+- [x] Review relevant prior recursive evidence
+- [x] Assemble the delegated audit context
+- [x] Run the phase audit
+- [x] Repair findings and re-audit to PASS
+- [x] Create traceability mapping
+- [x] Complete Coverage Gate
+- [x] Complete Approval Gate
+
+## Reproduction Steps (Novice-Runnable)
+
+1. Open `D:\DEV\role-model\.worktrees\78-dev-stage-main-cicd-runtime-channels`.
+2. Run `git branch --show-current` and confirm `recursive/78-dev-stage-main-cicd-runtime-channels`.
+3. Run `git rev-parse HEAD` and confirm baseline `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`.
+4. Run `git rev-list --left-right --count origin/main...origin/stage`; the observed result is `154 0`, so stage is stale and contains no unique commit.
+5. Inspect `.github/workflows/ci.yml`, `.github/workflows/build-binaries.yml`, `.github/workflows/docs-site-deploy.yml`, `.github/workflows/cla.yml`, `CONTRIBUTING.md`, and `.github/pull_request_template.md`.
+6. Run `gh api repos/try-works/role-model` and the branch-protection/environment API reads recorded below.
+7. Run `wrangler pages project list --json`; only `role-model-dev` currently exists and owns `role-model.dev`.
+8. Inspect `role-model-router/apps/launcher/main.go`, `role-model-router/apps/runtime-host-bridge/src/package-sea.ts`, `runtime-version.ts`, and the cited `index.ts` state/credential paths.
+9. Run the Phase 0 baseline commands: frozen install, workflow contract tests, launcher Go tests with `GO111MODULE=off`, and schema validation.
+
+## Current Behavior by Requirement
+
+- `R1`: blocked. GitHub defaults to `main`; `dev` does not exist; `stage` is 154 commits behind `main`; ordinary contribution docs branch from and target `main`; merged branches are not automatically deleted.
+- `R2`: blocked. There are no repository rulesets. `main` requires only the `cla` context, does not require a PR review or resolved conversations, and does not enforce administrators. `stage` is unprotected and no promotion-source guard exists.
+- `R3`: partially satisfied but blocked. CI exposes attributable steps and runtime lanes, but runs on every push/PR, uses `--frozen-lockfile=false`, has one serial job, lacks concurrency and explicit permissions, and is not a meaningful required check on `main`.
+- `R4`: superseded by the approved addendum. The docs site builds on relevant PRs; main pushes deploy to `role-model-dev`, but `workflow_dispatch` can deploy an arbitrary selected ref because every non-PR event is accepted. It reports no GitHub environment and has no post-deploy health check. Effective scope is one strictly main-only docs deployment, not three Pages projects.
+- `R5`: blocked. The binary matrix runs on `main`, tags, and manual dispatch; only tags publish releases. The package manifest already records executable SHA-256 and commit, but workflow/archive/artifact names lack channel/SHA identity, stage produces no candidate matrix, no channel field exists, and promotion evidence does not distinguish the channel-neutral core payload hash.
+- `R6`: blocked. The Windows launcher hard-codes port `3456`, scope `standalone-runtime`, and a title-case cache directory. Packaging has no trusted channel input or profile manifest. Runtime health/version responses do not report the effective channel/name/endpoint.
+- `R7`: blocked. Existing user-facing launcher/runtime strings and the Windows batch filename use title-case `Role Model`/`Role-Model`; stage/dev identities are absent. Pi correctly retains production endpoint `http://127.0.0.1:3456`, but stage/dev endpoint examples do not exist.
+- `R8`: blocked. Contribution, PR, recursive, CI/release, and release-checklist docs describe direct-main development and do not define the promotion/hotfix/resynchronization contract.
+- `R9`: blocked. Existing workflow and Go tests pass against the old topology. No invalid-promotion fixture, channel-profile tests, three-runtime concurrency test, state-isolation test, or final GitHub migration receipt exists.
+
+## Relevant Code Pointers
+
+- `.github/workflows/ci.yml`: current broad serial validation workflow.
+- `.github/workflows/build-binaries.yml`: current main/tag/manual runtime matrix and release publication.
+- `.github/workflows/docs-site-deploy.yml`: current single-site PR-build/main-deploy workflow.
+- `.github/workflows/cla.yml`: current `cla` check and main-based CLA storage.
+- `scripts/build-binaries-workflow.test.mjs`: binary-workflow contract test.
+- `apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs`: docs-workflow contract test.
+- `CONTRIBUTING.md` and `.github/pull_request_template.md`: contributor target-branch contract.
+- `role-model-router/apps/launcher/main.go`: hard-coded port, scope, state root, URLs, and launcher identity.
+- `role-model-router/apps/launcher/main_test.go`: current launcher argument tests.
+- `role-model-router/apps/runtime-host-bridge/src/package-sea.ts`: packaging, manifest, Go launcher, and `Role-Model.bat` creation.
+- `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`: current version/commit/build-date shape without channel metadata.
+- `role-model-router/apps/runtime-host-bridge/src/index.ts`: health/summary/version endpoints, standalone migration, stored OAuth location mirroring, and title-case discovery identity.
+- `role-model-router/apps/runtime-host-bridge/src/cli.ts`: raw SEA startup path and default option resolution used by Unix installs.
+- `role-model-router/apps/runtime-host-bridge/src/downstream-openai-discovery.ts`: literal runtime display name and effective base URL routes.
+- `scripts/install.sh`: Unix installer symlinks the raw SEA executable, so channel defaults must work without the Windows launcher.
+- `scripts/install.ps1`: Windows installer currently depends on the title-case batch filename and stable-release asset names.
+- `packages/pi-role-model/src/config.ts`: production endpoint default that must remain `3456`.
+- `docs/operations/02-ci-and-release-flow.md` and `03-release-checklist.md`: current direct-main operations contract.
+
+## Evidence
+
+- Repository settings: `default_branch=main`, `delete_branch_on_merge=false`, and all three merge methods enabled.
+- Branch topology: `origin/main...origin/stage` is `154 0`; `dev` is absent.
+- Main protection: required checks are only `["cla"]`; administrator enforcement, PR review requirements, and conversation resolution are disabled; force pushes and deletion are disabled.
+- GitHub environments: only `release` exists.
+- Cloudflare Pages: only `role-model-dev` exists; its domains are `role-model-dev.pages.dev` and `role-model.dev`.
+- `ci.yml` installs with `pnpm install --frozen-lockfile=false` and triggers on unfiltered pushes and pull requests.
+- `build-binaries.yml` verifies and packages `Role-Model.bat`; archive names have platform but no channel/SHA identity.
+- Launcher constants are `runtimePort=3456`, cache `Role Model Runtime`, and scope `standalone-runtime`.
+- Stored OAuth location resolution maps every non-`standalone-runtime` scope to a `standalone-runtime` counterpart under the selected container root. Distinct roots prevent direct production-filesystem leakage, but stage/dev would still duplicate credentials under a misleading production scope name; compatibility mirroring must become production-only or explicitly channel-aware.
+- Unix installation symlinks the raw SEA binary. Without a wrapper, it resolves port `3456`, title-case state, and scope `runtime-host-bridge`; channel defaults must therefore be consumed by the raw packaged executable, not only by the Windows launcher.
+- Phase 0 passed frozen install, both existing workflow contract tests, Go launcher tests with `GO111MODULE=off`, and 37-schema/30-fixture validation.
+
+## Known Unknowns
+
+- The exact GitHub required-check names can only be finalized after the new workflows run once; protections must be applied after check-name validation.
+- The current Cloudflare token can list projects, but domain movement is intentionally undecided because `role-model.dev` already serves from `role-model-dev`; the addendum removes any need to create dev/stage docs projects.
+- Runtime packaging is cross-platform, while the friendly Go launcher is Windows-only. The raw SEA executable used by `install.sh` must read the same packaged profile as the launcher so Unix packages do not silently fall back to production defaults.
+- Existing production state needs backward compatibility. Stage/dev must not participate in production legacy config or OAuth-location mirroring.
+
+## Source Requirement Inventory
+
+- `R1` | Disposition: `in-scope` | Source Quote: "Establish the three-branch integration and promotion contract" | Summary: establish dev integration and dev-to-stage-to-main promotion. | Owner: branch migration and contributor policy.
+- `R2` | Disposition: `in-scope` | Source Quote: "Protect branches and enforce promotion sources" | Summary: protect branches and enforce promotion sources. | Owner: GitHub protections and promotion guard.
+- `R3` | Disposition: `in-scope` | Source Quote: "Restructure CI into deliberate, diagnosable validation lanes" | Summary: deliberate required validation lanes. | Owner: CI workflow.
+- `R4` | Disposition: `in-scope` | Source Quote: "Provide separated development, staging, and production docs deployments" | Summary: the approved addendum narrows this to PR build plus one strictly main-only deploy. | Owner: docs workflow and locked addendum.
+- `R5` | Disposition: `in-scope` | Source Quote: "Align binary candidate and production release promotion" | Summary: stage candidates and tag-only stable releases. | Owner: binary workflow.
+- `R6` | Disposition: `in-scope` | Source Quote: "Add an explicit packaged-runtime channel profile" | Summary: explicit isolated runtime profiles on 3456/3457/3458. | Owner: runtime CLI, launcher, and packaging.
+- `R7` | Disposition: `in-scope` | Source Quote: "Make channel identity visible and consistently named" | Summary: exact lowercase channel identity and endpoint visibility. | Owner: runtime identity and docs.
+- `R8` | Disposition: `in-scope` | Source Quote: "Update repository policy and operations documentation" | Summary: update contribution and operations policy. | Owner: contributing and release docs.
+- `R9` | Disposition: `in-scope` | Source Quote: "Prove migration safety and concurrent runtime operation" | Summary: prove concurrent operation and migration safety. | Owner: automated and manual QA.
+
+## Prior Recursive Evidence Reviewed
+
+- `/.recursive/STATE.md` entries for attributable CI lanes, docs secret-skip behavior, release attestation retry, and runtime test lanes.
+- `/.recursive/DECISIONS.md` entries for workflow contract tests, single tag-gated release publication, recursive changelog generation, and GitHub-only validation caveats.
+- `/.recursive/memory/patterns/github-ci-and-release-workflow.md`: preserve workflow contract tests and distinguish repository definitions from external settings.
+- `/.recursive/memory/patterns/git-push-merge-workflow.md`: verify branch and ancestry around push/promotion operations.
+- `/.recursive/memory/skills/patterns/delegated-verification-and-refresh.md`: delegate only with a complete bundle and refresh evidence after repairs.
+
+## Audit Context
+
+Audit Execution Mode: `subagent`
+Subagent Availability: `available`
+Subagent Capability Probe: `collaboration agent accepted the bounded Phase 1 analyst task and returned file-backed FAIL then PASS re-audit verdicts`.
+Delegation Decision Basis: `The locked requirements, approved addendum, baseline receipt, current repository files, and external configuration reads form a complete bounded audit bundle.`
+Audit Inputs Provided:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+- targeted workflow, launcher, CLI, packaging, installer, runtime metadata, credential-location, and operations files listed above
+
+## Effective Inputs Re-read
+
+- Locked `00-requirements.md` and `00-worktree.md` were re-read.
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md` was re-read and changes effective `R4` to a single main-only docs deployment.
+- Current GitHub repository/branch/environment state and Cloudflare Pages project state were read immediately before this audit.
+
+## Earlier Phase Reconciliation
+
+- Phase 0 branch/runtime decisions remain applicable.
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`: effective `R4` is narrowed; no dev/stage Pages projects or docs environments will be planned.
+- Phase 0 baseline commands remain green; the initial Go module-mode failure was a command-context correction, not a product failure.
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase1-as-is-audit.md`.
+- Main-Agent Verification Performed:
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase1-as-is-analyst.md`
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase1-as-is-audit.md`
+  - `/.github/workflows/ci.yml`
+  - `/.github/workflows/build-binaries.yml`
+  - `/.github/workflows/docs-site-deploy.yml`
+  - `/role-model-router/apps/launcher/main.go`
+  - `/role-model-router/apps/runtime-host-bridge/src/cli.ts`
+  - `/role-model-router/apps/runtime-host-bridge/src/index.ts`
+  - `/role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+  - `/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+  - `/scripts/install.sh`
+  - `/scripts/install.ps1`
+- Acceptance Decision: accepted
+- Refresh Handling: `the review bundle was regenerated after material repairs and its artifact hash matched the repaired 01-as-is.md`.
+- Repair Performed After Verification:
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase1-as-is-analyst.md`
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4` plus `git status --short --untracked-files=all`
+- Base branch: `main`
+- Worktree branch: `recursive/78-dev-stage-main-cicd-runtime-channels`
+- Actual changed files reviewed: only the untracked run-78 recursive artifact directory.
+- Unexplained drift: none.
+
+## Gaps Found
+
+None. Phase 1 has no unresolved analysis or audit gaps. The product/configuration deficiencies identified in `## Current Behavior by Requirement` remain planned implementation work for later phases.
+
+## Repair Work Performed
+
+- Locked the Phase 1 upstream-gap addendum that narrows docs deployment to PR validation plus one main-only deploy.
+- Corrected docs manual-dispatch behavior, existing manifest hash/commit evidence, and the precise OAuth counterpart boundary after delegated review.
+- Elevated `cli.ts`, both installers, credential-location compatibility, and cross-platform channel profile delivery into explicit planning constraints.
+
+## Requirement Completion Status
+
+- R1 | Status: blocked | Rationale: dev/default-branch/topology settings and documentation are absent. | Blocking Evidence: GitHub repository settings, branch comparison, `CONTRIBUTING.md`.
+- R2 | Status: blocked | Rationale: protections and promotion guard are absent. | Blocking Evidence: `.github/workflows/ci.yml`, `.github/workflows/cla.yml`
+- R3 | Status: blocked | Rationale: current CI topology and mutable lockfile install do not meet the requirement. | Blocking Evidence: `.github/workflows/ci.yml`.
+- R4 | Status: superseded by approved addendum | Addendum: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md` | Audit Note: effective docs scope is PR build plus main-only deployment.
+- R5 | Status: blocked | Rationale: the manifest has executable hash/commit, but stage candidates, channel-aware artifact identity, and explicit promotion/core-payload evidence are absent. | Blocking Evidence: `.github/workflows/build-binaries.yml`, packaging manifest.
+- R6 | Status: blocked | Rationale: launcher and runtime metadata are production-hard-coded and channel isolation is absent. | Blocking Evidence: `role-model-router/apps/launcher/main.go`, `role-model-router/apps/runtime-host-bridge/src/cli.ts`, `role-model-router/apps/runtime-host-bridge/src/index.ts`
+- R7 | Status: blocked | Rationale: exact lowercase channel identity and endpoint docs are absent. | Blocking Evidence: `role-model-router/apps/runtime-host-bridge/src/package-sea.ts`, `README.md`, `docs/public/install.md`
+- R8 | Status: blocked | Rationale: policy and operations docs describe direct-main flow. | Blocking Evidence: `CONTRIBUTING.md`, `.github/pull_request_template.md`, `docs/operations/02-ci-and-release-flow.md`, `docs/operations/03-release-checklist.md`
+- R9 | Status: blocked | Rationale: migration and concurrent-runtime proofs do not exist. | Blocking Evidence: `scripts/build-binaries-workflow.test.mjs`, `role-model-router/apps/launcher/main_test.go`, `role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts`
+
+## Audit Verdict
+
+- Summary: the delegated audit found five evidence-precision gaps; all were repaired, the bundle was refreshed, and independent re-audit returned PASS.
+Audit: PASS
+
+## Traceability
+
+- `R1` -> branch/settings evidence in `## Current Behavior by Requirement` and GitHub reads.
+- `R2` -> protection and guard evidence in `## Current Behavior by Requirement` and `.github/workflows/ci.yml`.
+- `R3` -> CI trigger/install/lane evidence in `.github/workflows/ci.yml`.
+- `R4` -> locked addendum plus `.github/workflows/docs-site-deploy.yml` and Cloudflare evidence.
+- `R5` -> `.github/workflows/build-binaries.yml` and `package-sea.ts` manifest evidence.
+- `R6` -> launcher, CLI, packaging, metadata, and credential-location evidence.
+- `R7` -> naming and endpoint evidence in launcher/package/docs searches.
+- `R8` -> contributor, PR, recursive, and operations documentation evidence.
+- `R9` -> baseline test receipt and missing migration/concurrency coverage.
+
+## Coverage Gate
+
+- [x] Every R1-R9 requirement has current behavior and evidence
+- [x] The approved docs-site scope correction is effective input
+- [x] Repository, GitHub, Cloudflare, packaging, and runtime-state surfaces are covered
+- [x] OOS1-OOS5 remain preserved
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] The user approved implementation after tracker creation
+- [x] The user explicitly narrowed docs-site deployment scope
+- [x] No production repository, GitHub, or Cloudflare setting has been mutated during AS-IS audit
+
+Approval: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md
@@ -1,0 +1,342 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `02 TO-BE plan`
+Status: `LOCKED`
+LockedAt: `2026-07-19T00:12:45Z`
+LockHash: `d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md` (LOCKED)
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md` (LOCKED)
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md` (LOCKED)
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md` (LOCKED)
+- `/.recursive/STATE.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/memory/patterns/github-ci-and-release-workflow.md`
+- `/.recursive/memory/patterns/git-push-merge-workflow.md`
+Outputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+Scope note: Define the test-first repository, workflow, packaged-runtime, documentation, and recoverable GitHub migration sequence; docs remain a single main-only deployment.
+
+## TODO
+
+- [x] Reconcile locked requirements, AS-IS, and docs addendum
+- [x] Map R1-R9 to implementation, verification, and QA surfaces
+- [x] Define RED-GREEN-REFACTOR sub-phases and stop gates
+- [x] Define cross-platform runtime profile and compatibility behavior
+- [x] Define recoverable GitHub migration order
+- [x] Define rollback, security, and failure handling
+- [x] Run independent Phase 2 audit
+- [x] Repair findings and re-audit to PASS
+- [x] Complete Coverage and Approval gates
+
+## Audit Context
+
+Audit Execution Mode: `subagent`
+Subagent Availability: `available`
+Subagent Capability Probe: `the Phase 1 analyst completed a bounded review and re-audit using the canonical bundle`.
+Delegation Decision Basis: `the plan has locked inputs, explicit file/test surfaces, and bounded external mutations suitable for independent audit`.
+Audit Inputs Provided:
+- all paths under `Inputs`
+- diff basis `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4 -> working-tree`
+- planned workflow, runtime, installer, docs, and GitHub settings surfaces below
+
+## Effective Inputs Re-read
+
+- `00-requirements.md`: R1-R9, OOS1-OOS5, exact ports, state/scope identities, naming, and migration constraints.
+- `00-worktree.md`: isolated worktree and normalized baseline.
+- `01-as-is.md`: current GitHub topology, workflow triggers, runtime hard-coding, manifest evidence, and Unix raw-SEA behavior.
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`: docs are PR-build plus one strictly main-only deployment; no dev/stage Pages topology.
+
+## Earlier Phase Reconciliation
+
+- Phase 0 fixed decisions remain effective except original R4, which the locked addendum narrows.
+- Phase 1 proved stage/dev defaults must be consumed by both the Windows launcher and raw SEA CLI.
+- Phase 1 clarified OAuth compatibility mirroring is a misleading duplicate scope within a selected root, not proven cross-root leakage; the plan still removes it for non-production channels.
+- No product files have changed; Phase 3 starts with executable RED tests.
+
+## Prior Recursive Evidence Reviewed
+
+- `/.recursive/memory/patterns/github-ci-and-release-workflow.md`: keep workflow contract tests and distinguish repository workflow definitions from external settings.
+- `/.recursive/memory/patterns/git-push-merge-workflow.md`: verify branch, remote URL, ahead/behind, and ancestry immediately around every push or promotion.
+- `/.recursive/STATE.md` and `/.recursive/DECISIONS.md`: retain attributable runtime lanes, tag-only stable release publication, attestation retries, and visible docs credential skips.
+
+## Source Requirement Inventory
+
+- `R1` | Disposition: `in-scope` | Summary: dev integration and dev-to-stage-to-main promotion.
+- `R2` | Disposition: `in-scope` | Summary: branch protection and promotion-source enforcement.
+- `R3` | Disposition: `in-scope` | Summary: deliberate required CI lanes.
+- `R4` | Disposition: `in-scope` | Summary: effective addendum requires PR build plus main-only docs deploy.
+- `R5` | Disposition: `in-scope` | Summary: stage candidates, manual dev artifacts, and tag-only releases.
+- `R6` | Disposition: `in-scope` | Summary: explicit cross-platform packaged-runtime profiles.
+- `R7` | Disposition: `in-scope` | Summary: lowercase channel identity and endpoint visibility.
+- `R8` | Disposition: `in-scope` | Summary: contribution and operations policy.
+- `R9` | Disposition: `in-scope` | Summary: workflow/migration/concurrent-runtime proof.
+
+## Requirement Mapping
+
+- `R1` | Coverage: `direct` | Source Quote: "Establish the three-branch integration and promotion contract" | Implementation Surface: `CONTRIBUTING.md`, `.github/pull_request_template.md` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: GitHub API branch/default/ancestry reads.
+- `R2` | Coverage: `direct` | Source Quote: "Protect branches and enforce promotion sources" | Implementation Surface: `.github/workflows/ci.yml` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: GitHub API protection reads and promotion-source matrix.
+- `R3` | Coverage: `direct` | Source Quote: "Restructure CI into deliberate, diagnosable validation lanes" | Implementation Surface: `.github/workflows/ci.yml` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: GitHub checks on the implementation PR.
+- `R4` | Coverage: `merged` | Source Quote: "Provide separated development, staging, and production docs deployments" | Implementation Surface: `.github/workflows/docs-site-deploy.yml` | Verification Surface: `apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs` | QA Surface: main-only condition inspection and production URL health. | Merge Rationale: the approved addendum replaces three docs deployments with PR build plus one main deployment.
+- `R5` | Coverage: `direct` | Source Quote: "Align binary candidate and production release promotion" | Implementation Surface: `.github/workflows/build-binaries.yml`, `role-model-router/apps/runtime-host-bridge/src/package-sea.ts` | Verification Surface: `scripts/build-binaries-workflow.test.mjs` | QA Surface: dev/stage/prod manifest and archive identity.
+- `R6` | Coverage: `direct` | Source Quote: "Add an explicit packaged-runtime channel profile" | Implementation Surface: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`, `role-model-router/apps/runtime-host-bridge/src/cli.ts`, `role-model-router/apps/launcher/main.go` | Verification Surface: `role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts`, `role-model-router/apps/launcher/main_test.go` | QA Surface: three live runtimes and isolated state roots.
+- `R7` | Coverage: `direct` | Source Quote: "Make channel identity visible and consistently named" | Implementation Surface: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`, `role-model-router/apps/runtime-host-bridge/src/index.ts`, `docs/public/install.md` | Verification Surface: `role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts` | QA Surface: health/version/UI identity on all ports.
+- `R8` | Coverage: `direct` | Source Quote: "Update repository policy and operations documentation" | Implementation Surface: `CONTRIBUTING.md`, `.github/pull_request_template.md`, `docs/operations/02-ci-and-release-flow.md`, `docs/operations/03-release-checklist.md` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: rendered policy review.
+- `R9` | Coverage: `direct` | Source Quote: "Prove migration safety and concurrent runtime operation" | Implementation Surface: `role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts`, `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/` | Verification Surface: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/04-test-summary.md` | QA Surface: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`.
+
+## Plan Drift Check
+
+- The docs addendum removes development/staging Pages projects and environments from the original scope.
+- Cross-platform profile consumption adds `cli.ts` and Unix installer coverage discovered in Phase 1; this is required to satisfy the original concurrent-runtime requirement.
+- Production-only legacy compatibility is preserved; stage/dev never consult production state or compatibility scopes.
+- No automatic promotion, history rewrite, shared state, unrelated API redesign, or new distribution ecosystem is introduced.
+
+## Design Decisions
+
+1. Runtime build channels are `production`, `stage`, and `development`; trusted workflow/local input is `ROLE_MODEL_BUILD_CHANNEL` and unknown values fail packaging.
+2. Profiles are: production `role-model/3456/role-model-runtime/standalone-runtime`; stage `role-model-stage/3457/role-model-runtime-stage/standalone-runtime-stage`; development `role-model-dev/3458/role-model-runtime-dev/standalone-runtime-dev`.
+3. Local packaging defaults to `development` as the collision-safe choice; explicit `production` is required for stable release packaging.
+4. `manifest.json` is the portable profile contract. Both raw SEA startup and the Windows Go launcher read it; explicit CLI arguments remain test/operator overrides.
+5. The packaged binary is channel-neutral. The manifest separates `source_tree` (Git tree OID), `executable_sha256` (final named executable bytes), and `core_payload_sha256` (the raw SEA executable bytes before thin profile/launcher staging). Source-tree equality is diagnostic only. Stage uploads attested per-target core payloads named by source tree; a production tag must retrieve the matching successful stage core and reuse it, or deterministically rebuild and byte-compare before proceeding. A missing/mismatched stage digest fails production packaging.
+6. Default state roots use the platform user state/cache base plus the profile's exact root name. Production owns a copy-only, first-start cross-root migration from both legacy layouts: Windows `Role Model Runtime/standalone-runtime/**` and raw-SEA `Role Model Runtime/state/runtime-host-bridge/**`, mapped into canonical `role-model-runtime/standalone-runtime/**`. It covers credentials, codex-subscription state, memory SQLite/sidecars, and scoped `operator-intent.json`, plus the applicable root/state runtime config and policy/override/peer JSON. Destination files win; otherwise the Windows standalone source wins a conflicting raw-SEA source, byte-identical duplicates copy once, and every skipped conflict is recorded without deleting either source. Logs, PID/lock/temp files are excluded; stage/dev never inspect the title-case root.
+7. Health/version/runtime summary expose channel, name, effective endpoint, commit/version/build date, source-tree hash, and executable hash when available.
+8. CI jobs have stable names: `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, and `smoke`. Each has read-only permissions, timeout, frozen install, and concurrency cancellation.
+9. PRs to stage accept only `dev`; PRs to main accept only `stage`, except reviewed `hotfix/*` emergency PRs. Dev accepts ordinary short-lived branches.
+10. Binary matrices run automatically for stage candidates and production tags; dev artifacts require explicit dispatch. Only tags publish stable releases through `release`.
+11. Docs build on relevant PRs and deploy only when `github.ref == refs/heads/main`; manual runs from another ref cannot deploy.
+12. External GitHub changes occur only after repository tests pass: create/update branches without force, configure protections, then change default to dev and verify. Cloudflare topology is not expanded.
+
+## Planned Changes by File
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/build-binaries.yml`
+- `.github/workflows/docs-site-deploy.yml`
+- `scripts/ci-workflow.test.mjs` (new)
+- `scripts/build-binaries-workflow.test.mjs`
+- `apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts` (new)
+- `role-model-router/apps/runtime-host-bridge/src/cli.ts`
+- `role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+- `role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+- focused host tests including `runtime-channel.test.ts`, `runtime-version.test.ts`, `executable.test.ts`, and `index.test.ts`
+- `role-model-router/apps/launcher/main.go` and `main_test.go`
+- `scripts/install.sh`, `scripts/install.ps1`, and installer assertions
+- `CONTRIBUTING.md`, `.github/pull_request_template.md`, `.codex/AGENTS.md`
+- `docs/operations/02-ci-and-release-flow.md`, `03-release-checklist.md`, and runtime testing/installation docs
+- root/package script wiring only where needed for named contract tests.
+
+## Implementation Steps
+
+1. SP1: write failing workflow topology/promotion/docs/binary tests, then update workflows.
+2. SP2: write failing runtime-profile/version/options tests, then add the canonical profile and manifest contract.
+3. SP3: write failing Go/CLI/packaging/installer tests, then make all packaged launch paths consume the profile.
+4. SP4: write failing metadata/isolation tests, then expose identity and restrict legacy compatibility to production.
+5. SP5: update policy/operations docs with contract assertions.
+6. SP6: run focused/full validation, build three local profiles, and execute concurrent-runtime QA.
+7. SP7: apply recoverable GitHub topology/protections/settings and capture before/after evidence; leave Cloudflare project topology unchanged.
+
+## Implementation Sub-phases
+
+### SP1 — Workflow topology and promotion guard (`R1`-`R5`, `R8`)
+
+- RED: add contract tests that fail on broad push triggers, mutable install, missing concurrency/permissions/timeouts, invalid promotion acceptance, arbitrary-ref docs deploy, absent stage matrix, and ambiguous artifact names.
+- GREEN: split stable CI jobs; add promotion guard; make docs deploy strictly main-only; make binary channel selection explicit with stage candidates, manual dev artifacts, and tag-only releases.
+- REFACTOR: centralize repeated workflow assertions in test helpers without hiding check names.
+- Gate: invalid `feature -> stage`, `feature -> main`, and `dev -> main` fixtures fail; `feature -> dev`, `dev -> stage`, `stage -> main`, and `hotfix/* -> main` pass.
+- Recovery: workflow-only changes can be reverted before any external setting requires their check names.
+
+### SP2 — Canonical runtime channel/profile contract (`R5`-`R7`)
+
+- RED: profile resolver rejects unknown channels and asserts all exact names/ports/state roots/scope IDs; version/profile manifest tests require channel/name/endpoint, `source_tree`, `executable_sha256`, and real `core_payload_sha256` identity; workflow tests fail production without a matching successful stage payload.
+- GREEN: add `runtime-channel.ts`; package `manifest.json` with separated profile/source/executable/core identities; stage uploads attested per-target channel-neutral cores; production reuses or deterministically verifies exact stage core bytes; default local packaging to development and workflow packaging explicitly by ref/input.
+- REFACTOR: one typed resolver owns channel constants; no duplicate TS port/name tables.
+- Gate: production remains 3456 and Pi default is unchanged; stage/dev are 3457/3458.
+- Recovery: manifest additions are backward compatible; missing manifests retain production source-development defaults.
+
+### SP3 — Cross-platform packaged launch behavior (`R6`, `R7`, `R9`)
+
+- RED: Go tests require manifest-derived args/base URLs/names; CLI tests execute an extracted Unix install layout outside `role-model-router/dist/release/*` and require adjacent-manifest package-root/static/vendor resolution; installer/package tests require lowercase channel executables and launchers. Missing manifest is allowed only for explicit source-development layout and fails visibly for an extracted official package.
+- GREEN: raw CLI and Windows launcher read the adjacent manifest; packaged repoRoot resolves to the adjacent package directory so static and staged vendor assets remain addressable after installation; package executable/launcher/batch names follow profile; installers resolve channel-appropriate assets/commands without stable-channel regressions.
+- REFACTOR: explicit CLI arguments override profile defaults consistently; one manifest schema is mirrored minimally in Go.
+- Gate: Unix raw executable and Windows launcher produce the same effective profile.
+- Recovery: malformed/missing manifest fails visibly for official packages; source-development fallback remains explicit and tested.
+
+### SP4 — Runtime identity and state/credential isolation (`R6`, `R7`, `R9`)
+
+- RED: health/version/summary tests require name/channel/endpoint/build identity; credential-location tests prove stage/dev return only active locations; state tests prove distinct roots; cross-root fixtures cover Windows `standalone-runtime` and raw-SEA `state/runtime-host-bridge` credentials, subscriptions, memory SQLite/sidecars, operator intent, root/state configs, destination-wins and standalone-over-raw precedence, byte-identical duplicates, excluded logs/locks, repeat start, and stage/dev zero reads of the title-case root.
+- GREEN: thread profile metadata through backend/server responses and discovery; implement copy-only production migration before backend initialization; make legacy config/OAuth mirroring production-only; replace new identity strings with exact lowercase names.
+- REFACTOR: metadata builders are pure and reusable by health/version/summary.
+- Gate: a write/restart in one profile cannot change another root and stopping one process does not affect the other two.
+- Recovery: production legacy migration is copy-once and never deletes the legacy source.
+
+### SP5 — Repository and operations policy (`R1`, `R2`, `R5`, `R7`, `R8`)
+
+- RED: documentation contract assertions fail until target branches, promotion, hotfix, rollback, artifact identity, endpoints, and docs exception are documented.
+- GREEN: update contribution/PR/recursive guidance and CI/release/checklist/install/runtime testing docs.
+- Gate: exact examples include `ROLE_MODEL_ENDPOINT=http://127.0.0.1:3457` and `:3458`; canonical spelling is `role-model`.
+- Recovery: documentation follows tested workflow/profile constants and cannot broaden deployment scope.
+
+### SP6 — Automated and concurrent-runtime validation (`R3`, `R5`-`R9`)
+
+- Run focused workflow, TS, Go, installer, version, host, packaging, lint, schema, build, test, runtime, Rust, smoke, and docs checks according to changed-path matrix.
+- Package production, stage, and development with fixed build identity into separate retained evidence directories.
+- Start all three on 3456/3457/3458 with separate temporary state roots; verify metadata/UI/discovery; mutate and restart one; stop one; verify the other two.
+- Gate: no shared state/log/lock/PID paths; source-tree identity is comparable; executable hashes are reported honestly.
+- Recovery: processes use explicit PIDs and temporary roots; cleanup targets only verified run-78 evidence paths.
+
+### SP7 — Recoverable GitHub migration (`R1`, `R2`, `R4`, `R9`)
+
+- Snapshot remote/default/branch tips/protections/environments/settings and preserve the exact current main CLA-only protection payload for rollback.
+- Create the missing `dev` ref once from the validated main baseline through the GitHub refs API/non-force creation. Do not change the default or main protection yet.
+- Push this run branch, open its PR against `dev`, and observe a successful run of every stable check name. Apply dev protection only after those contexts exist; if checks or protection fail, dev remains non-default and main retains its original protection.
+- Merge the reviewed run PR to dev, then open a reviewed `dev -> stage` promotion PR. Align stale stage only through that merge commit—never by direct ref update—and observe promotion checks on the actual PR.
+- After dev/stage checks are proven, protect stage. Open/verify a `stage -> main` promotion PR and observe check names before replacing main's CLA-only protection with the complete main policy. On failure, restore the captured main payload exactly.
+- Protect main, enable delete-on-merge, and change default to dev last. Each mutation is independently read back; a failed later step restores only settings already changed and leaves existing protected branches protected.
+- Keep `release`; add only runtime candidate/production environments if workflows actually reference them. Do not create dev/stage docs Pages projects or move `role-model.dev`.
+- Gate: final API receipt records default, tips, protections, environments, merge settings, and no destructive history rewrite.
+- Recovery: default can be restored to main; protections/settings are captured before mutation; branches are never force-updated or deleted.
+
+## Testing Strategy
+
+- Workflow contract: Node tests for CI, promotion guard, docs main-only behavior, binary channel matrix/names/publication.
+- Runtime unit: profile resolver, option precedence, manifest/version metadata, credential location, discovery identity.
+- Launcher: `GO111MODULE=off go test ./...` with production/stage/dev manifest fixtures.
+- Packaging: focused executable/package tests plus three profile packages; validate no QA artifacts.
+- Regression: frozen install, lint, schemas, build, test, runtime critical/router, Rust, smoke, docs build.
+- Live QA: three concurrent processes with fixed local ports and temporary state roots.
+- External: GitHub API before/after receipt and first workflow check-name verification.
+- Payload promotion: attested stage core download/reuse or deterministic core byte comparison; source-tree equality alone never passes the gate.
+
+## Playwright Plan (if applicable)
+
+- No new browser interaction behavior is planned, so a new Playwright spec is not the primary regression surface.
+- Existing runtime browser smoke remains in the changed-path matrix. Live QA fetches each packaged `/app` page and verifies same-origin API/endpoint identity; if profile changes alter browser launch or visible UI behavior, add a focused Playwright case before implementation closeout.
+
+## Manual QA Scenarios
+
+1. Start production, stage, and development packages concurrently and verify 3456/3457/3458 metadata.
+2. Write configuration in development, restart it, and prove production/stage state timestamps and contents remain unchanged.
+3. Stop stage and prove production/development health and UI remain available.
+4. Exercise Windows manifest-derived launcher arguments through Go tests and Unix raw-SEA startup through a local package.
+5. Inspect allowed/rejected promotion-source fixtures and the final GitHub branch/protection/default state.
+6. Verify the docs workflow cannot deploy a manually selected non-main ref and that the current production docs URL remains healthy.
+
+## Idempotence and Recovery
+
+- Re-running branch creation is a no-op when the expected tip already exists; mismatched tips stop the migration.
+- Protection/settings writes use read-before-write payloads and are verified after each mutation.
+- Runtime legacy migration copies only missing production configuration and never deletes the source; repeated starts do not recopy over canonical state.
+- If a production migration copy fails, startup stops before opening the new database and leaves both source and already-existing destination files intact for inspection.
+- Packaging removes only the selected release target and each channel's evidence copy is retained separately.
+- QA cleanup records exact PIDs and temporary roots before stopping/removing them.
+
+## Security and Permissions Plan
+
+- Workflows declare least-privilege permissions; only attestation/release jobs receive write scopes already required.
+- `pull_request_target` remains confined to the CLA workflow; promotion guard runs untrusted PR data without secrets.
+- Docs deployment credentials are available only to a main-only deploy job and never to PR builds.
+- Runtime manifests contain no secrets; channel identity cannot redirect state outside the platform-owned base directory.
+- GitHub writes are repository-scoped, read-before-write, non-force, and independently verifiable.
+
+## Failure and Recovery Plan
+
+- A failing workflow contract blocks external migration.
+- A failing channel package blocks GitHub protection/default-branch changes.
+- A stage candidate never promotes automatically and a failed/skipped approval cannot publish production.
+- If required check names differ on GitHub, leave protections unchanged until actual names are observed.
+- If the Cloudflare production project/domain cannot be safely established, retain existing docs deployment target and report the external blocker; do not detach `role-model.dev`.
+- Concurrent QA cleanup stops only recorded PIDs and removes only validated run-78 temporary roots.
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4` plus untracked status.
+- Planned product files: paths under `## Planned Changes by File`.
+- Actual product changes: none before plan lock.
+- Unexplained drift: none; only run-78 recursive artifacts exist.
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase2-plan-audit.md`.
+- Main-Agent Verification Performed:
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase2-plan-planner.md`
+  - `/.github/workflows/ci.yml`
+  - `/.github/workflows/build-binaries.yml`
+  - `/.github/workflows/docs-site-deploy.yml`
+  - `/role-model-router/apps/runtime-host-bridge/src/cli.ts`
+  - `/role-model-router/apps/runtime-host-bridge/src/index.ts`
+  - `/role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+  - `/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+  - `/role-model-router/apps/launcher/main.go`
+  - `/scripts/install.sh`
+  - `/scripts/install.ps1`
+- Acceptance Decision: accepted
+- Refresh Handling: `the canonical Phase 2 review bundle was regenerated after each material repair and the final bundle matched the accepted plan`.
+- Repair Performed After Verification:
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+  - `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase2-plan-planner.md`
+
+## Gaps Found
+
+None. The independent audit's four initial gaps and one re-audit migration gap were repaired; no unmapped plan gap remains.
+
+## Repair Work Performed
+
+- Replaced source-tree-as-payload proof with separated source tree, executable digest, and attested real core payload digest plus a production reuse/byte-compare gate.
+- Added extracted Unix installation layout, adjacent package-root, static/vendor, and missing-manifest behavior.
+- Sequenced dev creation, PR checks, promotions, protections, main rollback, and default-branch change into recoverable steps.
+- Defined copy-only migration from both Windows and raw-SEA legacy production layouts with durable-path inventory and precedence fixtures.
+
+## Requirement Completion Status
+
+- R1 | Status: planned | Implementation Surface: `CONTRIBUTING.md`, `.github/pull_request_template.md` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: GitHub branch/default/ancestry receipt.
+- R2 | Status: planned | Implementation Surface: `.github/workflows/ci.yml` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: GitHub protection and promotion-source receipt.
+- R3 | Status: planned | Implementation Surface: `.github/workflows/ci.yml` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: GitHub required-check receipt.
+- R4 | Status: superseded by approved addendum | Addendum: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md` | Audit Note: effective behavior is planned in SP1/SP7 without extra Pages projects.
+- R5 | Status: planned | Implementation Surface: `.github/workflows/build-binaries.yml`, `role-model-router/apps/runtime-host-bridge/src/package-sea.ts` | Verification Surface: `scripts/build-binaries-workflow.test.mjs` | QA Surface: channel artifact receipt.
+- R6 | Status: planned | Implementation Surface: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`, `role-model-router/apps/runtime-host-bridge/src/cli.ts`, `role-model-router/apps/launcher/main.go` | Verification Surface: `role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts`, `role-model-router/apps/launcher/main_test.go` | QA Surface: concurrent runtime receipt.
+- R7 | Status: planned | Implementation Surface: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`, `role-model-router/apps/runtime-host-bridge/src/index.ts`, `docs/public/install.md` | Verification Surface: `role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts` | QA Surface: exact identity/endpoint receipt.
+- R8 | Status: planned | Implementation Surface: `CONTRIBUTING.md`, `.github/pull_request_template.md`, `docs/operations/02-ci-and-release-flow.md` | Verification Surface: `scripts/ci-workflow.test.mjs` | QA Surface: policy review receipt.
+- R9 | Status: planned | Implementation Surface: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/` | Verification Surface: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/04-test-summary.md` | QA Surface: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`.
+
+## Audit Verdict
+
+- Summary: independent planner audit returned PASS after all payload, installed-layout, migration-order, and legacy-state repairs.
+Audit: PASS
+
+## Traceability
+
+- `R1` -> SP1, SP5, SP7.
+- `R2` -> SP1, SP7.
+- `R3` -> SP1, SP6.
+- `R4` -> approved addendum, SP1, SP7.
+- `R5` -> SP1, SP2, SP6.
+- `R6` -> SP2-SP4, SP6.
+- `R7` -> SP2-SP5, SP6.
+- `R8` -> SP5.
+- `R9` -> SP1-SP7.
+
+## Coverage Gate
+
+- [x] R1-R9 map to implementation, verification, and QA
+- [x] Effective docs addendum is reconciled
+- [x] Windows and Unix package launch paths are covered
+- [x] GitHub migration is ordered, recoverable, and non-destructive
+- [x] OOS1-OOS5 remain excluded
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] User approved implementation after tracker creation
+- [x] User narrowed docs topology and the plan honors it
+- [x] External writes wait for repository validation
+- [x] No destructive history or production-domain move is planned
+
+Approval: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/03-implementation-summary.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/03-implementation-summary.md
@@ -1,0 +1,144 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `03 Implementation`
+Status: `LOCKED`
+LockedAt: `2026-07-19T00:57:17Z`
+LockHash: `7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a`
+Workflow version: `recursive-mode-audit-v2`
+Inputs: locked requirements, worktree, AS-IS, addendum 01, and TO-BE plan.
+Outputs: CI/CD workflows, channel-aware packages, isolated runtime state, migration compatibility, policy docs, tests, and runtime QA inputs.
+Scope note: Implements repository behavior before recoverable GitHub settings migration.
+
+## TODO
+
+- [x] Re-read effective locked inputs and addendum
+- [x] Execute workflow, runtime-profile, and migration RED/GREEN slices
+- [x] Implement SP1-SP6 product and documentation changes
+- [x] Reconcile the full product/test diff against the baseline
+- [x] Run automated and packaged-runtime verification
+
+## Effective Inputs Re-read
+
+- `00-requirements.md`
+- `00-worktree.md`
+- `01-as-is.md`
+- `02-to-be-plan.md`
+- `addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+
+The addendum remains controlling: the docs site keeps one simple main-only deployment and does not receive three Cloudflare environments.
+
+## Changes Applied
+
+- Split CI into stable `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, and `smoke` lanes for `dev`, `stage`, and `main`, with frozen installs, least privilege, timeouts, and cancellation.
+- Added promotion-source enforcement: `dev -> stage -> main`, with reviewed `hotfix/* -> main` as the only exception.
+- Made runtime packaging channel-aware with exact profiles: production `role-model:3456`, stage `role-model-stage:3457`, and development `role-model-dev:3458`.
+- Added manifest identity and separated `source_tree`, executable digest, and core-payload digest; production tags require a matching tested stage candidate payload.
+- Updated raw SEA and Windows launcher behavior to read adjacent manifests, use channel-specific names/ports/state roots, and support extracted install layouts.
+- Added production-only, copy-only migration from the title-case legacy root with destination-wins and Windows-layout-over-raw-SEA precedence. Stage and development never read legacy production state.
+- Exposed channel identity through health/version/summary metadata and normalized newly introduced user-facing product names to `role-model`.
+- Reduced docs CI/CD to relevant PR builds plus one strictly main-only deploy and post-deploy health check.
+- Updated contributor, installation, release, rollback, hotfix, and promotion documentation.
+- Restricted the Windows launcher to the exact executable declared by each fixed channel profile; manifest path redirects fail closed.
+
+## TDD Compliance Log
+
+- TDD Mode: `strict`
+- RED Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/red/workflow-runtime-migration-red.md`
+- GREEN Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+- Workflow contracts, runtime profiles/version, and state migration each failed for the intended missing behavior before production edits.
+- Compatibility regressions found by the full suite were repaired and rerun: production credential counterpart fixtures now use production scopes, and package-option tests use isolated adjacent manifests.
+
+TDD Compliance: PASS
+
+## Plan Deviations
+
+- The docs deployment was intentionally narrowed by approved addendum 01.
+- GitHub branch creation, protections, default-branch mutation, and PR creation remain an external SP7 action after this implementation/review gate; no external setting is claimed here.
+- Live QA used an already-running main runtime on `3456`, which provided stronger coexistence evidence than starting another production copy. Only temporary stage/dev processes were stopped.
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4` plus `git ls-files --others --exclude-standard`.
+- Actual changes reviewed: workflows, contributor/operations/install docs, installers, Go launcher, runtime channel/version/options/package/migration code, owning tests, and Run-78 artifacts.
+- Unexplained drift: none. Packaging-generated llama-swap binary drift was restored from the verified baseline copy.
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: `subagents/phase1-as-is-audit.md`, `subagents/phase2-plan-audit.md`.
+- Main-Agent Verification Performed: prior action records were reconciled before their phase locks; Phase 3 implementation and testing were controller-owned.
+- Acceptance Decision: accepted for upstream context; no subagent-authored product edits were used.
+- Refresh Handling: product diff, tests, package manifests, runtime endpoints, and generated binary drift were rechecked after final repairs.
+- Repair Performed After Verification: fixed legacy config precedence and production-scope compatibility fixtures.
+
+## Implementation Evidence
+
+- Workflow contracts: `scripts/ci-workflow.test.mjs`, `scripts/build-binaries-workflow.test.mjs`, `apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs`.
+- Runtime contracts: `role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts`, `runtime-channel-options.test.ts`, `runtime-version.test.ts`, `runtime-state-migration.test.ts`.
+- Launcher contracts: `role-model-router/apps/launcher/main_test.go`.
+- TDD receipts: `evidence/logs/red/workflow-runtime-migration-red.md`, `evidence/logs/green/workflow-runtime-migration-green.md`.
+
+## Gaps Found
+
+None for the Phase 3 implementation surface.
+
+## Repair Work Performed
+
+- Corrected two stale lowercase/channel assertions and two production credential-compatibility fixtures found by the full suite.
+- Made the packaged-options test independent of a real generated release directory.
+- Added docs post-deploy verification.
+- Corrected Windows legacy runtime config precedence over raw-SEA config.
+- Rejected launcher manifest executable redirects and removed stale user-facing installer names found during review.
+
+## Requirement Completion Status
+
+- R1 | Status: implemented | Changed Files: `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.codex/AGENTS.md` | Implementation Evidence: `CONTRIBUTING.md`
+- R2 | Status: implemented | Changed Files: `.github/workflows/ci.yml` | Implementation Evidence: `.github/workflows/ci.yml`
+- R3 | Status: verified | Changed Files: `.github/workflows/ci.yml` | Implementation Evidence: `.github/workflows/ci.yml` | Verification Evidence: `scripts/ci-workflow.test.mjs`
+- R4 | Status: superseded by approved addendum | Addendum: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- R5 | Status: verified | Changed Files: `.github/workflows/build-binaries.yml`, `role-model-router/apps/runtime-host-bridge/src/package-sea.ts` | Implementation Evidence: `.github/workflows/build-binaries.yml` | Verification Evidence: `scripts/build-binaries-workflow.test.mjs`
+- R6 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`, `role-model-router/apps/runtime-host-bridge/src/cli.ts`, `role-model-router/apps/launcher/main.go` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts` | Verification Evidence: `role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts`, `role-model-router/apps/launcher/main_test.go`
+- R7 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`, `role-model-router/apps/runtime-host-bridge/src/index.ts`, `docs/public/install.md` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts` | Verification Evidence: `role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts`
+- R8 | Status: verified | Changed Files: `CONTRIBUTING.md`, `docs/operations/02-ci-and-release-flow.md`, `docs/operations/03-release-checklist.md` | Implementation Evidence: `docs/operations/02-ci-and-release-flow.md` | Verification Evidence: `scripts/ci-workflow.test.mjs`
+- R9 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts`, `role-model-router/apps/runtime-host-bridge/test/runtime-state-migration.test.ts` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+
+## Traceability
+
+- R1/R2/R3 -> SP1 workflow files, promotion guard, and workflow contract tests.
+- R4 -> approved addendum 01 and main-only docs workflow/test.
+- R5 -> SP2 package manifest, stage candidate, and production payload comparison.
+- R6/R7 -> SP2-SP4 typed profile, launcher, extracted layout, identity metadata, and isolated roots.
+- R8 -> SP5 contributor, operations, release, rollback, and install docs.
+- R9 -> SP4 migration tests and SP6 concurrent package execution.
+
+## Coverage Gate
+
+Coverage: PASS
+
+All effective product requirements have implementation and verification coverage; R4 is governed by the approved docs addendum.
+
+## Approval Gate
+
+Approval: PASS
+
+No unresolved product blocker prevents Phase 3.5 review.
+
+## Audit Context
+
+Audit Execution Mode: `self-audit`
+Subagent Availability: available
+Subagent Capability Probe: prior phase auditors completed; Phase 3 was verified directly against builds, tests, manifests, and live processes.
+Delegation Decision Basis: implementation process ownership and live runtime QA remained with the controller.
+Delegation Override Reason: none.
+Audit Inputs Provided: locked inputs, full diff, RED/GREEN receipt, all test outputs, package manifests, and live health/state results.
+
+## Earlier Phase Reconciliation
+
+Implementation follows the repaired locked plan and approved docs addendum. The core-payload digest is separate from source identity and is compared against a successful stage artifact before production publication.
+
+## Audit Verdict
+
+Audit: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/03.5-code-review.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/03.5-code-review.md
@@ -1,0 +1,137 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `03.5 Code Review`
+Status: `LOCKED`
+LockedAt: `2026-07-19T00:58:53Z`
+LockHash: `d435c5e595c7a2d782e695bda19c43db7c6d9b581d3acde0a5ad8fca1994199a`
+Workflow version: `recursive-mode-audit-v2`
+Inputs: locked requirements, AS-IS, addendum 01, plan, implementation summary, canonical review bundle, and current diff.
+Outputs: classified findings, repair reconciliation, and approval verdict.
+Scope note: Reviews repository implementation before external GitHub migration.
+
+## TODO
+
+- [x] Generate and refresh the canonical review bundle
+- [x] Re-read effective upstream artifacts and addendum
+- [x] Review workflow, package, launcher, runtime, migration, installer, documentation, and test diffs
+- [x] Repair and retest findings
+- [x] Reconcile the final diff and verification evidence
+
+## Review Execution
+
+- Execution Mode: `self-audit`
+- Review Bundle: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase-03-5-code-review.md`
+- Diff Basis: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4..working-tree`
+
+The bundle grounds this review in `00-requirements.md`, `01-as-is.md`, `02-to-be-plan.md`, the docs addendum, `03-implementation-summary.md`, all 33 changed paths, and the GREEN receipt.
+
+## Review Scope
+
+The review explicitly reconciles bundle-listed upstream artifacts `.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`, `.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`, `.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`, and `.recursive/run/78-dev-stage-main-cicd-runtime-channels/03-implementation-summary.md`. It also checked the bundle-listed prior recursive router `.recursive/memory/skills/SKILLS.md` for relevant reusable guidance. Product scope covers all changed workflow, runtime, launcher, installer, documentation, test, and run-artifact paths in the canonical bundle.
+
+## Effective Inputs Re-read
+
+- `00-requirements.md`
+- `01-as-is.md`
+- `02-to-be-plan.md`
+- `03-implementation-summary.md`
+- `addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- `evidence/review-bundles/phase-03-5-code-review.md`
+
+## Plan Alignment Assessment
+
+SP1-SP6 are implemented as planned. The docs workflow follows addendum 01, and SP7 remains sequenced after this review/test gate. Production artifacts compare a real executable/core digest against the matching stage candidate rather than treating source identity as payload proof.
+
+## Code Quality Assessment
+
+Channel constants are centralized in TypeScript and strictly mirrored/validated by Go. Runtime state selection uses fixed profile-owned directory names, explicit CLI values retain precedence, and production migration is copy-only. Workflow check names are stable and contract-tested. Docs deployment remains a single isolated exception.
+
+## Issues Found
+
+- Important, repaired: `role-model-router/apps/launcher/main.go` accepted a non-empty manifest `executable` without comparing it to the fixed channel executable, permitting a local manifest path redirect. It now rejects any mismatch; `main_test.go` covers traversal.
+- Minor, repaired: README and installer output retained several stale `role-model-router` user-facing launcher/install names. They now use `role-model`; repository directory/package identifiers remain unchanged where technically correct.
+- Critical: none.
+- Important remaining: none.
+
+## Repair Work Performed
+
+- Reopened Phase 3, restricted executable identity, added the Go regression, corrected installer/README strings, reran Go tests, relocked Phase 3, and regenerated the review bundle.
+
+## Review Metadata
+
+- Reviewer: primary controller self-audit
+- Controller Verification: primary controller
+- Review Bundle Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase-03-5-code-review.md`
+- Reviewer Receipt: this artifact
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4` plus untracked enumeration.
+- Actual changed files reviewed: all 33 paths enumerated by the refreshed canonical bundle.
+- Unexplained drift: none; generated vendor binaries were restored from the hash-verified baseline copy.
+
+## Gaps Found
+
+None in the reviewed implementation.
+
+## Requirement Completion Status
+
+- R1 | Status: verified | Changed Files: `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.codex/AGENTS.md` | Implementation Evidence: `CONTRIBUTING.md` | Verification Evidence: `scripts/ci-workflow.test.mjs`
+- R2 | Status: implemented | Changed Files: `.github/workflows/ci.yml` | Implementation Evidence: `.github/workflows/ci.yml`
+- R3 | Status: verified | Changed Files: `.github/workflows/ci.yml` | Implementation Evidence: `.github/workflows/ci.yml` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+- R4 | Status: superseded by approved addendum | Addendum: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- R5 | Status: verified | Changed Files: `.github/workflows/build-binaries.yml`, `role-model-router/apps/runtime-host-bridge/src/package-sea.ts` | Implementation Evidence: `.github/workflows/build-binaries.yml` | Verification Evidence: `scripts/build-binaries-workflow.test.mjs`
+- R6 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`, `role-model-router/apps/runtime-host-bridge/src/cli.ts`, `role-model-router/apps/launcher/main.go` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts` | Verification Evidence: `role-model-router/apps/launcher/main_test.go`
+- R7 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`, `role-model-router/apps/runtime-host-bridge/src/index.ts`, `docs/public/install.md` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts` | Verification Evidence: `role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts`
+- R8 | Status: verified | Changed Files: `CONTRIBUTING.md`, `docs/operations/02-ci-and-release-flow.md`, `docs/operations/03-release-checklist.md` | Implementation Evidence: `docs/operations/02-ci-and-release-flow.md` | Verification Evidence: `scripts/ci-workflow.test.mjs`
+- R9 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts`, `role-model-router/apps/runtime-host-bridge/test/runtime-state-migration.test.ts` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+
+## Traceability
+
+- R1/R2/R3 -> reviewed branch policy, promotion guard, stable lanes, and workflow tests.
+- R4 -> reviewed approved addendum and main-only docs workflow.
+- R5 -> reviewed stage artifact naming, payload lookup/compare, package manifest, and release publication.
+- R6/R7 -> reviewed profile validation, launcher executable restriction, options, state roots, and metadata.
+- R8 -> reviewed contributor and operations documentation.
+- R9 -> reviewed migration precedence/idempotence and concurrent-runtime receipt.
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: `subagents/phase1-as-is-audit.md`, `subagents/phase2-plan-audit.md`.
+- Main-Agent Verification Performed: upstream action records, current bundle, every material diff, tests, manifests, and live QA results.
+- Acceptance Decision: accepted upstream context; Phase 3.5 verdict is controller-owned.
+- Refresh Handling: Phase 3 was reopened/relocked and the review bundle regenerated after the launcher repair.
+- Repair Performed After Verification: exact executable validation and naming cleanup.
+
+## Audit Context
+
+Audit Execution Mode: `self-audit`
+Subagent Availability: available
+Subagent Capability Probe: prior auditors completed; final code review used the canonical local bundle and controller verification.
+Delegation Decision Basis: no additional delegation was needed after the bounded review repair.
+Delegation Override Reason: none.
+Audit Inputs Provided: locked artifacts, addendum, refreshed bundle, complete diff, test receipts, manifests, and live QA results.
+
+## Earlier Phase Reconciliation
+
+The only material review finding triggered the required Phase 3 reopen/repair/relock cycle. The refreshed Phase 3 hash and review bundle include the repair.
+
+## Coverage Gate
+
+Coverage: PASS
+
+## Approval Gate
+
+Approval: PASS
+
+## Verdict
+
+- [x] APPROVED - ready for Phase 4.
+
+## Audit Verdict
+
+Audit: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/04-test-summary.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/04-test-summary.md
@@ -1,0 +1,153 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `04 Test Summary`
+Status: `LOCKED`
+LockedAt: `2026-07-19T01:01:09Z`
+LockHash: `59854e58833dc3fba804275c2e9d295678ad5cfa8cd43f283a96bb60e3c37c1a`
+Workflow version: `recursive-mode-audit-v2`
+Inputs: locked plan, implementation, review, RED/GREEN receipts, and current diff.
+Outputs: audited automated-test receipt.
+Scope note: Verifies repository implementation before external GitHub migration and final manual QA.
+
+## TODO
+
+- [x] Record pre-test implementation audit and environment
+- [x] Execute focused and repository-wide tests
+- [x] Execute packaging and concurrent runtime checks
+- [x] Reconcile failures, reruns, and final results
+
+## Pre-Test Implementation Audit
+
+Locked Phase 3.5 is approved, its launcher finding was repaired through a Phase 3 reopen/relock, and the refreshed review bundle contains the final product diff. No unfinished product change remained before this receipt.
+
+## Environment
+
+- Windows amd64, isolated Run-78 worktree.
+- Node `v24.11.0`, pnpm `10.6.5`, Go `1.26.2`, Rust/Cargo `1.96.1`.
+- Package QA used `D:/DEV/role-model/.worktrees/runtime-channel-qa-78` and a run-scoped `LOCALAPPDATA`; the user's existing main runtime was read-only and preserved.
+
+## Execution Mode
+
+Local repository commands plus agent-operated packaged-runtime HTTP verification.
+
+## Commands Executed (Exact)
+
+- `corepack pnpm run lint`
+- `corepack pnpm run schemas:validate`
+- `corepack pnpm run build`
+- `corepack pnpm run test`
+- `corepack pnpm run runtime:test-critical`
+- `corepack pnpm run test:rust`
+- `corepack pnpm run smoke`
+- `go test role-model-router/apps/launcher/main.go role-model-router/apps/launcher/main_test.go`
+- `ROLE_MODEL_BUILD_CHANNEL={development,stage,production} corepack pnpm --filter @role-model-router/runtime-host-bridge run package-sea` (PowerShell environment assignment)
+- Focused `node --test` and Vitest commands for workflow, channel, version, migration, package, and host contracts.
+
+## Results Summary
+
+- Lint, Rust clippy/fmt, schema validation, monorepo build, docs build, Go, Rust, smoke, and runtime-critical all passed.
+- Full `pnpm test` passed after repair; runtime-host-bridge: 63 files and 570 tests passed.
+- Workflow contract tests: 6 passed.
+- Three Windows packages built with identical core payload `550762f4c3d4743c1563f88ffed3ba7b76a3e3d2d8c46244f7bca98ad61e8f32` and exact channel manifests.
+- Live main/stage/dev coexistence and isolated restart/state checks passed.
+
+## Evidence and Artifacts
+
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/red/workflow-runtime-migration-red.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase-03-5-code-review.md`
+
+## Failures and Diagnostics (if any)
+
+- First focused command incorrectly passed Node test-runner `.mjs` files to Vitest; rerun with `node --test` passed.
+- First package copy used `Copy-Item -LiteralPath` with a wildcard; the development package was rebuilt and copied correctly.
+- First full suite exposed stale production counterpart fixtures; both were corrected to production scopes and the complete suite rerun passed.
+- Review found executable redirect acceptance; Phase 3 was reopened, repaired, and Go regression passed.
+
+## Flake/Rerun Notes
+
+No unresolved flake. Every product-related failure was repaired and rerun; the final full suite exited 0.
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4` plus untracked enumeration.
+- Planned or claimed changed files: workflows, channel/package/runtime/launcher/migration code, installers, docs, tests, and Run-78 artifacts.
+- Actual changed files reviewed: all paths in `evidence/review-bundles/phase-03-5-code-review.md`.
+- Unexplained drift: none.
+
+## Gaps Found
+
+None in automated verification. External branch/settings migration remains assigned to Phase 5.
+
+## Repair Work Performed
+
+Production compatibility fixtures, package-option isolation, legacy config precedence, launcher executable validation, and user-facing installer names were repaired before final pass.
+
+## Requirement Completion Status
+
+- R1 | Status: deferred | Rationale: external branch/default mutation follows the repository verification gate; repository policy tests passed. | Deferred By: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R2 | Status: deferred | Rationale: external protections require successful observed checks from the implementation PR; promotion guard tests passed. | Deferred By: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R3 | Status: verified | Changed Files: `.github/workflows/ci.yml` | Implementation Evidence: `.github/workflows/ci.yml` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+- R4 | Status: superseded by approved addendum | Addendum: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- R5 | Status: verified | Changed Files: `.github/workflows/build-binaries.yml`, `role-model-router/apps/runtime-host-bridge/src/package-sea.ts` | Implementation Evidence: `.github/workflows/build-binaries.yml` | Verification Evidence: `scripts/build-binaries-workflow.test.mjs`
+- R6 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`, `role-model-router/apps/launcher/main.go` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+- R7 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`, `role-model-router/apps/runtime-host-bridge/src/index.ts` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts` | Verification Evidence: `role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts`
+- R8 | Status: verified | Changed Files: `CONTRIBUTING.md`, `docs/operations/02-ci-and-release-flow.md` | Implementation Evidence: `docs/operations/02-ci-and-release-flow.md` | Verification Evidence: `scripts/ci-workflow.test.mjs`
+- R9 | Status: verified | Changed Files: `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts` | Implementation Evidence: `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+
+## Traceability
+
+- R1/R2 -> workflow/policy tests complete; external readback deferred to Phase 5.
+- R3 -> complete CI lane command families passed locally.
+- R4 -> docs contract tests and docs build passed under addendum 01.
+- R5 -> workflow contracts and three channel packages passed.
+- R6/R7/R9 -> unit, Go, full-suite, package, and concurrent runtime checks passed.
+- R8 -> policy/documentation diff and workflow contracts passed.
+
+## Coverage Gate
+
+Coverage: PASS
+
+## Approval Gate
+
+Approval: PASS
+
+## Audit Context
+
+Audit Execution Mode: `self-audit`
+Subagent Availability: available
+Subagent Capability Probe: prior phase auditors and canonical review bundle were available; test execution remained controller-owned.
+Delegation Decision Basis: local process/test ownership and direct output reconciliation.
+Delegation Override Reason: none.
+Audit Inputs Provided: locked plan/implementation/review, full command output, RED/GREEN receipts, package manifests, and live runtime results.
+
+## Effective Inputs Re-read
+
+- `02-to-be-plan.md`
+- `03-implementation-summary.md`
+- `03.5-code-review.md`
+- `addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+
+## Earlier Phase Reconciliation
+
+All reviewed implementation claims have final passing automated evidence. The Phase 3.5 repair is included in the final Go and lint checks.
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: `subagents/phase1-as-is-audit.md`, `subagents/phase2-plan-audit.md`.
+- Main-Agent Verification Performed: all final commands, manifests, live endpoints, and final diff.
+- Acceptance Decision: accepted upstream records; Phase 4 is controller-executed.
+- Refresh Handling: final tests followed all product repairs.
+- Repair Performed After Verification: none after the final pass.
+
+## Audit Verdict
+
+Audit: PASS
+
+## Prior Recursive Evidence Reviewed
+
+- `/.recursive/memory/skills/SKILLS.md`

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
@@ -49,4 +49,4 @@ PR #62 is ready for review. The approved design requires one maintainer review a
 
 ## Cleanup
 
-Temporary stage/development processes were stopped. The existing main runtime was preserved. Disposable package/state artifacts remain only under the explicit sibling QA path for inspection and can be removed after final migration closeout.
+Temporary stage/development processes were stopped. The existing main runtime was preserved. The resolved disposable QA path `D:/DEV/role-model/.worktrees/runtime-channel-qa-78` was removed after verification.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
@@ -1,50 +1,52 @@
 Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
 Phase: `05 Manual QA`
 Status: `DRAFT`
-Inputs:
-- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
-- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
-- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/red/workflow-runtime-migration-red.md`
-Outputs:
-- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
-Scope note: Scaffolds the manual-QA receipt and captures any preview URL evidence that should appear in the QA record.
+LockedAt: `pending`
+LockHash: `pending`
+Workflow version: `recursive-mode-audit-v2`
+Inputs: locked test summary, packaged channel builds, GitHub PR #62, and observed check runs.
+Outputs: concurrent-runtime receipt and recoverable GitHub migration status.
+Scope note: Local/runtime QA is complete; final repository migration awaits the required maintainer-reviewed merge.
 
 ## TODO
 
-- [ ] Declare the QA execution mode and supporting evidence
-- [ ] Record the manual QA scenarios and observed results
-- [ ] Complete Coverage and Approval gates before locking
+- [x] Build production, stage, and development Windows packages
+- [x] Run stage and development beside the existing main runtime
+- [x] Restart one channel and verify state isolation
+- [x] Create `dev`, push the implementation, and open PR #62 targeting `dev`
+- [x] Observe all real GitHub check names and results
+- [ ] Receive maintainer review and merge PR #62
+- [ ] Promote `dev -> stage -> main` with reviewed PRs
+- [ ] Apply/read back final protections and set default branch to `dev`
 
 ## QA Execution Record
 
-- QA Execution Mode: agent-operated
-- Agent Executor: populate the actual executor before locking
-- Tools Used: populate the actual tools used before locking
-- Evidence Path: populate the concrete QA evidence path before locking
+- Existing main remained healthy on `127.0.0.1:3456` and was never stopped or modified.
+- `role-model-stage` ran and restarted on `127.0.0.1:3457`.
+- `role-model-dev` remained healthy on `127.0.0.1:3458` during the stage restart.
+- Stage marker state persisted; no marker appeared in development; the development SQLite hash remained unchanged.
+- Stage/development used distinct `role-model-runtime-stage` and `role-model-runtime-dev` roots under disposable `LOCALAPPDATA`.
+- Temporary stage/development processes were shut down; the existing main runtime stayed healthy.
 
-## QA Scenarios and Results
+## GitHub Migration Status
 
-- Record each manual QA scenario and observed result here before locking.
+- Tracker: https://github.com/try-works/role-model/issues/61
+- Pull request: https://github.com/try-works/role-model/pull/62
+- `dev` was created from captured main baseline `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`.
+- Implementation branch `recursive/78-dev-stage-main-cicd-runtime-channels` was pushed and PR #62 targets `dev`.
+- Observed passing checks: `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, `smoke`, `cla`, and `Build docs site`.
+- Docs deployment correctly skipped on the PR.
 
-## Evidence and Artifacts
+## Approval Boundary
 
-- List concrete evidence paths under `/.recursive/run/<run-id>/evidence/` that support this phase.
+PR #62 is ready for review. The approved design requires one maintainer review and reviewed promotion PRs. Self-merging before that review would contradict the policy being installed, so protections/default-branch changes remain pending until the reviewed implementation reaches `dev` and can be promoted without bypassing the new contract.
 
-## User Sign-Off
+## Requirement Status
 
-- Approved by: N/A (set a real approver when QA mode requires human sign-off)
-- Date: N/A (set a real approval date when required)
+- R1: partially complete; `dev` and the default targeting policy exist, but reviewed promotions/default-branch mutation remain pending.
+- R2: pending reviewed merge and observed-check protection application.
+- R3-R9: QA complete; R4 follows approved docs addendum 01.
 
-## Traceability
+## Cleanup
 
-- Map the closeout evidence back to the in-scope requirements before locking.
-
-## Coverage Gate
-
-- Replace these checklist items with phase-specific proof before locking.
-Coverage: FAIL
-
-## Approval Gate
-
-- Replace these checklist items with phase-specific approval proof before locking.
-Approval: FAIL
+Temporary stage/development processes were stopped. The existing main runtime was preserved. Disposable package/state artifacts remain only under the explicit sibling QA path for inspection and can be removed after final migration closeout.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
@@ -1,0 +1,50 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `05 Manual QA`
+Status: `DRAFT`
+Inputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/red/workflow-runtime-migration-red.md`
+Outputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+Scope note: Scaffolds the manual-QA receipt and captures any preview URL evidence that should appear in the QA record.
+
+## TODO
+
+- [ ] Declare the QA execution mode and supporting evidence
+- [ ] Record the manual QA scenarios and observed results
+- [ ] Complete Coverage and Approval gates before locking
+
+## QA Execution Record
+
+- QA Execution Mode: agent-operated
+- Agent Executor: populate the actual executor before locking
+- Tools Used: populate the actual tools used before locking
+- Evidence Path: populate the concrete QA evidence path before locking
+
+## QA Scenarios and Results
+
+- Record each manual QA scenario and observed result here before locking.
+
+## Evidence and Artifacts
+
+- List concrete evidence paths under `/.recursive/run/<run-id>/evidence/` that support this phase.
+
+## User Sign-Off
+
+- Approved by: N/A (set a real approver when QA mode requires human sign-off)
+- Date: N/A (set a real approval date when required)
+
+## Traceability
+
+- Map the closeout evidence back to the in-scope requirements before locking.
+
+## Coverage Gate
+
+- Replace these checklist items with phase-specific proof before locking.
+Coverage: FAIL
+
+## Approval Gate
+
+- Replace these checklist items with phase-specific approval proof before locking.
+Approval: FAIL

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md
@@ -1,0 +1,68 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `01 AS-IS`
+Status: `LOCKED`
+LockedAt: `2026-07-18T23:41:10Z`
+LockHash: `5765b0a93e01194b7686f71f10e84c9f97e850509561f4ffcf4b03fff8739570`
+Inputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- user clarification on 2026-07-19 that the simple docs site does not need the full repository CI/CD promotion topology
+Outputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+Scope note: This addendum narrows the locked docs-deployment requirement while preserving the runtime and repository promotion requirements.
+
+## TODO
+
+- [x] Record the upstream gap precisely
+- [x] Add discovery evidence
+- [x] State impact and compensation plan
+- [x] Update current-phase planning accordingly
+- [x] Complete Coverage Gate checklist
+- [x] Complete Approval Gate checklist
+
+## Gap Statement
+
+- `R4` over-scoped the simple docs site by requiring separate Cloudflare Pages projects and deployments for `dev`, `stage`, and `main`.
+- The effective requirement is a single docs deployment from `main`, with relevant pull requests retaining build validation without deployment credentials.
+- Repository promotion gates, runtime candidate builds, and the three isolated packaged-runtime channel profiles remain unchanged.
+
+## Discovery Evidence
+
+- The user stated: "the docs-site is simple, it may not need the full ci/cd like the rest of the repo".
+- The existing docs workflow already separates pull-request builds from non-PR deployment, while Cloudflare currently has only the `role-model-dev` Pages project and the `role-model.dev` custom domain attached to it.
+- Applying the original `R4` literally would create deployment infrastructure that the user has now identified as unnecessary.
+
+## Impact
+
+- Phase 1 audits the docs workflow as an intentionally smaller deployment surface rather than a three-channel deployment surface.
+- Phase 2 will plan one production docs deployment from `main`, relevant PR build checks, least-privilege permissions, explicit deployment identity, visible credential skips, health checks, and rollback guidance.
+- GitHub environments are reduced to those needed for runtime candidate/release authorization; separate docs `development` and `staging` environments are not required.
+- Cloudflare Pages projects `role-model-stage` and a second dev/stage docs topology are not created by this run.
+
+## Compensation Plan
+
+- Add workflow contract tests proving docs deploys only from `main` and relevant pull requests only build.
+- Keep the docs deployment job distinct from repository CI and runtime artifact workflows.
+- Document the single-site deployment and rollback contract without coupling it to runtime-channel promotion.
+- Record the existing `role-model-dev` project/custom-domain state before any Cloudflare mutation; do not move the custom domain without a validated production replacement.
+
+## Traceability Impact
+
+- `R4 | Status: superseded by approved addendum | Addendum: /.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- `R1`, `R2`, `R3`, and `R5` through `R9` remain in force.
+
+## Coverage Gate
+
+- [x] The docs-site exception is bounded to deployment topology
+- [x] Pull-request docs build validation remains required
+- [x] Main-only docs deployment and operational verification remain required
+- [x] Runtime dev/stage/main isolation and promotion remain required
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] The user supplied the scope correction during Phase 1
+- [x] The correction reduces infrastructure scope and does not authorize unrelated changes
+- [x] The locked Phase 0 artifact remains unmodified
+
+Approval: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md
@@ -1,0 +1,7 @@
+# GREEN receipt
+
+- Workflow contracts: 6 passed.
+- Focused runtime channel, version, migration, package, and host tests: passed.
+- Full repository suite: passed; runtime-host-bridge reported 63 files and 570 tests passed.
+- Lint, schemas, build, runtime-critical, Go, Rust, smoke, and three channel package builds: passed.
+- Live coexistence: existing main healthy on 3456, stage healthy/restarted on 3457, development healthy throughout on 3458, isolated state preserved.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/red/workflow-runtime-migration-red.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/red/workflow-runtime-migration-red.md
@@ -1,0 +1,7 @@
+# RED receipt
+
+- Workflow contract tests failed on the former broad single CI job, arbitrary docs refs, and missing development/stage packaging channels.
+- Runtime profile/version tests failed because the channel module and metadata did not exist.
+- Migration tests failed because the production legacy-state migration module did not exist.
+
+These failures were observed before the corresponding production edits and matched the missing contracts.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase-03-5-code-review.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase-03-5-code-review.md
@@ -1,0 +1,96 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `03.5 Code Review`
+Role: `code-reviewer`
+Bundle Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase-03-5-code-review.md`
+Artifact Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/03-implementation-summary.md`
+Artifact Content Hash: `494cbad0b26d8643866ceb4b680295a1e12ea5a4f39d1a570edda67e657dece6`
+GeneratedAt: `2026-07-19T00:57:27Z`
+
+## Bundle Scope
+- Canonical delegated review bundle for recursive-mode audit/review work.
+- Regenerate this bundle if the draft, changed files, or required evidence changes materially before review.
+
+## Routing
+- Routed CLI: `none`
+- Routed Model: `none`
+- Routing Config Path: `none`
+- Routing Discovery Path: `none`
+
+## Diff Basis
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+
+## Changed Files Reviewed
+- `.codex/AGENTS.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/workflows/build-binaries.yml`
+- `.github/workflows/ci.yml`
+- `.github/workflows/docs-site-deploy.yml`
+- `CONTRIBUTING.md`
+- `README.md`
+- `apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs`
+- `docs/operations/02-ci-and-release-flow.md`
+- `docs/operations/03-release-checklist.md`
+- `docs/public/install.md`
+- `package.json`
+- `packages/pi-role-model/README.md`
+- `role-model-router/apps/launcher/main.go`
+- `role-model-router/apps/launcher/main_test.go`
+- `role-model-router/apps/runtime-host-bridge/src/cli.ts`
+- `role-model-router/apps/runtime-host-bridge/src/downstream-openai-discovery.ts`
+- `role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+- `role-model-router/apps/runtime-host-bridge/test/executable.test.ts`
+- `role-model-router/apps/runtime-host-bridge/test/index.test.ts`
+- `role-model-router/apps/runtime-host-bridge/test/restart-rehydration.test.ts`
+- `role-model-router/apps/runtime-host-bridge/test/runtime-channel-options.test.ts`
+- `role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts`
+- `role-model-router/apps/runtime-host-bridge/test/runtime-state-migration.test.ts`
+- `role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts`
+- `scripts/build-binaries-workflow.test.mjs`
+- `scripts/ci-workflow.test.mjs`
+- `scripts/install.ps1`
+- `scripts/install.sh`
+
+## Upstream Artifacts To Re-read
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+
+## Relevant Addenda
+- none
+
+## Prior Recursive Evidence
+- `.recursive/memory/skills/SKILLS.md`
+
+## Control-Plane Docs
+- none
+
+## Targeted Code References
+- `.github/workflows/ci.yml`
+- `.github/workflows/build-binaries.yml`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts`
+- `role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `role-model-router/apps/launcher/main.go`
+
+## Evidence References
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`
+
+## Audit Questions
+- `Does the repaired implementation satisfy R1-R9 and the docs addendum without unsafe state or release behavior?`
+
+## Required Output
+- `Classified findings with file references`
+- `APPROVED or CHANGES REQUIRED verdict`
+
+## Notes
+- Review output is invalid if it does not cite the upstream artifacts, diff basis, changed files, and final verdict.
+- If this bundle is incomplete, reject delegation and perform the audit as self-audit.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase1-as-is-analyst.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase1-as-is-analyst.md
@@ -1,0 +1,70 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `01 AS-IS`
+Role: `analyst`
+Bundle Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase1-as-is-analyst.md`
+Artifact Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+Artifact Content Hash: `b77199895db8357491b51767b82b4aa4ea7833ef44c6c508f26601cf49d9e08c`
+GeneratedAt: `2026-07-18T23:54:37Z`
+
+## Bundle Scope
+- Canonical delegated review bundle for recursive-mode audit/review work.
+- Regenerate this bundle if the draft, changed files, or required evidence changes materially before review.
+
+## Routing
+- Routed CLI: `none`
+- Routed Model: `none`
+- Routing Config Path: `none`
+- Routing Discovery Path: `none`
+
+## Diff Basis
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+
+## Changed Files Reviewed
+- none
+
+## Upstream Artifacts To Re-read
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+
+## Relevant Addenda
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+
+## Prior Recursive Evidence
+- `.recursive/memory/patterns/git-push-merge-workflow.md`
+- `.recursive/memory/patterns/github-ci-and-release-workflow.md`
+- `.recursive/memory/skills/SKILLS.md`
+- `.recursive/memory/skills/patterns/delegated-verification-and-refresh.md`
+
+## Control-Plane Docs
+- `.recursive/STATE.md`
+- `.recursive/DECISIONS.md`
+
+## Targeted Code References
+- `.github/workflows/ci.yml`
+- `.github/workflows/build-binaries.yml`
+- `.github/workflows/docs-site-deploy.yml`
+- `role-model-router/apps/launcher/main.go`
+- `role-model-router/apps/runtime-host-bridge/src/cli.ts`
+- `role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+- `role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `scripts/install.sh`
+- `scripts/install.ps1`
+
+## Evidence References
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase1-as-is-audit.md`
+
+## Audit Questions
+- `Final PASS re-audit recorded after controller repairs`
+
+## Required Output
+- `PASS`
+
+## Notes
+- Review output is invalid if it does not cite the upstream artifacts, diff basis, changed files, and final verdict.
+- If this bundle is incomplete, reject delegation and perform the audit as self-audit.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase2-plan-planner.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase2-plan-planner.md
@@ -1,0 +1,68 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `02 TO-BE plan`
+Role: `planner`
+Bundle Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase2-plan-planner.md`
+Artifact Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+Artifact Content Hash: `ad3cc90292ef11eacbda7db639b10715c2429a406165e00e0c19ae498a718baf`
+GeneratedAt: `2026-07-19T00:12:45Z`
+
+## Bundle Scope
+- Canonical delegated review bundle for recursive-mode audit/review work.
+- Regenerate this bundle if the draft, changed files, or required evidence changes materially before review.
+
+## Routing
+- Routed CLI: `none`
+- Routed Model: `none`
+- Routing Config Path: `none`
+- Routing Discovery Path: `none`
+
+## Diff Basis
+- Baseline type: `local commit`
+- Baseline reference: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Comparison reference: `working-tree`
+- Normalized baseline: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`
+
+## Changed Files Reviewed
+- none
+
+## Upstream Artifacts To Re-read
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+
+## Relevant Addenda
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+
+## Prior Recursive Evidence
+- `.recursive/memory/skills/SKILLS.md`
+
+## Control-Plane Docs
+- `.recursive/STATE.md`
+- `.recursive/DECISIONS.md`
+
+## Targeted Code References
+- `.github/workflows/ci.yml`
+- `.github/workflows/build-binaries.yml`
+- `.github/workflows/docs-site-deploy.yml`
+- `role-model-router/apps/runtime-host-bridge/src/cli.ts`
+- `role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+- `role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+- `role-model-router/apps/launcher/main.go`
+- `scripts/install.sh`
+- `scripts/install.ps1`
+
+## Evidence References
+- `.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase2-plan-audit.md`
+
+## Audit Questions
+- `Final PASS`
+
+## Required Output
+- `PASS`
+
+## Notes
+- Review output is invalid if it does not cite the upstream artifacts, diff basis, changed files, and final verdict.
+- If this bundle is incomplete, reject delegation and perform the audit as self-audit.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/tdd-red-green.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/tdd-red-green.md
@@ -1,0 +1,22 @@
+# Run 78 TDD evidence
+
+## RED
+
+- Workflow contracts: `node --test` failed because CI still had one broad mutable-install job, docs could deploy arbitrary refs, and binary builds had no development/stage channel contract.
+- Runtime profiles: focused Vitest failed because `runtime-channel.ts` did not exist and runtime version responses lacked channel metadata.
+- State migration: focused Vitest failed because `runtime-state-migration.ts` did not exist.
+
+All RED failures occurred before their corresponding production edits and failed for the expected missing behavior.
+
+## GREEN
+
+- `node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs`: 6 passed.
+- Focused channel/version/state/package/host tests: passed after implementation.
+- Full repository test rerun: passed, including runtime-host-bridge 63 files and 570 tests.
+- Go launcher tests, packaging builds, lint, schemas, build, runtime-critical, Rust, and smoke: passed.
+
+## Refactor verification
+
+- One typed TypeScript profile table owns names, ports, state roots, and scope IDs.
+- Go reads the adjacent manifest and validates the same fixed profile identities.
+- Workflow contract tests own stable job names, promotion rules, and docs/release constraints.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/00-requirements.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/00-requirements.receipt.json
@@ -1,0 +1,9 @@
+{
+  "artifact": "00-requirements.md",
+  "artifact_hash": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\00-requirements.md",
+  "locked_at": "2026-07-18T23:33:39Z",
+  "prerequisite_hashes": {},
+  "previous_receipt_hash": null,
+  "receipt_hash": "57049802f0b99a59044f77e2ff0cd18de4c6645763353c234e1c5a976a29600b"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/00-worktree.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/00-worktree.receipt.json
@@ -1,0 +1,11 @@
+{
+  "artifact": "00-worktree.md",
+  "artifact_hash": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\00-worktree.md",
+  "locked_at": "2026-07-18T23:35:41Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "a25dde56efd07ab7a778c0ddfe2a19425b127c28a7f75cf4cacc62a16c42456d"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/01-as-is.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/01-as-is.receipt.json
@@ -1,0 +1,12 @@
+{
+  "artifact": "01-as-is.md",
+  "artifact_hash": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\01-as-is.md",
+  "locked_at": "2026-07-18T23:54:38Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "b4ea010de6083d351ed0cacf9809d6e8e657fe51ce39cec388754dcf2586caf4"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/02-to-be-plan.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/02-to-be-plan.receipt.json
@@ -1,0 +1,13 @@
+{
+  "artifact": "02-to-be-plan.md",
+  "artifact_hash": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\02-to-be-plan.md",
+  "locked_at": "2026-07-19T00:12:45Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "1c0f3a6e7686fc8c91181b617222e3c47763469b925b672d8f40c369696112e5"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/03-implementation-summary.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/03-implementation-summary.receipt.json
@@ -1,0 +1,14 @@
+{
+  "artifact": "03-implementation-summary.md",
+  "artifact_hash": "7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\03-implementation-summary.md",
+  "locked_at": "2026-07-19T00:57:17Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+    "02-to-be-plan.md": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "b5b7af6785f6bbfd0009965ec4fc43509e9848993a0230cfa8f92775a18269f7"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/03.5-code-review.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/03.5-code-review.receipt.json
@@ -1,0 +1,15 @@
+{
+  "artifact": "03.5-code-review.md",
+  "artifact_hash": "d435c5e595c7a2d782e695bda19c43db7c6d9b581d3acde0a5ad8fca1994199a",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\03.5-code-review.md",
+  "locked_at": "2026-07-19T00:58:53Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+    "02-to-be-plan.md": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e",
+    "03-implementation-summary.md": "7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "a034f8f4e62a90190ccca1ba9cf644a26e17d5b4c560ddb3f37bd82e4ac0bd1b"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/04-test-summary.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/04-test-summary.receipt.json
@@ -1,0 +1,16 @@
+{
+  "artifact": "04-test-summary.md",
+  "artifact_hash": "59854e58833dc3fba804275c2e9d295678ad5cfa8cd43f283a96bb60e3c37c1a",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\04-test-summary.md",
+  "locked_at": "2026-07-19T01:01:09Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+    "02-to-be-plan.md": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e",
+    "03-implementation-summary.md": "7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a",
+    "03.5-code-review.md": "d435c5e595c7a2d782e695bda19c43db7c6d9b581d3acde0a5ad8fca1994199a"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "79f290c99d01cacdb46ad63679111ff63b98ffe0e9a491eab69893791c97d43d"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase1-as-is-audit.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase1-as-is-audit.md
@@ -1,0 +1,98 @@
+# Subagent Action Record
+
+## Metadata
+- Subagent ID: `phase1-audit`
+- Run ID: `78-dev-stage-main-cicd-runtime-channels`
+- Phase: `01 AS-IS`
+- Purpose: `Independently audit AS-IS completeness and accuracy`
+- Execution Mode: `audit`
+- Timestamp: `2026-07-18T23:49:07Z`
+- Action Record Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase1-as-is-audit.md`
+
+## Inputs Provided
+- Current Artifact: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+- Artifact Content Hash: `40c2ce85aeefc2f9bb482a19e25afff3ad41bae6fa690efcc67ed3412f840ea7`
+- Upstream Artifacts:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+- Addenda:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- Review Bundle: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase1-as-is-analyst.md`
+- Diff Basis: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4 -> working-tree`
+- Code Refs:
+- `/.github/workflows/ci.yml`
+- `/.github/workflows/build-binaries.yml`
+- `/.github/workflows/docs-site-deploy.yml`
+- `/role-model-router/apps/launcher/main.go`
+- `/role-model-router/apps/runtime-host-bridge/src/cli.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+- `/scripts/install.ps1`
+- `/scripts/install.sh`
+- Memory Refs:
+- none
+- Audit / Task Questions:
+- none
+
+## Routing
+- Router Used: `none`
+- Routed Role: `none`
+- Routed CLI: `none`
+- Routed Model: `none`
+- Routing Config Path: `none`
+- Routing Discovery Path: `none`
+- Routing Resolution Basis: `none`
+- Routing Fallback Reason: `none`
+- CLI Probe Summary: `none`
+- Prompt Bundle Path: `none`
+- Invocation Exit Code: `none`
+- Output Capture Paths:
+- none
+
+## Claimed Actions Taken
+- none
+
+## Claimed File Impact
+### Created
+- none
+### Modified
+- none
+### Reviewed
+- `/.github/workflows/ci.yml`
+- `/.github/workflows/build-binaries.yml`
+- `/.github/workflows/docs-site-deploy.yml`
+- `/role-model-router/apps/launcher/main.go`
+- `/role-model-router/apps/runtime-host-bridge/src/cli.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+- `/scripts/install.ps1`
+- `/scripts/install.sh`
+### Relevant but Untouched
+- none
+
+## Claimed Artifact Impact
+### Read
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+### Updated
+- none
+### Evidence Used
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase1-as-is-analyst.md`
+
+## Claimed Findings
+- FAIL: manual workflow_dispatch can deploy a non-main docs ref
+- FAIL: manifest already has commit and executable SHA; missing identity is channel/artifact/promotion evidence
+- FAIL: OAuth counterpart ambiguity stays inside selected root rather than proving cross-root leakage
+- FAIL: Unix raw SEA path bypasses the Windows launcher and retains legacy defaults
+- FAIL: review bundle must be refreshed after repairs
+- PASS on re-audit: all five repairs are file-accurate and the refreshed review bundle matches the repaired artifact
+
+## Verification Handoff
+- Inspect first:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+- Notes:
+- Controller verified the five repairs; refreshed bundle hash matched and independent re-audit returned PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase2-plan-audit.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase2-plan-audit.md
@@ -1,0 +1,89 @@
+# Subagent Action Record
+
+## Metadata
+- Subagent ID: `phase2-plan-audit`
+- Run ID: `78-dev-stage-main-cicd-runtime-channels`
+- Phase: `02 TO-BE plan`
+- Purpose: `Independently audit plan completeness, safety, and implementability`
+- Execution Mode: `audit`
+- Timestamp: `2026-07-19T00:05:54Z`
+- Action Record Path: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/subagents/phase2-plan-audit.md`
+
+## Inputs Provided
+- Current Artifact: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+- Artifact Content Hash: `ad3cc90292ef11eacbda7db639b10715c2429a406165e00e0c19ae498a718baf`
+- Upstream Artifacts:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+- Addenda:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+- Review Bundle: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase2-plan-planner.md`
+- Diff Basis: `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4 -> working-tree`
+- Code Refs:
+- none
+- Memory Refs:
+- none
+- Audit / Task Questions:
+- none
+
+## Routing
+- Router Used: `none`
+- Routed Role: `none`
+- Routed CLI: `none`
+- Routed Model: `none`
+- Routing Config Path: `none`
+- Routing Discovery Path: `none`
+- Routing Resolution Basis: `none`
+- Routing Fallback Reason: `none`
+- CLI Probe Summary: `none`
+- Prompt Bundle Path: `none`
+- Invocation Exit Code: `none`
+- Output Capture Paths:
+- none
+
+## Claimed Actions Taken
+- none
+
+## Claimed File Impact
+### Created
+- none
+### Modified
+- none
+### Reviewed
+- `/.github/workflows/ci.yml`
+- `/.github/workflows/build-binaries.yml`
+- `/.github/workflows/docs-site-deploy.yml`
+- `/role-model-router/apps/launcher/main.go`
+- `/role-model-router/apps/runtime-host-bridge/src/cli.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/index.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/package-sea.ts`
+- `/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts`
+- `/scripts/install.ps1`
+- `/scripts/install.sh`
+### Relevant but Untouched
+- none
+
+## Claimed Artifact Impact
+### Read
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-worktree.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/01-as-is.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/01-as-is.upstream-gap.00-requirements.addendum-01.md`
+### Updated
+- none
+### Evidence Used
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/review-bundles/phase2-plan-planner.md`
+
+## Claimed Findings
+- FAIL: source tree OID cannot substitute for real core payload SHA-256 or stage-to-prod proof
+- FAIL: installed Unix layout lacks repo-root inference and needs explicit RED/GREEN coverage
+- FAIL: GitHub check/protection migration order is not executable enough
+- FAIL: cross-root production legacy-state migration ownership and copied paths are underspecified
+- PASS on final re-audit: all payload, installed-layout, GitHub sequencing, and dual legacy-layout migration repairs are complete
+
+## Verification Handoff
+- Inspect first:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+- Notes:
+- Controller repaired all findings; refreshed bundle matched and final independent re-audit returned PASS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ A human maintainer reviews every dep change. PRs that add or bump a package must
 
 ## PR workflow
 
-1. Fork, branch from `main`.
+1. Fork, branch from `dev`, and target `dev` with ordinary feature, fix, dependency, or `recursive/*` work.
 2. Install **Node.js >=24 <25** and **pnpm >=10**.
 3. Run `corepack pnpm install --frozen-lockfile`.
 4. One logical change per PR.
@@ -132,9 +132,13 @@ A human maintainer reviews every dep change. PRs that add or bump a package must
    ```
 7. Open the PR with a clear description + `Real behavior proof` + any spec/justification required.
 
+Maintainers promote reviewed integration commits with merge commits from `dev` to `stage`, then from `stage` to
+`main`. Do not target `stage` or `main` directly for ordinary work. Production hotfixes use `hotfix/*` from
+`main`, require review, and must be forwarded to both `stage` and `dev` after the production merge.
+
 **Title format** (conventional commits): `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`.
 
-**Review:** CI green, one maintainer review, coverage held or improved.
+**Review:** all required CI lanes green, one maintainer review, conversations resolved, coverage held or improved.
 
 ## Coding standards
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="docs/public/role-model-hero.png" alt="Role Model" width="600"></p>
+<p align="center"><img src="docs/public/role-model-hero.png" alt="role-model" width="600"></p>
 
 # role-model
 
@@ -44,7 +44,7 @@ curl -fsSL https://raw.githubusercontent.com/try-works/role-model/main/scripts/i
 ```
 
 The installer downloads the latest GitHub Release archive, installs it under
-`~/.local/share/role-model-router/<version>/<target>/`, and exposes a `role-model-router` launcher in
+`~/.local/share/role-model/<version>/<target>/`, and exposes a `role-model` launcher in
 `~/.local/bin`.
 
 ### Windows
@@ -54,7 +54,7 @@ irm https://raw.githubusercontent.com/try-works/role-model/main/scripts/install.
 ```
 
 The installer downloads the latest GitHub Release archive, installs it under
-`%LOCALAPPDATA%\Programs\RoleModelRouter\<version>\<target>\`, and creates a `role-model-router.cmd`
+`%LOCALAPPDATA%\Programs\role-model\<version>\<target>\`, and creates a `role-model.cmd`
 launcher.
 
 ### Manual downloads
@@ -63,16 +63,16 @@ If you do not want to use installer scripts, download the matching archive from 
 
 | Platform | Archive | Launch |
 | --- | --- | --- |
-| Windows | `role-model-router-win32-x64.zip` | `Role-Model.bat` or `role-model-runtime.exe` |
-| macOS x64 | `role-model-router-darwin-x64.tar.gz` | `role-model-runtime` |
-| macOS arm64 | `role-model-router-darwin-arm64.tar.gz` | `role-model-runtime` |
-| Linux x64 | `role-model-router-linux-x64.tar.gz` | `role-model-runtime` |
+| Windows | `role-model-win32-x64.zip` | `role-model.bat` or `role-model.exe` |
+| macOS x64 | `role-model-darwin-x64.tar.gz` | `role-model` |
+| macOS arm64 | `role-model-darwin-arm64.tar.gz` | `role-model` |
+| Linux x64 | `role-model-linux-x64.tar.gz` | `role-model` |
 
 ## Installation for Pi
 
-The `pi-role-model` package connects Pi to an externally running Role-Model runtime.
+The `pi-role-model` package connects Pi to an externally running role-model runtime.
 
-Start the Role-Model runtime first, then install the public Pi package:
+Start the role-model runtime first, then install the public Pi package:
 
 ```bash
 pi install npm:@try-works/pi-role-model
@@ -99,7 +99,7 @@ Inside Pi, run:
 
 Use those slash commands only from an interactive Pi session. `pi -p "/role-model status"` is unsupported because Pi print mode does not currently invoke extension commands.
 
-By default the package connects to `http://127.0.0.1:3456` and registers Role-Model as the
+By default the package connects to `http://127.0.0.1:3456` and registers role-model as the
 `role-model` provider using `/api/role-model/downstream/openai`. Set `ROLE_MODEL_ENDPOINT`
 before starting Pi to use a different local runtime. Remote endpoints require explicit
 trusted `allowRemote` behavior, and runtimes that report `authentication.required` fail
@@ -107,7 +107,7 @@ closed unless a future supported token source is configured. For local developme
 and the full command reference, see
 [`packages/pi-role-model/README.md`](packages/pi-role-model/README.md).
 
-For explicit provider prompts, use the provider-relative Role-Model alias that Pi lists for provider `role-model`, for example:
+For explicit provider prompts, use the provider-relative role-model alias that Pi lists for provider `role-model`, for example:
 
 ```bash
 pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"
@@ -164,7 +164,9 @@ corepack pnpm --filter @role-model-router/runtime-ui run build
 corepack pnpm run runtime:package-sea
 ```
 
-Output: `role-model-router/dist/release/<platform-arch>/role-model-runtime`
+Output: `role-model-router/dist/release/<platform-arch>/role-model-dev` by default. Set
+`ROLE_MODEL_BUILD_CHANNEL=production` for `role-model` or `ROLE_MODEL_BUILD_CHANNEL=stage` for
+`role-model-stage`.
 
 ### Windows desktop launcher
 
@@ -179,7 +181,7 @@ corepack pnpm run runtime:package-sea
 
 # 3. Build Go launcher
 cd role-model-router/apps/launcher
-go build -o ../../dist/release/win32-x64/role-model-launcher.exe main.go
+go build -o ../../dist/release/win32-x64/role-model-launcher.exe .
 
 # 4. Bundle UI files
 cp -r ../runtime-ui/build/client ../../dist/release/win32-x64/

--- a/apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
+++ b/apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
@@ -15,3 +15,15 @@ test("docs deploy workflow skips gracefully when Cloudflare secrets are absent",
   assert.doesNotMatch(workflow, /exit 1/);
   assert.match(workflow, /if:\s*steps\.cloudflare_ready\.outputs\.ready == 'true'/);
 });
+
+test("docs deploy is a single main-only deployment even for manual runs", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /if:\s*github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /--project-name role-model-dev/);
+  assert.match(workflow, /--branch main/);
+  assert.match(workflow, /Verify docs deployment/);
+  assert.match(workflow, /https:\/\/role-model\.dev\//);
+  assert.doesNotMatch(workflow, /role-model-stage/);
+  assert.doesNotMatch(workflow, /PAGES_BRANCH=\$\{\{ github\.ref_name \}\}/);
+});

--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -1,166 +1,60 @@
-# CI and Release Flow
+# CI, promotion, and release flow
 
-This is the canonical operator-facing reference for the GitHub automation that validates, packages, and
-publishes `role-model`.
+`role-model` uses three long-lived branches:
 
-Use it when you need to:
+1. Ordinary `feature/*`, `fix/*`, dependency, and `recursive/*` pull requests target `dev` and normally squash merge.
+2. A maintainer promotes a tested integration with a merge-commit PR from `dev` to `stage`.
+3. A maintainer promotes a tested stage candidate with a merge-commit PR from `stage` to `main`.
 
-- understand which workflow owns which responsibility,
-- diagnose a GitHub-only failure,
-- verify what should happen before a merge or release tag,
-- onboard another agent or contributor to the automation surface.
+`main` is production truth. A production-only emergency starts as `hotfix/*` from `main`, requires review, and is
+forwarded to `stage` and `dev` after merge. Never force-push a promotion branch to resynchronize it; use reviewed
+merge commits and resolve conflicts in the promotion PR.
 
-## Workflow inventory
+## Required CI lanes
 
-### `ci.yml`
+`.github/workflows/ci.yml` runs on pull requests and post-merge pushes for `dev`, `stage`, and `main`. Stable check
+names are `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, and `smoke`.
+Superseded runs cancel, permissions default to read-only, jobs use bounded timeouts, and dependencies install with a
+frozen lockfile.
 
-Purpose: fast merge gate for the whole monorepo.
+The promotion guard accepts ordinary work into `dev`, only `dev` into `stage`, and only `stage` into `main`.
+Reviewed `hotfix/* -> main` is the explicit emergency exception.
 
-Triggers:
+## Runtime build channels
 
-- every `push`
-- every `pull_request`
+`.github/workflows/build-binaries.yml` builds the full matrix for stage candidates and production tags. Development
+packages are available by explicit manual dispatch. Only a `v*` tag publishes a stable GitHub Release.
 
-What it runs, in order:
+| Channel | Identity | Endpoint | State root | Scope |
+| --- | --- | --- | --- | --- |
+| Production | `role-model` | `http://127.0.0.1:3456` | `role-model-runtime` | `standalone-runtime` |
+| Stage | `role-model-stage` | `http://127.0.0.1:3457` | `role-model-runtime-stage` | `standalone-runtime-stage` |
+| Development | `role-model-dev` | `http://127.0.0.1:3458` | `role-model-runtime-dev` | `standalone-runtime-dev` |
 
-1. dependency install
-2. `pnpm run lint`
-3. `pnpm run schemas:validate`
-4. `pnpm run build`
-5. `pnpm run test`
-6. `pnpm run test:rust`
-7. `pnpm run smoke`
+Manifests report channel, endpoint, commit, source tree, executable SHA-256, and channel-neutral core payload
+SHA-256. A production tag must find the matching successful stage candidate and prove the core payload digest is
+identical; source-tree equality alone is insufficient.
 
-Notes:
+## Docs site exception
 
-- this workflow should stay close to the local contributor command surface.
-- each phase is split into its own GitHub Actions step so failures are attributable without expanding a
-  single umbrella command.
+The docs site is intentionally simpler than the runtime pipeline. Relevant pull requests build it without deploy
+credentials. Only `main` deploys the single site to Cloudflare Pages project `role-model-dev`; manual runs from other
+refs cannot deploy. There are no dev/stage docs projects in this topology.
 
-### `build-binaries.yml`
+If credentials are missing, the deploy step reports a non-fatal skip. After deployment, verify the public URL. To
+roll back, use the Cloudflare Pages deployment history for the same project; do not move `role-model.dev` between
+projects during an incident.
 
-Purpose: produce tagged release archives and manual-download artifacts for the standalone router runtime.
-
-Triggers:
-
-- `workflow_dispatch`
-- pushes to `main`
-- tags matching `v*`
-
-Outputs:
-
-- `role-model-router-linux-x64.tar.gz`
-- `role-model-router-darwin-x64.tar.gz`
-- `role-model-router-darwin-arm64.tar.gz`
-- `role-model-router-win32-x64.zip`
-- `SHA256SUMS.txt`
-- installer scripts `install.sh` and `install.ps1` on tagged releases
-
-Notes:
-
-- the workflow packages one matrix target per OS/architecture.
-- release-archive attestation remains mandatory, but transient Sigstore/Rekor failures now get three attempts with short backoff before the matrix job is allowed to fail.
-- tagged runs now publish through one final release job so notes, checksums, and assets stay coherent.
-- release notes are synthesized from recursive implementation, decisions, and state-update artifacts in the
-  tagged commit range, then combined with GitHub's generated notes.
-- the final publish job targets a `release` environment so repository settings can require approvals.
-- failed runs now upload partial packaging outputs from `role-model-router/dist/**` and
-  `role-model-router/vendor/llama-swap/dist-assets/**` so Windows-only packaging failures are inspectable after
-  the runner is gone.
-
-### `docs-site-deploy.yml`
-
-Purpose: build the docs site on every relevant PR and deploy it only when deployment credentials are expected
-to exist.
-
-Triggers:
-
-- pushes to `main` that touch the docs site or shared build inputs
-- matching `pull_request` changes
-- `workflow_dispatch`
-
-Job model:
-
-1. `build`: installs dependencies, builds `apps/docs-site`, and uploads the built client bundle as an artifact
-2. `deploy`: downloads that artifact and deploys to Cloudflare Pages, but only for non-PR events
-
-Notes:
-
-- PRs validate the docs build without requiring Cloudflare secrets.
-- non-PR deploys only run when Cloudflare secrets are present; otherwise the workflow emits a clear skip notice and stays green.
-
-### `cla.yml`
-
-Purpose: enforce the contributor license agreement on pull requests.
-
-Triggers:
-
-- `pull_request_target`
-- matching `issue_comment` events
-
-Audit result:
-
-- the workflow is operationally healthy and already has a dedicated self-test history on GitHub.
-- no release-flow changes are currently required there.
-
-## Canonical local verification
-
-Run these from the repo root before pushing workflow-affecting changes:
+## Local verification
 
 ```bash
-corepack pnpm install
+corepack pnpm install --frozen-lockfile
+node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
 corepack pnpm run ci:check
 corepack pnpm run docs:build
-corepack pnpm run runtime:package-sea
+ROLE_MODEL_BUILD_CHANNEL=development corepack pnpm run runtime:package-sea
 ```
 
-Use narrower commands only when you are intentionally iterating on one workflow surface.
-
-## Release sequence
-
-The expected release path is:
-
-1. merge validated changes into `main`
-2. confirm the recursive implementation, decisions, and state receipts for the release commits are present and locked
-3. confirm `ci.yml` is green on the target commit
-4. update `apps/docs-site/content/docs/` for any user-visible install, setup, routing, benchmark, UI, or release-flow changes
-5. confirm the docs site build is green and the public docs still match the release assets and operator flow
-6. create and push a `v*` tag
-7. let `build-binaries.yml` publish the release archives, checksums, and installer scripts
-8. verify the release assets match the filenames referenced in [install.md](../public/install.md)
-
-Packaged installs are the default user path. Source builds remain a contributor/developer path.
-
-## GitHub-only diagnostics
-
-When a failure reproduces only on GitHub:
-
-1. inspect the failing workflow run, job, and step first
-2. prefer the GitHub plugin plus `gh` job logs over guessing from local state
-3. compare the failing phase to the local command listed above
-4. download any uploaded workflow artifact before rerunning a transient failure away
-
-Current workflow-specific diagnostics:
-
-- `ci.yml`: failing phase is visible directly from the step list
-- `build-binaries.yml`: package subprocesses now emit their exact command, working directory, stdout, and stderr
-- `build-binaries.yml`: release notes are derived from commit-range recursive receipts instead of a manual release block
-- `docs-site-deploy.yml`: build and deploy are separate jobs, so credential failures cannot masquerade as build failures
-
-For the operator-facing checklist, see [03-release-checklist.md](03-release-checklist.md).
-
-## Toolchain contract
-
-Current automation assumptions:
-
-- Node.js 24
-- pnpm 10.6.5
-- Go 1.24.2 for binary packaging
-- stable Rust toolchain for repo validation
-
-Keep workflow versions aligned with the contributor-facing setup in [README.md](../../README.md).
-
-## Repository hygiene notes
-
-- `.agents/**` and `.recursive/**` are intentionally excluded from normal formatting and lint enforcement.
-- routine CI/release automation work should not rewrite those artifacts unless the task explicitly targets them.
+Before changing GitHub protections, observe the successful check names on a real PR. Capture current settings, apply
+one recoverable change at a time, read it back, and keep `main` protected until the complete replacement policy is
+verified.

--- a/docs/operations/03-release-checklist.md
+++ b/docs/operations/03-release-checklist.md
@@ -1,57 +1,33 @@
-# Release Checklist
+# Release checklist
 
-Use this checklist every time you cut a tagged `role-model` release.
+## Stage candidate
 
-## Before tagging
+1. Confirm the intended work is merged into `dev` with all required CI lanes green.
+2. Open and review `dev -> stage`; use a merge commit and do not rewrite stage history.
+3. Confirm the stage binary matrix completed and its artifacts include `role-model-stage`, commit/SHA identity,
+   attestations, and `core_payload_sha256`.
+4. Run the stage package on `3457` beside production on `3456` and development on `3458`; verify isolated state.
 
-1. Merge only from a commit that already passed `ci.yml`.
-2. Confirm the release commit range includes the locked recursive receipts you want the changelog generator to read.
-3. Update `apps/docs-site/content/docs/` for every user-visible install, benchmark, routing, UI, or release-flow change in the release.
-4. Confirm installer and manual-download docs still match the assets the workflow will publish.
-5. Run the local release floor:
+## Production promotion
 
-```bash
-corepack pnpm run ci:check
-corepack pnpm run docs:build
-corepack pnpm run runtime:package-sea
-```
+1. Open and review `stage -> main`; do not add untested product changes during promotion.
+2. Confirm all main promotion checks pass and merge with a merge commit.
+3. Create an annotated tag: `git tag -a vX.Y.Z -m "role-model vX.Y.Z"`.
+4. Push the tag. Production packaging must retrieve the matching stage candidate and verify the exact core payload
+   digest before publication.
+5. Approve the protected `release` environment when requested.
 
-## Tagging
+## Published assets
 
-1. Create an annotated tag: `git tag -a vX.Y.Z -m "role-model vX.Y.Z"`
-2. Push the tag: `git push origin vX.Y.Z`
+Verify the release contains `role-model-{linux-x64,darwin-x64,darwin-arm64}` archives,
+`role-model-win32-x64.zip`, `install.sh`, `install.ps1`, `SHA256SUMS.txt`, generated release highlights, and
+artifact attestations. Installer and manual-download docs must use the same filenames.
 
-## What GitHub should do
+## Rollback and hotfix
 
-The tag should trigger `build-binaries.yml`, which now:
-
-1. builds all supported runtime archives,
-2. attests the built archives, retrying transient Sigstore/Rekor timeouts before the job is allowed to fail,
-3. gathers every archive into one publish job,
-4. adds installer scripts,
-5. writes `SHA256SUMS.txt`,
-6. generates a recursive changelog from implementation, decisions, and state receipts in the tag range,
-7. creates one GitHub Release using those generated user-facing highlights.
-
-## After publish
-
-Verify the GitHub Release contains:
-
-- all four platform archives,
-- `install.sh`,
-- `install.ps1`,
-- `SHA256SUMS.txt`,
-- user-facing release highlights generated from the recursive receipts,
-- no internal recursive run names or implementation-phase wording in the public release body.
-
-Also verify:
-
-- the release is marked prerelease only when the tag is prerelease-like,
-- installer scripts still resolve the latest published release,
-- the release workflow produced artifact attestations for the archives,
-- manual-download instructions in [install.md](../public/install.md) still match the released filenames.
-
-## Environment protection
-
-Use a GitHub Actions environment named `release` for required reviewers or other deployment protections. The
-workflow references this environment, but the approval rules themselves live in repository settings.
+- Roll back a bad release by restoring the last known-good tag/assets and documenting the failed candidate; do not
+  force-reset `main`.
+- For an emergency, branch `hotfix/*` from `main`, review and validate it, merge to `main`, then forward the hotfix to
+  `stage` and `dev` through reviewed merges.
+- If a promotion branch diverges, merge the upstream promotion branch and resolve conflicts; never delete or
+  force-update long-lived history.

--- a/docs/public/install.md
+++ b/docs/public/install.md
@@ -1,6 +1,6 @@
 # Install the router
 
-For normal users, the easiest way to run `role-model-router` is to install a packaged release.
+For normal users, the easiest way to run `role-model` is to install a packaged release.
 
 Building from source is still supported, but it requires Node.js 24, `pnpm`, and Go.
 
@@ -12,8 +12,8 @@ Building from source is still supported, but it requires Node.js 24, `pnpm`, and
 curl -fsSL https://raw.githubusercontent.com/try-works/role-model/main/scripts/install.sh | sh
 ```
 
-This installs the latest release bundle under `~/.local/share/role-model-router/` and creates a
-`role-model-router` launcher in `~/.local/bin`.
+This installs the latest release bundle under `~/.local/share/role-model/` and creates a
+`role-model` launcher in `~/.local/bin`.
 
 ### Windows
 
@@ -21,31 +21,44 @@ This installs the latest release bundle under `~/.local/share/role-model-router/
 irm https://raw.githubusercontent.com/try-works/role-model/main/scripts/install.ps1 | iex
 ```
 
-This installs the latest release bundle under `%LOCALAPPDATA%\Programs\RoleModelRouter\` and creates a
-`role-model-router.cmd` launcher.
+This installs the latest release bundle under `%LOCALAPPDATA%\Programs\role-model\` and creates a
+`role-model.cmd` launcher.
 
-If your shell cannot find `role-model-router` immediately after installation, open a new terminal so it picks
+If your shell cannot find `role-model` immediately after installation, open a new terminal so it picks
 up the updated `PATH`.
 
 ## Manual downloads
 
 Every tagged release should publish one archive per supported platform:
 
-- `role-model-router-linux-x64.tar.gz`
-- `role-model-router-darwin-x64.tar.gz`
-- `role-model-router-darwin-arm64.tar.gz`
-- `role-model-router-win32-x64.zip`
+- `role-model-linux-x64.tar.gz`
+- `role-model-darwin-x64.tar.gz`
+- `role-model-darwin-arm64.tar.gz`
+- `role-model-win32-x64.zip`
 - `SHA256SUMS.txt`
 
 After extracting the archive:
 
-- Windows: run `Role-Model.bat` or `role-model-runtime.exe`
-- macOS/Linux: run `role-model-runtime`
+- Windows: run `role-model.bat` or `role-model.exe`
+- macOS/Linux: run `role-model`
 
 Before running a manual download, verify its checksum against `SHA256SUMS.txt`.
 
 When launched without extra runtime arguments, the packaged runtime opens the local UI in your default
 browser.
+
+## Runtime channels
+
+Stable production packages run as `role-model` at `http://127.0.0.1:3456`. Stage candidates run as
+`role-model-stage` at `http://127.0.0.1:3457`, and development packages run as `role-model-dev` at
+`http://127.0.0.1:3458`. Each channel has its own state root and can run concurrently on one device.
+
+Pi keeps the production endpoint by default. To use a candidate explicitly:
+
+```bash
+ROLE_MODEL_ENDPOINT=http://127.0.0.1:3457 pi # stage
+ROLE_MODEL_ENDPOINT=http://127.0.0.1:3458 pi # development
+```
 
 ## Source builds
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "runtime:test-full": "corepack pnpm run runtime:test-critical && corepack pnpm run runtime:test-browser",
     "build": "corepack pnpm run types:generate && corepack pnpm -r --if-present build",
     "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present test",
-    "test:release-workflows": "node --test scripts/build-binaries-workflow.test.mjs",
+    "test:release-workflows": "node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs",
     "test:rust": "cargo test --manifest-path role-model-router/rust/Cargo.toml --workspace",
     "smoke": "corepack pnpm --filter @role-model-router/gateway-smoke exec tsx src/index.ts",
     "ci:check": "corepack pnpm run lint && corepack pnpm run schemas:validate && corepack pnpm run build && corepack pnpm run test && corepack pnpm run runtime:test-critical && corepack pnpm run test:rust && corepack pnpm run smoke"

--- a/packages/pi-role-model/README.md
+++ b/packages/pi-role-model/README.md
@@ -1,6 +1,6 @@
 # pi-role-model
 
-Pi package for connecting Pi to an already-running Role-Model runtime.
+Pi package for connecting Pi to an already-running role-model runtime.
 
 Install the public package:
 
@@ -14,10 +14,11 @@ For local development from this repository root:
 pi install ./packages/pi-role-model
 ```
 
-By default the package connects to `http://127.0.0.1:3456`. To point Pi at a different local Role-Model runtime, set `ROLE_MODEL_ENDPOINT` before starting Pi:
+By default the package connects to production at `http://127.0.0.1:3456`. To point Pi at a different local role-model runtime, set `ROLE_MODEL_ENDPOINT` before starting Pi:
 
 ```bash
-ROLE_MODEL_ENDPOINT=http://127.0.0.1:4567 pi
+ROLE_MODEL_ENDPOINT=http://127.0.0.1:3457 pi # stage
+ROLE_MODEL_ENDPOINT=http://127.0.0.1:3458 pi # development
 ```
 
 Remote endpoints are blocked by default. Enable remote runtime access only for a trusted endpoint and trusted project context with explicit `allowRemote` behavior, for example by setting `ROLE_MODEL_ALLOW_REMOTE=1` when launching Pi. A runtime whose downstream discovery reports `authentication.required` fails closed unless a future explicit supported token source is added; the package does not read Pi auth files.
@@ -44,11 +45,11 @@ Unsupported noninteractive slash-command path:
 pi -p "/role-model status"
 ```
 
-Pi print mode currently does not invoke package slash commands. Treat that as an upstream Pi limitation, not as a Role-Model routing failure.
+Pi print mode currently does not invoke package slash commands. Treat that as an upstream Pi limitation, not as a role-model routing failure.
 
-The package registers a Pi provider named `role-model` from Role-Model's downstream OpenAI discovery endpoint at `/api/role-model/downstream/openai`.
+The package registers a Pi provider named `role-model` from role-model's downstream OpenAI discovery endpoint at `/api/role-model/downstream/openai`.
 
-For explicit provider prompts, use the provider-relative Role-Model id that Pi lists for provider `role-model`, for example:
+For explicit provider prompts, use the provider-relative role-model id that Pi lists for provider `role-model`, for example:
 
 ```bash
 pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"
@@ -56,14 +57,14 @@ pi --no-session --provider role-model --model baseline.remote-only -p "<prompt>"
 
 Canonical explicit-provider ids are provider-relative aliases such as `baseline.remote-only`. The qualified form `role-model/<alias>` is compatibility-only for Pi surfaces that explicitly require a qualified id for storage or display.
 
-`/role-model alias list` shows the exact ids you can pass to Pi. `/role-model alias recommended` shows the current default. If someone tries a foreign id such as `gpt-4o` under provider `role-model`, the recovery path is to inspect the alias list and retry with the recommended Role-Model alias.
+`/role-model alias list` shows the exact ids you can pass to Pi. `/role-model alias recommended` shows the current default. If someone tries a foreign id such as `gpt-4o` under provider `role-model`, the recovery path is to inspect the alias list and retry with the recommended role-model alias.
 
-`/role-model alias use <alias>` stores the selected alias and asks Pi to make that exact Role-Model model id active when Pi exposes active model selection in the command context. If Pi rejects the model switch, the command reports that the active model was not changed.
+`/role-model alias use <alias>` stores the selected alias and asks Pi to make that exact role-model model id active when Pi exposes active model selection in the command context. If Pi rejects the model switch, the command reports that the active model was not changed.
 
 `/role-model requests` and `/role-model explain <request-id|latest>` read the runtime-owned structured request inspection and router decision surfaces. They report routing reason codes, selected endpoint/model, and Observe request links from the runtime without claiming that the Pi package computes benchmark or telemetry analytics itself.
 
-This package does not install, start, stop, or update the Role-Model runtime. It also does not copy or sync Pi provider credentials. Start Role-Model outside Pi, then run `/role-model setup`.
+This package does not install, start, stop, or update the role-model runtime. It also does not copy or sync Pi provider credentials. Start role-model outside Pi, then run `/role-model setup`.
 
 If Pi prints successful output and then exits with a Windows assertion, that is an upstream Pi bug rather than a package-owned routing failure.
 
-Direct `curl` calls to the Role-Model `/v1/chat/completions` endpoint remain debug-only fallback tools when diagnosing Pi or runtime issues. They are not the primary supported integration path.
+Direct `curl` calls to the role-model `/v1/chat/completions` endpoint remain debug-only fallback tools when diagnosing Pi or runtime issues. They are not the primary supported integration path.

--- a/role-model-router/apps/launcher/main.go
+++ b/role-model-router/apps/launcher/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,13 +25,60 @@ const (
 	frontendShutdownWait  = 5 * time.Second
 )
 
+type runtimeProfile struct {
+	Channel       string `json:"channel"`
+	Name          string `json:"name"`
+	Host          string `json:"host"`
+	Port          int    `json:"port"`
+	StateRootName string `json:"state_root_name"`
+	ScopeID       string `json:"scope_id"`
+	Executable    string `json:"executable"`
+}
+
+func productionRuntimeProfile() runtimeProfile {
+	return runtimeProfile{
+		Channel: "production", Name: "role-model", Host: runtimeHost, Port: runtimePort,
+		StateRootName: "role-model-runtime", ScopeID: "standalone-runtime", Executable: "role-model.exe",
+	}
+}
+
+func readRuntimeProfile(packageDir string) (runtimeProfile, error) {
+	content, err := os.ReadFile(filepath.Join(packageDir, "manifest.json"))
+	if err != nil {
+		return runtimeProfile{}, fmt.Errorf("read manifest: %w", err)
+	}
+	var profile runtimeProfile
+	if err := json.Unmarshal(content, &profile); err != nil {
+		return runtimeProfile{}, fmt.Errorf("parse manifest: %w", err)
+	}
+	expected := map[string]runtimeProfile{
+		"production":  productionRuntimeProfile(),
+		"stage":       {Channel: "stage", Name: "role-model-stage", Host: runtimeHost, Port: 3457, StateRootName: "role-model-runtime-stage", ScopeID: "standalone-runtime-stage", Executable: "role-model-stage.exe"},
+		"development": {Channel: "development", Name: "role-model-dev", Host: runtimeHost, Port: 3458, StateRootName: "role-model-runtime-dev", ScopeID: "standalone-runtime-dev", Executable: "role-model-dev.exe"},
+	}
+	want, ok := expected[profile.Channel]
+	if !ok || profile.Name != want.Name || profile.Host != want.Host || profile.Port != want.Port || profile.StateRootName != want.StateRootName || profile.ScopeID != want.ScopeID {
+		return runtimeProfile{}, fmt.Errorf("manifest runtime profile does not match channel %q", profile.Channel)
+	}
+	if profile.Executable == "" {
+		profile.Executable = want.Executable
+	} else if profile.Executable != want.Executable {
+		return runtimeProfile{}, fmt.Errorf("manifest executable does not match channel %q", profile.Channel)
+	}
+	return profile, nil
+}
+
 func resolveRuntimeStateRoot(packageDir string) string {
+	return resolveRuntimeStateRootForProfile(packageDir, productionRuntimeProfile())
+}
+
+func resolveRuntimeStateRootForProfile(packageDir string, profile runtimeProfile) string {
 	cacheDir, err := os.UserCacheDir()
 	if err == nil && cacheDir != "" {
-		return filepath.Join(cacheDir, "Role Model Runtime")
+		return filepath.Join(cacheDir, profile.StateRootName)
 	}
 
-	return filepath.Join(packageDir, "runtime-state")
+	return filepath.Join(packageDir, profile.StateRootName)
 }
 
 func looksLikeWorkspaceRoot(directory string) bool {
@@ -85,15 +133,19 @@ func resolveStandaloneWorkspaceRoot(packageDir string) string {
 }
 
 func buildRuntimeArgs(packageDir string, runtimeStateRoot string) []string {
+	return buildRuntimeArgsForProfile(packageDir, runtimeStateRoot, productionRuntimeProfile())
+}
+
+func buildRuntimeArgsForProfile(packageDir string, runtimeStateRoot string, profile runtimeProfile) []string {
 	workspaceRoot := resolveStandaloneWorkspaceRoot(packageDir)
 	unifiedRuntimeConfigPath := filepath.Join(runtimeStateRoot, "state", "runtime-config.yaml")
 	return []string{
 		"--repo-root", workspaceRoot,
 		"--runtime-state-root", runtimeStateRoot,
-		"--scope-id", "standalone-runtime",
+		"--scope-id", profile.ScopeID,
 		"--unified-runtime-config", unifiedRuntimeConfigPath,
-		"--host", runtimeHost,
-		"--port", fmt.Sprintf("%d", runtimePort),
+		"--host", profile.Host,
+		"--port", fmt.Sprintf("%d", profile.Port),
 		"--static-root", filepath.Join(packageDir, "build", "client"),
 	}
 }
@@ -330,15 +382,17 @@ func run() int {
 	}
 
 	exeDir := filepath.Dir(executablePath)
-
-	var bridgeBinary string
-	if runtime.GOOS == "windows" {
-		bridgeBinary = filepath.Join(exeDir, "role-model-runtime.exe")
-	} else {
-		bridgeBinary = filepath.Join(exeDir, "role-model-runtime")
+	profile, err := readRuntimeProfile(exeDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load role-model runtime profile: %v\n", err)
+		return 1
+	}
+	bridgeBinary := filepath.Join(exeDir, profile.Executable)
+	if runtime.GOOS != "windows" {
+		bridgeBinary = filepath.Join(exeDir, strings.TrimSuffix(profile.Executable, ".exe"))
 	}
 
-	runtimeStateRoot := resolveRuntimeStateRoot(exeDir)
+	runtimeStateRoot := resolveRuntimeStateRootForProfile(exeDir, profile)
 	if err := os.MkdirAll(runtimeStateRoot, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create runtime state directory: %v\n", err)
 		return 1
@@ -349,10 +403,10 @@ func run() int {
 		return 1
 	}
 
-	baseURL := buildRuntimeBaseURL(runtimeHost, runtimePort)
+	baseURL := buildRuntimeBaseURL(profile.Host, profile.Port)
 
-	fmt.Println("Starting Role Model Runtime...")
-	backendCmd := exec.Command(bridgeBinary, buildRuntimeArgs(exeDir, runtimeStateRoot)...)
+	fmt.Printf("Starting %s...\n", profile.Name)
+	backendCmd := exec.Command(bridgeBinary, buildRuntimeArgsForProfile(exeDir, runtimeStateRoot, profile)...)
 	backendCmd.Stdout = os.Stdout
 	backendCmd.Stderr = os.Stderr
 	backendCmd.Dir = exeDir
@@ -403,7 +457,7 @@ func run() int {
 			return 1
 		}
 
-		fmt.Println("Role Model is running. Close this window or press Ctrl+C to stop.")
+		fmt.Printf("%s is running. Close this window or press Ctrl+C to stop.\n", profile.Name)
 
 		select {
 		case signalValue := <-signalChannel:
@@ -431,7 +485,7 @@ func run() int {
 		return 1
 	}
 
-	fmt.Println("Role Model is running. Close this window or press Ctrl+C to stop.")
+	fmt.Printf("%s is running. Close this window or press Ctrl+C to stop.\n", profile.Name)
 
 	frontendResultCh := make(chan error, 1)
 	go func() {

--- a/role-model-router/apps/launcher/main_test.go
+++ b/role-model-router/apps/launcher/main_test.go
@@ -37,6 +37,51 @@ func TestBuildRuntimeArgsUsesStandalonePaths(t *testing.T) {
 	}
 }
 
+func TestReadRuntimeProfileAndBuildStageArgs(t *testing.T) {
+	packageDir := t.TempDir()
+	manifest := `{"channel":"stage","name":"role-model-stage","host":"127.0.0.1","port":3457,"state_root_name":"role-model-runtime-stage","scope_id":"standalone-runtime-stage","executable":"role-model-stage.exe"}`
+	if err := os.WriteFile(filepath.Join(packageDir, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	profile, err := readRuntimeProfile(packageDir)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	if profile.Name != "role-model-stage" || profile.Port != 3457 {
+		t.Fatalf("unexpected profile: %+v", profile)
+	}
+	args := buildRuntimeArgsForProfile(packageDir, filepath.Join(packageDir, "state"), profile)
+	joined := strings.Join(args, " ")
+	for _, expected := range []string{"standalone-runtime-stage", "3457"} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected args to contain %q: %v", expected, args)
+		}
+	}
+}
+
+func TestReadRuntimeProfileRejectsChannelMismatch(t *testing.T) {
+	packageDir := t.TempDir()
+	manifest := `{"channel":"development","name":"role-model","host":"127.0.0.1","port":3458,"state_root_name":"role-model-runtime-dev","scope_id":"standalone-runtime-dev"}`
+	if err := os.WriteFile(filepath.Join(packageDir, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if _, err := readRuntimeProfile(packageDir); err == nil {
+		t.Fatal("expected mismatched manifest to fail")
+	}
+}
+
+func TestReadRuntimeProfileRejectsExecutableRedirect(t *testing.T) {
+	packageDir := t.TempDir()
+	manifest := `{"channel":"stage","name":"role-model-stage","host":"127.0.0.1","port":3457,"state_root_name":"role-model-runtime-stage","scope_id":"standalone-runtime-stage","executable":"..\\untrusted.exe"}`
+	if err := os.WriteFile(filepath.Join(packageDir, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if _, err := readRuntimeProfile(packageDir); err == nil {
+		t.Fatal("expected executable redirect to fail")
+	}
+}
+
 func TestBuildRuntimeArgsUsesAncestorWorkspaceRootWhenPackageLivesInsideRepo(t *testing.T) {
 	tempRoot := t.TempDir()
 	workspaceRoot := filepath.Join(tempRoot, "workspace")

--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import os from "node:os";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
@@ -12,6 +13,8 @@ import {
   resolveBridgeServerOptions,
   startBridgeServer,
 } from "./index.js";
+import { readPackagedRuntimeProfile } from "./runtime-channel.js";
+import { migrateLegacyProductionState } from "./runtime-state-migration.js";
 
 type CliBackend = Pick<
   RuntimeBridgeBackend,
@@ -495,6 +498,22 @@ export async function main(): Promise<void> {
     localAppData: process.env.LOCALAPPDATA,
     unifiedRuntimeConfigPath: args.values["unified-runtime-config"],
   });
+  const packagedProfile = readPackagedRuntimeProfile(process.execPath);
+  if (packagedProfile?.channel === "production" && !args.values["runtime-state-root"]) {
+    const migration = await migrateLegacyProductionState({
+      legacyRoot: path.join(process.env.LOCALAPPDATA || os.tmpdir(), "Role Model Runtime"),
+      destinationRoot: options.runtimeStateRoot,
+    });
+    if (migration.copied.length > 0 || migration.conflicts.length > 0) {
+      console.log(
+        JSON.stringify({
+          status: "legacy-state-migration",
+          copied: migration.copied.length,
+          conflicts: migration.conflicts,
+        }),
+      );
+    }
+  }
   const staticRoot = args.values["static-root"]?.trim() || options.staticRoot;
   let server: Awaited<ReturnType<typeof startBridgeServer>> | null = null;
   let backend: RuntimeBridgeBackend | null = null;

--- a/role-model-router/apps/runtime-host-bridge/src/downstream-openai-discovery.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/downstream-openai-discovery.ts
@@ -12,6 +12,7 @@ import type { UnifiedRuntimeModelAliasConfig } from "./unified-runtime-config.js
 
 export interface DownstreamOpenAIDiscoveryInput {
   readonly baseUrl: string;
+  readonly displayName?: string;
   readonly registry: EndpointRegistryResult;
   readonly catalog: NormalizedCatalog;
   readonly modelAliases?: readonly UnifiedRuntimeModelAliasConfig[];
@@ -92,7 +93,7 @@ export interface DownstreamOpenAIDiscoveryResponse {
   readonly contractVersion: "role-model.downstream.openai.v1";
   readonly kind: "openai-compatible";
   readonly providerId: "role-model-runtime";
-  readonly displayName: "Role Model Runtime";
+  readonly displayName: string;
   readonly baseUrl: string;
   readonly endpoints: {
     readonly health: string;
@@ -488,7 +489,7 @@ export function createDownstreamOpenAIDiscovery(
     contractVersion: "role-model.downstream.openai.v1",
     kind: "openai-compatible",
     providerId: "role-model-runtime",
-    displayName: "Role Model Runtime",
+    displayName: input.displayName ?? "role-model",
     baseUrl: input.baseUrl,
     endpoints: {
       health: `${input.baseUrl}/healthz`,

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -125,7 +125,8 @@ import {
   inferChatCompletionsCapabilityRequirements,
   inferResponsesCapabilityRequirements,
 } from "./request-capability-inference.js";
-import { resolveRuntimeVersionInfo } from "./runtime-version.js";
+import { readPackagedRuntimeProfile, resolveRuntimeChannelProfile } from "./runtime-channel.js";
+import { type RuntimeVersionInfoRecord, resolveRuntimeVersionInfo } from "./runtime-version.js";
 
 import {
   type ProviderRequestCapture,
@@ -800,7 +801,7 @@ export interface BridgeDownstreamOpenAIProviderConfig {
   readonly contractVersion: "role-model.downstream.openai.v1";
   readonly kind: "openai-compatible";
   readonly providerId: "role-model-runtime";
-  readonly displayName: "Role Model Runtime";
+  readonly displayName: string;
   readonly baseUrl: string;
   readonly endpoints: {
     readonly health: string;
@@ -3033,6 +3034,7 @@ interface RuntimeCredentialLifecycleSummary {
 }
 
 interface RuntimeBridgeSummary {
+  runtime: RuntimeVersionInfoRecord;
   lifecycleSummary: EndpointRegistryResult["lifecycleSummary"];
   providerCount: number;
   accountCount: number;
@@ -7771,6 +7773,7 @@ export function createDownstreamOpenAIProviderConfig(
     readonly catalog?: NormalizedCatalog;
     readonly inventory?: RoutableInventory | null;
     readonly recommendedModelId?: string | null;
+    readonly displayName?: string;
   } = {},
 ): BridgeDownstreamOpenAIProviderConfig {
   if (options.catalog) {
@@ -7781,6 +7784,7 @@ export function createDownstreamOpenAIProviderConfig(
       modelAliases,
       inventory: options.inventory ?? null,
       recommendedModelId: options.recommendedModelId ?? null,
+      displayName: options.displayName,
     }) as unknown as BridgeDownstreamOpenAIProviderConfig;
   }
 
@@ -7799,7 +7803,7 @@ export function createDownstreamOpenAIProviderConfig(
     contractVersion: "role-model.downstream.openai.v1",
     kind: "openai-compatible",
     providerId: "role-model-runtime",
-    displayName: "Role Model Runtime",
+    displayName: options.displayName ?? "role-model",
     baseUrl,
     endpoints: {
       health: `${baseUrl}/healthz`,
@@ -9589,7 +9593,7 @@ function createDeviceHeaders(
 ): Record<string, string> {
   const isKimi = requiredHeaders.includes("X-Msh-Platform");
   const headers: Record<string, string> = {
-    "User-Agent": isKimi ? "KimiCLI/1.41.0" : "Role-Model-Runtime/1.0",
+    "User-Agent": isKimi ? "KimiCLI/1.41.0" : "role-model-runtime/1.0",
   };
   if (requiredHeaders.includes("X-Msh-Platform")) {
     headers["X-Msh-Platform"] = "kimi_cli";
@@ -11451,7 +11455,7 @@ interface StoredOauthTokenLocation {
   readonly scopeId: string;
 }
 
-function resolveStoredOauthTokenLocations(input: {
+export function resolveStoredOauthTokenLocations(input: {
   readonly runtimeStateRoot: string;
   readonly scopeId: string;
 }): readonly StoredOauthTokenLocation[] {
@@ -11459,6 +11463,9 @@ function resolveStoredOauthTokenLocations(input: {
     runtimeStateRoot: input.runtimeStateRoot,
     scopeId: input.scopeId,
   };
+  if (input.scopeId !== "standalone-runtime" && input.scopeId !== "runtime-host-bridge") {
+    return [activeLocation];
+  }
   const normalizedRoot = path.resolve(input.runtimeStateRoot);
   const containerRoot =
     path.basename(normalizedRoot).toLowerCase() === "state"
@@ -14126,6 +14133,7 @@ function createRequestHandler(options: StartBridgeServerOptions) {
     }
 
     if (request.method === "GET" && url.pathname === "/api/role-model/downstream/openai") {
+      const runtimeIdentity = options.readVersionInfo ? await options.readVersionInfo() : null;
       const configuredRuntimeConfig = await resolveConfiguredRuntimeConfig(
         options.readRuntimeConfig,
       );
@@ -14151,6 +14159,13 @@ function createRequestHandler(options: StartBridgeServerOptions) {
             catalog: options.getExecutionCatalog?.(),
             inventory,
             recommendedModelId,
+            displayName:
+              runtimeIdentity &&
+              typeof runtimeIdentity === "object" &&
+              "name" in runtimeIdentity &&
+              typeof runtimeIdentity.name === "string"
+                ? runtimeIdentity.name
+                : "role-model",
           },
         ),
       );
@@ -21803,6 +21818,7 @@ export async function createRuntimeBridgeBackend(
     async readRuntimeSummary(): Promise<RuntimeBridgeSummary> {
       const credentialLifecycle = buildCredentialLifecycleSummary();
       return {
+        runtime: runtimeVersionInfo,
         lifecycleSummary: currentRegistry.lifecycleSummary,
         providerCount:
           currentNormalizedCatalog.providers.length +
@@ -21850,6 +21866,7 @@ export async function createRuntimeBridgeBackend(
       };
     },
     async readHealthStatus(): Promise<{
+      runtime: RuntimeVersionInfoRecord;
       status: "healthy" | "degraded";
       executionMode: UnifiedRuntimeExecutionMode;
       vendors: Record<string, VendorRuntimeStatus>;
@@ -21871,6 +21888,7 @@ export async function createRuntimeBridgeBackend(
       const bootstrapBlocked =
         sessionBootstrapState.status === "blocked" || sessionBootstrapState.status === "degraded";
       return {
+        runtime: runtimeVersionInfo,
         status: bootstrapBlocked ? "degraded" : summarized.status,
         executionMode: currentUnifiedRuntimeConfig?.executionMode ?? "decision_only",
         vendors,
@@ -25169,6 +25187,8 @@ export function resolveBridgeServerOptions(input: {
   unifiedRuntimeConfigPath?: string;
 }): BridgeServerOptions {
   const repoPath = resolveBridgePathApi([input.executablePath, input.repoRoot]);
+  const packagedProfile = readPackagedRuntimeProfile(input.executablePath);
+  const profile = packagedProfile ?? resolveRuntimeChannelProfile("production");
   const statePath = resolveBridgePathApi([input.localAppData], process.env.LOCALAPPDATA);
   const runtimeStatePath = resolveBridgePathApi(
     [input.runtimeStateRoot, input.localAppData],
@@ -25190,32 +25210,36 @@ export function resolveBridgeServerOptions(input: {
         return repoPath.dirname(routerRoot);
       })()
     : undefined;
-  const repoRoot = input.repoRoot?.trim() || inferredRepoRoot;
+  const packagedRoot =
+    packagedProfile && input.executablePath
+      ? repoPath.dirname(repoPath.resolve(input.executablePath))
+      : undefined;
+  const repoRoot = input.repoRoot?.trim() || inferredRepoRoot || packagedRoot;
   if (!repoRoot) {
     throw new Error("repoRoot is required for the runtime host bridge.");
   }
+  const platformStateBase =
+    input.localAppData?.trim() ||
+    process.env.LOCALAPPDATA ||
+    process.env.XDG_STATE_HOME ||
+    statePath.join(os.homedir(), ".local", "state");
   const runtimeStateRoot =
-    input.runtimeStateRoot?.trim() ||
-    statePath.join(
-      input.localAppData?.trim() || process.env.LOCALAPPDATA || os.tmpdir(),
-      "Role Model Runtime",
-      "state",
-    );
+    input.runtimeStateRoot?.trim() || statePath.join(platformStateBase, profile.state_root_name);
 
   return {
-    host: input.host?.trim() || "127.0.0.1",
-    port: input.port ? Number.parseInt(input.port, 10) : 3456,
+    host: input.host?.trim() || profile.host,
+    port: input.port ? Number.parseInt(input.port, 10) : profile.port,
     repoRoot,
     runtimeStateRoot,
-    scopeId: input.scopeId?.trim() || "runtime-host-bridge",
+    scopeId: input.scopeId?.trim() || profile.scope_id,
     staticRoot: resolveStandaloneStaticRoot({
       repoPath,
       repoRoot,
       executablePath: input.executablePath,
-      preferRepoRootBuild: Boolean(input.repoRoot?.trim()),
+      preferRepoRootBuild: Boolean(input.repoRoot?.trim()) || Boolean(packagedProfile),
     }),
     unifiedRuntimeConfigPath:
       input.unifiedRuntimeConfigPath?.trim() ||
-      runtimeStatePath.join(runtimeStateRoot, "runtime-config.yaml"),
+      runtimeStatePath.join(runtimeStateRoot, "state", "runtime-config.yaml"),
   };
 }

--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -19,6 +19,7 @@ import { gzipSync } from "node:zlib";
 
 import { build as buildBundle } from "esbuild";
 
+import { resolveBuildRuntimeChannel, resolveRuntimeChannelProfile } from "./runtime-channel.js";
 import { resolveRuntimeVersionInfo } from "./runtime-version.js";
 
 export interface BuildTarget {
@@ -275,8 +276,8 @@ export function resolveGoCommand(): string {
   return process.env.GO_BINARY ?? "go";
 }
 
-function resolvePackagedRuntimeName(): string {
-  return process.platform === "win32" ? "role-model-runtime.exe" : "role-model-runtime";
+function resolvePackagedRuntimeName(name: string): string {
+  return process.platform === "win32" ? `${name}.exe` : name;
 }
 
 function resolvePowerShellCommand(): string {
@@ -358,32 +359,40 @@ export async function stampReleaseTreeModificationTimes(
   await utimes(releaseDir, packageBuildDate, packageBuildDate);
 }
 
-async function buildWindowsLauncher(releaseDir: string): Promise<void> {
+async function buildWindowsLauncher(releaseDir: string, launcherName: string): Promise<void> {
   if (process.platform !== "win32") {
     return;
   }
-  runOrThrow(resolveGoCommand(), createWindowsLauncherBuildArgs(releaseDir), repoRoot, {
-    GO111MODULE: "off",
-    GOWORK: "off",
-  });
+  runOrThrow(
+    resolveGoCommand(),
+    createWindowsLauncherBuildArgs(releaseDir, launcherName),
+    repoRoot,
+    {
+      GO111MODULE: "off",
+      GOWORK: "off",
+    },
+  );
 }
 
-export function createWindowsLauncherBuildArgs(releaseDir: string): string[] {
+export function createWindowsLauncherBuildArgs(
+  releaseDir: string,
+  launcherName = "role-model-launcher.exe",
+): string[] {
   const launcherPackagePath = `./${path
     .relative(repoRoot, path.join(routerRoot, "apps", "launcher"))
     .split(path.sep)
     .join("/")}`;
-  return ["build", "-o", path.join(releaseDir, "role-model-launcher.exe"), launcherPackagePath];
+  return ["build", "-o", path.join(releaseDir, launcherName), launcherPackagePath];
 }
 
-export function createWindowsLauncherBatchFile(): string {
+export function createWindowsLauncherBatchFile(launcherName = "role-model-launcher.exe"): string {
   return [
     "@echo off",
     "set SCRIPT_DIR=%~dp0",
-    'if exist "%SCRIPT_DIR%role-model-launcher.exe" (',
-    '  "%SCRIPT_DIR%role-model-launcher.exe"',
+    `if exist "%SCRIPT_DIR%${launcherName}" (`,
+    `  "%SCRIPT_DIR%${launcherName}"`,
     ") else (",
-    "  echo ERROR: role-model-launcher.exe not found.",
+    `  echo ERROR: ${launcherName} not found.`,
     "  pause",
     "  exit /b 1",
     ")",
@@ -499,6 +508,7 @@ export async function packageSeaRuntime(): Promise<{
   if (!buildTarget) {
     throw new Error(`Unsupported runtime packaging target: ${process.platform}-${process.arch}`);
   }
+  const profile = resolveRuntimeChannelProfile(resolveBuildRuntimeChannel());
   const packageBuildDate = new Date();
   const packageBuildDateIso = packageBuildDate.toISOString();
   const versionInfo = await resolveRuntimeVersionInfo({
@@ -532,7 +542,7 @@ export async function packageSeaRuntime(): Promise<{
   }
 
   const releaseDir = path.join(distRoot, "release", releaseTarget);
-  const outputPath = path.join(releaseDir, resolvePackagedRuntimeName());
+  const outputPath = path.join(releaseDir, resolvePackagedRuntimeName(profile.name));
   const blobPath = path.join(distRoot, "sea-prep.blob");
   await rm(releaseDir, { recursive: true, force: true });
   await mkdir(releaseDir, { recursive: true });
@@ -543,16 +553,25 @@ export async function packageSeaRuntime(): Promise<{
   await injectSeaBlob(outputPath, blobPath);
 
   await stageStandaloneReleaseFiles(releaseDir);
-  await buildWindowsLauncher(releaseDir);
+  const launcherName = `${profile.name}-launcher.exe`;
+  await buildWindowsLauncher(releaseDir, launcherName);
   if (process.platform === "win32") {
     await writeFile(
-      path.join(releaseDir, "Role-Model.bat"),
-      createWindowsLauncherBatchFile(),
+      path.join(releaseDir, `${profile.name}.bat`),
+      createWindowsLauncherBatchFile(launcherName),
       "ascii",
     );
   }
 
   const sha256 = await writeSha256(outputPath);
+  const sourceTreeResult = spawnSync("git", ["rev-parse", "HEAD^{tree}"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (sourceTreeResult.status !== 0 || !sourceTreeResult.stdout.trim()) {
+    throw new Error("Unable to resolve source_tree for packaged runtime");
+  }
+  const sourceTree = sourceTreeResult.stdout.trim();
   await writeFile(
     path.join(releaseDir, "manifest.json"),
     JSON.stringify(
@@ -562,9 +581,14 @@ export async function packageSeaRuntime(): Promise<{
         arch: process.arch,
         target: releaseTarget,
         sha256,
+        executable_sha256: sha256,
+        core_payload_sha256: sha256,
+        source_tree: sourceTree,
         version: versionInfo.version,
         commit: versionInfo.commit,
         build_date: versionInfo.build_date,
+        ...profile,
+        endpoint: `http://${profile.host}:${profile.port}`,
       },
       null,
       2,

--- a/role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/runtime-channel.ts
@@ -1,0 +1,101 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export type RuntimeChannel = "production" | "stage" | "development";
+
+export interface RuntimeChannelProfile {
+  readonly schema_version: 1;
+  readonly channel: RuntimeChannel;
+  readonly name: "role-model" | "role-model-stage" | "role-model-dev";
+  readonly host: "127.0.0.1";
+  readonly port: 3456 | 3457 | 3458;
+  readonly state_root_name:
+    | "role-model-runtime"
+    | "role-model-runtime-stage"
+    | "role-model-runtime-dev";
+  readonly scope_id: "standalone-runtime" | "standalone-runtime-stage" | "standalone-runtime-dev";
+}
+
+const PROFILES: Record<RuntimeChannel, RuntimeChannelProfile> = {
+  production: {
+    schema_version: 1,
+    channel: "production",
+    name: "role-model",
+    host: "127.0.0.1",
+    port: 3456,
+    state_root_name: "role-model-runtime",
+    scope_id: "standalone-runtime",
+  },
+  stage: {
+    schema_version: 1,
+    channel: "stage",
+    name: "role-model-stage",
+    host: "127.0.0.1",
+    port: 3457,
+    state_root_name: "role-model-runtime-stage",
+    scope_id: "standalone-runtime-stage",
+  },
+  development: {
+    schema_version: 1,
+    channel: "development",
+    name: "role-model-dev",
+    host: "127.0.0.1",
+    port: 3458,
+    state_root_name: "role-model-runtime-dev",
+    scope_id: "standalone-runtime-dev",
+  },
+};
+
+export function resolveRuntimeChannelProfile(value: unknown): RuntimeChannelProfile {
+  if (value !== "production" && value !== "stage" && value !== "development") {
+    throw new Error(`Unsupported runtime channel: ${String(value)}`);
+  }
+  return PROFILES[value];
+}
+
+export function resolveRuntimeStateRoot(
+  platformStateBase: string,
+  profile: RuntimeChannelProfile,
+): string {
+  return path.join(platformStateBase, profile.state_root_name);
+}
+
+export function resolveBuildRuntimeChannel(env: NodeJS.ProcessEnv = process.env): RuntimeChannel {
+  const value = env.ROLE_MODEL_BUILD_CHANNEL?.trim() || "development";
+  resolveRuntimeChannelProfile(value);
+  return value as RuntimeChannel;
+}
+
+export function readPackagedRuntimeProfile(
+  executablePath: string | undefined,
+): RuntimeChannelProfile | null {
+  if (!executablePath) {
+    return null;
+  }
+  const manifestPath = path.join(path.dirname(path.resolve(executablePath)), "manifest.json");
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Invalid packaged runtime manifest at ${manifestPath}`, { cause: error });
+  }
+  const record = manifest as Record<string, unknown>;
+  const profile = resolveRuntimeChannelProfile(record.channel);
+  for (const [field, expected] of [
+    ["name", profile.name],
+    ["host", profile.host],
+    ["port", profile.port],
+    ["state_root_name", profile.state_root_name],
+    ["scope_id", profile.scope_id],
+  ] as const) {
+    if (record[field] !== expected) {
+      throw new Error(
+        `Packaged runtime manifest ${field} does not match channel ${profile.channel}`,
+      );
+    }
+  }
+  return profile;
+}

--- a/role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/runtime-state-migration.ts
@@ -1,0 +1,88 @@
+import { constants } from "node:fs";
+import { copyFile, mkdir, readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+export interface LegacyProductionStateMigrationReceipt {
+  readonly copied: string[];
+  readonly skipped: string[];
+  readonly conflicts: string[];
+}
+
+interface MigrationInput {
+  readonly legacyRoot: string;
+  readonly destinationRoot: string;
+}
+
+async function listFiles(root: string): Promise<string[]> {
+  const info = await stat(root).catch(() => null);
+  if (!info) return [];
+  if (info.isFile()) return [""];
+  if (!info.isDirectory()) return [];
+  const result: string[] = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const relativeChildren = await listFiles(path.join(root, entry.name));
+    for (const child of relativeChildren) {
+      result.push(path.join(entry.name, child));
+    }
+  }
+  return result;
+}
+
+export async function migrateLegacyProductionState(
+  input: MigrationInput,
+): Promise<LegacyProductionStateMigrationReceipt> {
+  const copied: string[] = [];
+  const skipped: string[] = [];
+  const conflicts: string[] = [];
+  const copiedThisRun = new Set<string>();
+
+  const mappings = [
+    ["runtime-config.yaml", "state/runtime-config.yaml"],
+    ["role-policy.json", "role-policy.json"],
+    ["local-policy.json", "local-policy.json"],
+    ["model-overrides.json", "model-overrides.json"],
+    ["peers.json", "peers.json"],
+    ["standalone-runtime/credentials", "standalone-runtime/credentials"],
+    ["standalone-runtime/codex-subscription", "standalone-runtime/codex-subscription"],
+    ["standalone-runtime/memory", "standalone-runtime/memory"],
+    ["standalone-runtime/operator-intent.json", "standalone-runtime/operator-intent.json"],
+    ["state/runtime-config.yaml", "state/runtime-config.yaml"],
+    ["state/role-policy.json", "role-policy.json"],
+    ["state/local-policy.json", "local-policy.json"],
+    ["state/model-overrides.json", "model-overrides.json"],
+    ["state/peers.json", "peers.json"],
+    ["state/runtime-host-bridge/credentials", "standalone-runtime/credentials"],
+    ["state/runtime-host-bridge/codex-subscription", "standalone-runtime/codex-subscription"],
+    ["state/runtime-host-bridge/memory", "standalone-runtime/memory"],
+    ["state/runtime-host-bridge/operator-intent.json", "standalone-runtime/operator-intent.json"],
+  ] as const;
+
+  for (const [sourceRelative, destinationRelative] of mappings) {
+    const sourceRoot = path.join(input.legacyRoot, sourceRelative);
+    for (const child of await listFiles(sourceRoot)) {
+      const sourcePath = path.join(sourceRoot, child);
+      const targetRelative = path.normalize(path.join(destinationRelative, child));
+      const receiptRelative = targetRelative.split(path.sep).join("/");
+      const targetPath = path.join(input.destinationRoot, targetRelative);
+      const targetInfo = await stat(targetPath).catch(() => null);
+      if (targetInfo) {
+        if (copiedThisRun.has(targetRelative)) {
+          const [sourceBytes, targetBytes] = await Promise.all([
+            readFile(sourcePath),
+            readFile(targetPath),
+          ]);
+          if (!sourceBytes.equals(targetBytes)) conflicts.push(receiptRelative);
+        } else {
+          skipped.push(receiptRelative);
+        }
+        continue;
+      }
+      await mkdir(path.dirname(targetPath), { recursive: true });
+      await copyFile(sourcePath, targetPath, constants.COPYFILE_EXCL);
+      copiedThisRun.add(targetRelative);
+      copied.push(receiptRelative);
+    }
+  }
+
+  return { copied, skipped, conflicts };
+}

--- a/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts
@@ -9,12 +9,43 @@ export interface RuntimeVersionInfoRecord {
   readonly commit: string;
   readonly build_date: string;
   readonly configVersion?: string;
+  readonly channel?: string;
+  readonly name?: string;
+  readonly endpoint?: string;
+  readonly source_tree?: string;
+  readonly executable_sha256?: string;
+  readonly core_payload_sha256?: string;
 }
 
 interface RuntimeVersionManifest {
   readonly version?: unknown;
   readonly commit?: unknown;
   readonly build_date?: unknown;
+  readonly channel?: unknown;
+  readonly name?: unknown;
+  readonly endpoint?: unknown;
+  readonly source_tree?: unknown;
+  readonly executable_sha256?: unknown;
+  readonly core_payload_sha256?: unknown;
+}
+
+function readManifestIdentity(
+  manifest: RuntimeVersionManifest | null,
+): Partial<RuntimeVersionInfoRecord> {
+  const fields = [
+    "channel",
+    "name",
+    "endpoint",
+    "source_tree",
+    "executable_sha256",
+    "core_payload_sha256",
+  ] as const;
+  return Object.fromEntries(
+    fields.flatMap((field) => {
+      const value = readNonEmptyString(manifest?.[field]);
+      return value ? [[field, value]] : [];
+    }),
+  );
 }
 
 export interface ResolveRuntimeVersionInfoOptions {
@@ -98,6 +129,7 @@ export async function resolveRuntimeVersionInfo(
         readNonEmptyString(env.BUILD_DATE) ??
         readNonEmptyString(env.GITHUB_RUN_CREATED_AT) ??
         "runtime-derived",
+      ...readManifestIdentity(manifest),
       ...(options.fallbackConfigVersion ? { configVersion: options.fallbackConfigVersion } : {}),
     };
   }

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -306,11 +306,11 @@ describe("runtime-host-bridge executable packaging", () => {
     const installScript = await readFile(installScriptPath, "utf8");
     const installPowerShell = await readFile(installPowerShellPath, "utf8");
 
-    expect(installScript).toContain("role-model-router-${TARGET}.tar.gz");
-    expect(installScript).toContain("role-model-router");
+    expect(installScript).toContain("role-model-${TARGET}.tar.gz");
+    expect(installScript).toContain("role-model");
     expect(installScript).toContain(".local/bin");
-    expect(installPowerShell).toContain("role-model-router-$target.zip");
-    expect(installPowerShell).toContain("role-model-router.cmd");
+    expect(installPowerShell).toContain("role-model-$target.zip");
+    expect(installPowerShell).toContain("role-model.cmd");
   });
 
   test("wires device-authorization readback into the packaged runtime cli server", async () => {

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -8871,7 +8871,7 @@ describe("runtime-host-bridge", () => {
         contractVersion: "role-model.downstream.openai.v1",
         kind: "openai-compatible",
         providerId: "role-model-runtime",
-        displayName: "Role Model Runtime",
+        displayName: "role-model",
         baseUrl: `http://127.0.0.1:${server.port}`,
         endpoints: {
           health: `http://127.0.0.1:${server.port}/healthz`,
@@ -16676,7 +16676,7 @@ describe("runtime-host-bridge", () => {
       path.join(os.tmpdir(), "runtime-host-codex-auth-repair-"),
     );
     const runtimeStateRoot = path.join(runtimeContainerRoot, "state");
-    const scopeId = "runtime-host-codex-auth-repair-tests";
+    const scopeId = "runtime-host-bridge";
     const bridgeCredentialFile = path.join(
       runtimeStateRoot,
       scopeId,
@@ -22763,9 +22763,9 @@ describe("runtime-host-bridge", () => {
       port: 9191,
       repoRoot,
       runtimeStateRoot: "C:\\runtime-state",
-      scopeId: "runtime-host-bridge",
+      scopeId: "standalone-runtime",
       staticRoot: path.join(repoRoot, "role-model-router", "apps", "runtime-ui", "build", "client"),
-      unifiedRuntimeConfigPath: "C:\\runtime-state\\runtime-config.yaml",
+      unifiedRuntimeConfigPath: "C:\\runtime-state\\state\\runtime-config.yaml",
     });
   });
 
@@ -22800,23 +22800,30 @@ describe("runtime-host-bridge", () => {
       port: 9191,
       repoRoot: "/home/runner/work/role-model/role-model",
       runtimeStateRoot: "C:\\runtime-state",
-      scopeId: "runtime-host-bridge",
+      scopeId: "standalone-runtime",
       staticRoot:
         "/home/runner/work/role-model/role-model/role-model-router/apps/runtime-ui/build/client",
-      unifiedRuntimeConfigPath: "C:\\runtime-state\\runtime-config.yaml",
+      unifiedRuntimeConfigPath: "C:\\runtime-state\\state\\runtime-config.yaml",
     });
   });
 
-  test("resolves packaged bridge server options from executable path defaults", () => {
-    const packageDir = path.join(repoRoot, "role-model-router", "dist", "release", "win32-x64");
+  test("resolves packaged bridge server options from executable path defaults", async () => {
+    const packageDir = await mkdtemp(path.join(os.tmpdir(), "role-model-production-package-"));
     const packagedStaticRoot = path.join(packageDir, "build", "client");
-    const devStaticRoot = path.join(
-      repoRoot,
-      "role-model-router",
-      "apps",
-      "runtime-ui",
-      "build",
-      "client",
+    await mkdir(packagedStaticRoot, { recursive: true });
+    await writeFile(path.join(packagedStaticRoot, "index.html"), "<!doctype html>", "utf8");
+    await writeFile(
+      path.join(packageDir, "manifest.json"),
+      JSON.stringify({
+        schema_version: 1,
+        channel: "production",
+        name: "role-model",
+        host: "127.0.0.1",
+        port: 3456,
+        state_root_name: "role-model-runtime",
+        scope_id: "standalone-runtime",
+      }),
+      "utf8",
     );
     const result = (
       bridge as {
@@ -22838,22 +22845,24 @@ describe("runtime-host-bridge", () => {
         };
       }
     ).resolveBridgeServerOptions({
-      executablePath: path.join(packageDir, "role-model-runtime.exe"),
+      executablePath: path.join(packageDir, "role-model.exe"),
       localAppData: "C:\\Users\\tester\\AppData\\Local",
     });
 
-    expect(result).toEqual({
-      host: "127.0.0.1",
-      port: 3456,
-      repoRoot,
-      runtimeStateRoot: "C:\\Users\\tester\\AppData\\Local\\Role Model Runtime\\state",
-      scopeId: "runtime-host-bridge",
-      staticRoot: existsSync(path.join(packagedStaticRoot, "index.html"))
-        ? packagedStaticRoot
-        : devStaticRoot,
-      unifiedRuntimeConfigPath:
-        "C:\\Users\\tester\\AppData\\Local\\Role Model Runtime\\state\\runtime-config.yaml",
-    });
+    try {
+      expect(result).toEqual({
+        host: "127.0.0.1",
+        port: 3456,
+        repoRoot: packageDir,
+        runtimeStateRoot: "C:\\Users\\tester\\AppData\\Local\\role-model-runtime",
+        scopeId: "standalone-runtime",
+        staticRoot: packagedStaticRoot,
+        unifiedRuntimeConfigPath:
+          "C:\\Users\\tester\\AppData\\Local\\role-model-runtime\\state\\runtime-config.yaml",
+      });
+    } finally {
+      await rm(packageDir, { recursive: true, force: true });
+    }
   });
 
   test("prefers repoRoot frontend assets over packaged assets when repoRoot is explicit", () => {
@@ -22924,11 +22933,11 @@ describe("runtime-host-bridge", () => {
       host: "127.0.0.1",
       port: 3456,
       repoRoot: "/home/tester/role-model",
-      runtimeStateRoot: "/home/tester/.local/share/Role Model Runtime/state",
-      scopeId: "runtime-host-bridge",
+      runtimeStateRoot: "/home/tester/.local/share/role-model-runtime",
+      scopeId: "standalone-runtime",
       staticRoot: "/home/tester/role-model/role-model-router/apps/runtime-ui/build/client",
       unifiedRuntimeConfigPath:
-        "/home/tester/.local/share/Role Model Runtime/state/runtime-config.yaml",
+        "/home/tester/.local/share/role-model-runtime/state/runtime-config.yaml",
     });
   });
 });

--- a/role-model-router/apps/runtime-host-bridge/test/restart-rehydration.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/restart-rehydration.test.ts
@@ -888,7 +888,7 @@ describe("restart rehydration", () => {
       `restart-standalone-oauth-repair-${Date.now()}`,
     );
     const runtimeStateRoot = path.join(runtimeContainerRoot, "state");
-    const scopeId = "restart-standalone-oauth-repair-tests";
+    const scopeId = "runtime-host-bridge";
     const bridgeCredentialPath = path.join(
       runtimeStateRoot,
       scopeId,

--- a/role-model-router/apps/runtime-host-bridge/test/runtime-channel-options.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/runtime-channel-options.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { resolveBridgeServerOptions, resolveStoredOauthTokenLocations } from "../src/index.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("packaged runtime channel options", () => {
+  test("resolves an extracted Unix-style package from its adjacent manifest", async () => {
+    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-installed-package-"));
+    roots.push(packageRoot);
+    const executablePath = path.join(packageRoot, "role-model-stage");
+    await writeFile(executablePath, "", "utf8");
+    await mkdir(path.join(packageRoot, "build", "client"), { recursive: true });
+    await writeFile(path.join(packageRoot, "build", "client", "index.html"), "role-model", "utf8");
+    await writeFile(
+      path.join(packageRoot, "manifest.json"),
+      JSON.stringify({
+        channel: "stage",
+        name: "role-model-stage",
+        host: "127.0.0.1",
+        port: 3457,
+        state_root_name: "role-model-runtime-stage",
+        scope_id: "standalone-runtime-stage",
+      }),
+      "utf8",
+    );
+
+    const options = resolveBridgeServerOptions({
+      executablePath,
+      localAppData: path.join(packageRoot, "state-base"),
+    });
+    expect(options.repoRoot).toBe(packageRoot);
+    expect(options.staticRoot).toBe(path.join(packageRoot, "build", "client"));
+    expect(options.port).toBe(3457);
+    expect(options.scopeId).toBe("standalone-runtime-stage");
+    expect(options.runtimeStateRoot).toBe(
+      path.join(packageRoot, "state-base", "role-model-runtime-stage"),
+    );
+  });
+
+  test("does not mirror stage or development OAuth locations into production scope names", () => {
+    expect(
+      resolveStoredOauthTokenLocations({
+        runtimeStateRoot: "stage-root",
+        scopeId: "standalone-runtime-stage",
+      }),
+    ).toEqual([{ runtimeStateRoot: "stage-root", scopeId: "standalone-runtime-stage" }]);
+    expect(
+      resolveStoredOauthTokenLocations({
+        runtimeStateRoot: "dev-root",
+        scopeId: "standalone-runtime-dev",
+      }),
+    ).toEqual([{ runtimeStateRoot: "dev-root", scopeId: "standalone-runtime-dev" }]);
+  });
+});

--- a/role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/runtime-channel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveRuntimeChannelProfile, resolveRuntimeStateRoot } from "../src/runtime-channel.js";
+
+describe("runtime channel profiles", () => {
+  test.each([
+    ["production", "role-model", 3456, "role-model-runtime", "standalone-runtime"],
+    ["stage", "role-model-stage", 3457, "role-model-runtime-stage", "standalone-runtime-stage"],
+    ["development", "role-model-dev", 3458, "role-model-runtime-dev", "standalone-runtime-dev"],
+  ] as const)("resolves %s", (channel, name, port, stateRootName, scopeId) => {
+    expect(resolveRuntimeChannelProfile(channel)).toEqual({
+      schema_version: 1,
+      channel,
+      name,
+      host: "127.0.0.1",
+      port,
+      state_root_name: stateRootName,
+      scope_id: scopeId,
+    });
+  });
+
+  test("rejects unsupported build channels", () => {
+    expect(() => resolveRuntimeChannelProfile("preview")).toThrow(/unsupported runtime channel/i);
+  });
+
+  test("derives separate state roots from one platform base", () => {
+    const base = "C:\\Users\\tester\\AppData\\Local";
+    expect(resolveRuntimeStateRoot(base, resolveRuntimeChannelProfile("production"))).toContain(
+      "role-model-runtime",
+    );
+    expect(resolveRuntimeStateRoot(base, resolveRuntimeChannelProfile("stage"))).toContain(
+      "role-model-runtime-stage",
+    );
+    expect(resolveRuntimeStateRoot(base, resolveRuntimeChannelProfile("development"))).toContain(
+      "role-model-runtime-dev",
+    );
+  });
+});

--- a/role-model-router/apps/runtime-host-bridge/test/runtime-state-migration.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/runtime-state-migration.test.ts
@@ -1,0 +1,74 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { migrateLegacyProductionState } from "../src/runtime-state-migration.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function put(root: string, relativePath: string, content: string): Promise<void> {
+  const target = path.join(root, relativePath);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, content, "utf8");
+}
+
+describe("legacy production state migration", () => {
+  test("merges Windows and raw-SEA layouts with deterministic precedence", async () => {
+    const base = await mkdtemp(path.join(os.tmpdir(), "role-model-state-migration-"));
+    roots.push(base);
+    const legacy = path.join(base, "Role Model Runtime");
+    const destination = path.join(base, "role-model-runtime");
+
+    await put(legacy, "standalone-runtime/credentials/shared.json", "windows");
+    await put(legacy, "state/runtime-host-bridge/credentials/shared.json", "unix");
+    await put(legacy, "runtime-config.yaml", "windows-config");
+    await put(legacy, "state/runtime-config.yaml", "raw-sea-config");
+    await put(legacy, "state/runtime-host-bridge/operator-intent.json", "intent");
+    await put(legacy, "state/runtime-host-bridge/memory/memory.sqlite-wal", "wal");
+    await put(legacy, "logs/runtime-http.log", "do-not-copy");
+    await put(destination, "standalone-runtime/credentials/existing.json", "destination");
+
+    const receipt = await migrateLegacyProductionState({
+      legacyRoot: legacy,
+      destinationRoot: destination,
+    });
+
+    await expect(
+      readFile(path.join(destination, "standalone-runtime/credentials/shared.json"), "utf8"),
+    ).resolves.toBe("windows");
+    await expect(
+      readFile(path.join(destination, "state/runtime-config.yaml"), "utf8"),
+    ).resolves.toBe("windows-config");
+    await expect(
+      readFile(path.join(destination, "standalone-runtime/operator-intent.json"), "utf8"),
+    ).resolves.toBe("intent");
+    await expect(
+      readFile(path.join(destination, "standalone-runtime/memory/memory.sqlite-wal"), "utf8"),
+    ).resolves.toBe("wal");
+    await expect(
+      readFile(path.join(destination, "logs/runtime-http.log"), "utf8"),
+    ).rejects.toThrow();
+    expect(receipt.conflicts).toContain("standalone-runtime/credentials/shared.json");
+  });
+
+  test("never overwrites canonical destination state and is repeatable", async () => {
+    const base = await mkdtemp(path.join(os.tmpdir(), "role-model-state-idempotent-"));
+    roots.push(base);
+    const legacy = path.join(base, "Role Model Runtime");
+    const destination = path.join(base, "role-model-runtime");
+    await put(legacy, "standalone-runtime/credentials/token.json", "legacy");
+    await put(destination, "standalone-runtime/credentials/token.json", "canonical");
+
+    await migrateLegacyProductionState({ legacyRoot: legacy, destinationRoot: destination });
+    await migrateLegacyProductionState({ legacyRoot: legacy, destinationRoot: destination });
+
+    await expect(
+      readFile(path.join(destination, "standalone-runtime/credentials/token.json"), "utf8"),
+    ).resolves.toBe("canonical");
+  });
+});

--- a/role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/runtime-version.test.ts
@@ -21,6 +21,12 @@ describe("resolveRuntimeVersionInfo", () => {
         version: "0.0.2",
         commit: "abc123def456",
         build_date: "2026-06-29T00:00:00.000Z",
+        channel: "stage",
+        name: "role-model-stage",
+        endpoint: "http://127.0.0.1:3457",
+        source_tree: "tree123",
+        executable_sha256: "exe123",
+        core_payload_sha256: "core123",
       }),
       "utf8",
     );
@@ -35,6 +41,12 @@ describe("resolveRuntimeVersionInfo", () => {
       release_version: "0.0.2",
       commit: "abc123def456",
       build_date: "2026-06-29T00:00:00.000Z",
+      channel: "stage",
+      name: "role-model-stage",
+      endpoint: "http://127.0.0.1:3457",
+      source_tree: "tree123",
+      executable_sha256: "exe123",
+      core_payload_sha256: "core123",
       configVersion: "1.1",
     });
   });

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -15,3 +15,16 @@ test("build-binaries retries release attestation before failing", () => {
   assert.match(workflow, /steps\.attest_release_archive_attempt_1\.outcome == 'failure'/);
   assert.match(workflow, /steps\.attest_release_archive_attempt_2\.outcome == 'failure'/);
 });
+
+test("build-binaries produces stage candidates, manual dev builds, and tag-only releases", () => {
+  assert.match(workflow, /branches:\s*\n\s*- stage/);
+  assert.match(workflow, /ROLE_MODEL_BUILD_CHANNEL/);
+  assert.match(workflow, /development/);
+  assert.match(workflow, /stage/);
+  assert.match(workflow, /production/);
+  assert.match(workflow, /core_payload_sha256/);
+  assert.match(workflow, /source_tree/);
+  assert.match(workflow, /github\.ref_type == 'tag'/);
+  assert.match(workflow, /role-model-stage/);
+  assert.match(workflow, /role-model-dev/);
+});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+test("CI is scoped to long-lived branches with stable cancellable lanes", () => {
+  assert.match(workflow, /push:\s*\n\s*branches:\s*\n\s*- dev\s*\n\s*- stage\s*\n\s*- main/);
+  assert.match(
+    workflow,
+    /pull_request:\s*\n\s*branches:\s*\n\s*- dev\s*\n\s*- stage\s*\n\s*- main/,
+  );
+  assert.match(workflow, /concurrency:[\s\S]*cancel-in-progress: true/);
+  assert.match(workflow, /permissions:\s*\n\s*contents: read/);
+  assert.doesNotMatch(workflow, /--frozen-lockfile=false/);
+  for (const job of [
+    "promotion-guard",
+    "quality",
+    "build-test",
+    "runtime-critical",
+    "runtime-router",
+    "rust",
+    "smoke",
+  ]) {
+    assert.match(workflow, new RegExp(`^  ${job}:`, "m"));
+  }
+});
+
+test("promotion guard encodes dev to stage to main with a hotfix exception", () => {
+  assert.match(workflow, /BASE_REF.*stage[\s\S]*HEAD_REF.*dev/);
+  assert.match(workflow, /BASE_REF.*main[\s\S]*HEAD_REF.*stage/);
+  assert.match(workflow, /hotfix\//);
+  assert.match(workflow, /Invalid promotion source/);
+});

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,8 +3,8 @@
 param(
     [string]$OwnerRepo = $(if ($env:ROLE_MODEL_REPOSITORY) { $env:ROLE_MODEL_REPOSITORY } else { "try-works/role-model" }),
     [string]$Version = $(if ($env:ROLE_MODEL_VERSION) { $env:ROLE_MODEL_VERSION } else { "latest" }),
-    [string]$InstallRoot = $(if ($env:ROLE_MODEL_INSTALL_ROOT) { $env:ROLE_MODEL_INSTALL_ROOT } else { Join-Path $env:LOCALAPPDATA "Programs\RoleModelRouter" }),
-    [string]$BinDir = $(if ($env:ROLE_MODEL_BIN_DIR) { $env:ROLE_MODEL_BIN_DIR } else { Join-Path $env:LOCALAPPDATA "Programs\RoleModelRouter\bin" })
+    [string]$InstallRoot = $(if ($env:ROLE_MODEL_INSTALL_ROOT) { $env:ROLE_MODEL_INSTALL_ROOT } else { Join-Path $env:LOCALAPPDATA "Programs\role-model" }),
+    [string]$BinDir = $(if ($env:ROLE_MODEL_BIN_DIR) { $env:ROLE_MODEL_BIN_DIR } else { Join-Path $env:LOCALAPPDATA "Programs\role-model\bin" })
 )
 
 $ErrorActionPreference = "Stop"
@@ -51,12 +51,12 @@ function Ensure-UserPathContains([string]$PathEntry) {
 
 $target = Get-Target
 $resolvedVersion = Resolve-Version -Repository $OwnerRepo -RequestedVersion $Version
-$assetName = "role-model-router-$target.zip"
+$assetName = "role-model-$target.zip"
 $downloadUrl = "https://github.com/$OwnerRepo/releases/download/$resolvedVersion/$assetName"
 $packageDir = Join-Path $InstallRoot (Join-Path $resolvedVersion $target)
-$launcherBatch = Join-Path $packageDir "Role-Model.bat"
-$runtimeExe = Join-Path $packageDir "role-model-runtime.exe"
-$shimPath = Join-Path $BinDir "role-model-router.cmd"
+$launcherBatch = Join-Path $packageDir "role-model.bat"
+$runtimeExe = Join-Path $packageDir "role-model.exe"
+$shimPath = Join-Path $BinDir "role-model.cmd"
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("role-model-router-" + [System.Guid]::NewGuid().ToString("N"))
 $archivePath = Join-Path $tempDir $assetName
 
@@ -84,12 +84,12 @@ try {
 
     $pathUpdated = Ensure-UserPathContains -PathEntry $BinDir
 
-    Write-Host "Installed role-model-router to $packageDir"
+    Write-Host "Installed role-model to $packageDir"
     Write-Host "Launcher command: $shimPath"
     if ($pathUpdated) {
-        Write-Host "Updated your user PATH. Open a new terminal before running role-model-router."
+        Write-Host "Updated your user PATH. Open a new terminal before running role-model."
     } else {
-        Write-Host "Run role-model-router from a new terminal."
+        Write-Host "Run role-model from a new terminal."
     }
 }
 finally {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 OWNER_REPO="${ROLE_MODEL_REPOSITORY:-try-works/role-model}"
-INSTALL_ROOT="${ROLE_MODEL_INSTALL_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/role-model-router}"
+INSTALL_ROOT="${ROLE_MODEL_INSTALL_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/role-model}"
 BIN_DIR="${ROLE_MODEL_BIN_DIR:-$HOME/.local/bin}"
 VERSION="${ROLE_MODEL_VERSION:-latest}"
 
@@ -30,11 +30,11 @@ if [ "$VERSION" = "latest" ]; then
 fi
 
 TARGET="$(detect_platform)-$(detect_arch)"
-ASSET_NAME="${ROLE_MODEL_ASSET_NAME:-role-model-router-${TARGET}.tar.gz}"
+ASSET_NAME="${ROLE_MODEL_ASSET_NAME:-role-model-${TARGET}.tar.gz}"
 DOWNLOAD_URL="https://github.com/${OWNER_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
 PACKAGE_DIR="${INSTALL_ROOT}/${VERSION}/${TARGET}"
-LAUNCHER_PATH="${PACKAGE_DIR}/role-model-runtime"
-COMMAND_PATH="${BIN_DIR}/role-model-router"
+LAUNCHER_PATH="${PACKAGE_DIR}/role-model"
+COMMAND_PATH="${BIN_DIR}/role-model"
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
@@ -43,12 +43,12 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required to install role-model-router." >&2
+  echo "curl is required to install role-model." >&2
   exit 1
 fi
 
 if ! command -v tar >/dev/null 2>&1; then
-  echo "tar is required to install role-model-router." >&2
+  echo "tar is required to install role-model." >&2
   exit 1
 fi
 
@@ -60,13 +60,13 @@ chmod +x "${LAUNCHER_PATH}"
 rm -f "${COMMAND_PATH}"
 ln -s "${LAUNCHER_PATH}" "${COMMAND_PATH}"
 
-printf "Installed role-model-router to %s\n" "${PACKAGE_DIR}"
+printf "Installed role-model to %s\n" "${PACKAGE_DIR}"
 printf "Launcher command: %s\n" "${COMMAND_PATH}"
 
 case ":$PATH:" in
   *:"${BIN_DIR}":*)
     ;;
   *)
-    printf "Add %s to your PATH, then run: role-model-router\n" "${BIN_DIR}"
+    printf "Add %s to your PATH, then run: role-model\n" "${BIN_DIR}"
     ;;
 esac


### PR DESCRIPTION
## Summary
- split CI into stable validation lanes with dev -> stage -> main promotion guards
- package isolated role-model, role-model-stage, and role-model-dev runtimes on ports 3456/3457/3458
- add stage-candidate payload verification, production state migration, and updated operations docs
- keep docs deployment intentionally simple and main-only

Closes #61

## Verification
- pnpm lint, schemas, build, and full test suite
- runtime critical, Rust, smoke, Go launcher tests
- concurrent packaged runtime QA with main/stage/dev