### PR TITLE
ci: isolate resource-heavy Pi tests

### DIFF
--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md
@@ -1,0 +1,58 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `05 Manual QA upstream-gap addendum`
+Status: `DRAFT`
+Inputs:
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- GitHub Actions runs `29668088068` and `29668594990`
+- User instruction approving stronger agent guidance and durable memory closeout
+Outputs:
+- `/AGENTS.md`
+- `/package.json`
+- `/scripts/ci-workflow.test.mjs`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md`
+Scope note: This addendum records Phase 5 evidence that exposed CI fan-out instability and a repository-level agent-instruction gap after the locked implementation plan.
+
+## Gap
+
+The locked Phase 2 plan required stable required checks and a Codex recursive-mode bridge, but live promotion QA exposed two gaps:
+
+1. The workspace-wide recursive test fan-out twice terminated `@try-works/pi-role-model` without a failing assertion while its resource-heavy rebuilt-runtime proof was running. The identical package passed all 95 tests in isolation and passed on rerun, so repeated blind reruns would leave a flaky required check.
+2. `/.codex/AGENTS.md` instructed recursive-mode sessions, but the repository had no root `/AGENTS.md` with unconditional branch, promotion, runtime-channel, and naming rules for ordinary agent work.
+
+## Evidence and compensation
+
+- Run `29668088068`, job `88142085912`, and run `29668594990`, job `88143425962`, both ended with `packages/pi-role-model test: Failed` and no failed Vitest assertion.
+- The isolated command `corepack pnpm --filter @try-works/pi-role-model test` passed 15 files and 95 tests, including the 15-second rebuilt-runtime alias proof.
+- `/package.json` now excludes `@try-works/pi-role-model` from the concurrent recursive fan-out and runs it once afterward.
+- `/scripts/ci-workflow.test.mjs` contains the RED/GREEN contract for that sequencing.
+- `/AGENTS.md` makes the delivery workflow visible without requiring recursive-mode discovery.
+
+## Implications
+
+The promotion PR must wait for this compensation to merge into `dev`, then rerun from the updated `dev` head. Phase 5 must record the resulting green promotion and post-merge stage candidate before it can lock. Phase 8 must refresh the two GitHub workflow memory patterns and the memory router.
+
+## TODO
+
+- [x] Record both assertion-free CI failures.
+- [x] Add a failing sequencing contract.
+- [x] Isolate and verify the Pi package test.
+- [x] Add root agent instructions.
+- [ ] Merge the compensation through a reviewed pull request into `dev`.
+- [ ] Re-run and complete the promotion QA.
+
+## Traceability
+
+- `R1`: root agent guidance reinforces ordinary work targeting `dev`.
+- `R2`: the compensation preserves stable protected checks and promotion enforcement.
+- `R3`: the required `build-test` lane becomes deterministic under bounded sequencing.
+- `R4`: root guidance preserves the approved main-only docs exception.
+- `R5`-`R9`: unchanged; later Phase 5 evidence must verify their already implemented behavior and migration state.
+
+## Coverage Gate
+
+Coverage: FAIL — promotion and final GitHub topology evidence remain incomplete.
+
+## Approval Gate
+
+Approval: FAIL — this addendum remains active until the compensation and promotions are verified.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md
@@ -19,6 +19,7 @@ The locked Phase 2 plan required stable required checks and a Codex recursive-mo
 
 1. The workspace-wide recursive test fan-out twice terminated `@try-works/pi-role-model` without a failing assertion while its resource-heavy rebuilt-runtime proof was running. The identical package passed all 95 tests in isolation and passed on rerun, so repeated blind reruns would leave a flaky required check.
 2. `/.codex/AGENTS.md` instructed recursive-mode sessions, but the repository had no root `/AGENTS.md` with unconditional branch, promotion, runtime-channel, and naming rules for ordinary agent work.
+3. After Pi isolation made the rest of the host suite run to completion on Linux, `endpoint-rehydration.test.ts` exposed a separate one-second bootstrap polling assumption. Under CI load the assertion ran while bootstrap still reported `running`, before the remote health probe could mark the endpoint offline.
 
 ## Evidence and compensation
 
@@ -26,6 +27,7 @@ The locked Phase 2 plan required stable required checks and a Codex recursive-mo
 - The isolated command `corepack pnpm --filter @try-works/pi-role-model test` passed 15 files and 95 tests, including the 15-second rebuilt-runtime alias proof.
 - `/package.json` now excludes `@try-works/pi-role-model` from the concurrent recursive fan-out and runs it once afterward.
 - `/scripts/ci-workflow.test.mjs` contains the RED/GREEN contract for that sequencing.
+- `/role-model-router/apps/runtime-host-bridge/test/endpoint-rehydration.test.ts` now makes the slow-probe case deterministic, waits up to the test's bounded deadline, and asserts bootstrap completion before endpoint state.
 - `/AGENTS.md` makes the delivery workflow visible without requiring recursive-mode discovery.
 
 ## Implications
@@ -38,6 +40,7 @@ The promotion PR must wait for this compensation to merge into `dev`, then rerun
 - [x] Add a failing sequencing contract.
 - [x] Isolate and verify the Pi package test.
 - [x] Add root agent instructions.
+- [x] Reproduce and repair the endpoint-rehydration bootstrap timing race.
 - [ ] Merge the compensation through a reviewed pull request into `dev`.
 - [ ] Re-run and complete the promotion QA.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# role-model agent instructions
+
+These instructions apply to all work in this repository.
+
+## Git and delivery workflow
+
+- Start ordinary feature, fix, dependency, and `recursive/*` work from the current `origin/dev` tip.
+- Commit work on a non-long-lived branch and open its pull request against `dev`.
+- Ordinary pull requests into `dev` normally squash merge after required checks, one maintainer approval, and resolved conversations.
+- Never push directly to `dev`, `stage`, or `main`. Never force-push or delete those branches.
+- Promote with reviewed merge-commit pull requests in order: `dev -> stage`, then `stage -> main`.
+- Do not target `stage` or `main` from an ordinary branch. The only production exception is a reviewed `hotfix/* -> main` pull request created from `main`; forward the merged hotfix to `stage` and `dev` afterward.
+- Treat GitHub's `promotion-guard` and protected-branch checks as mandatory. Do not bypass, disable, or rename required checks merely to merge.
+- Keep the docs site on its simpler main-only deployment path; do not create dev/stage docs deployments unless the repository policy is intentionally revised.
+
+Before opening or merging a pull request, read `CONTRIBUTING.md` and `docs/operations/02-ci-and-release-flow.md`.
+
+## Runtime channels
+
+- Production: `role-model`, port `3456`.
+- Stage: `role-model-stage`, port `3457`.
+- Development: `role-model-dev`, port `3458`.
+
+Keep channel state, logs, locks, process identity, and artifacts isolated. Use the lowercase project name `role-model` in current user-facing names.
+
+## recursive-mode
+
+When starting or resuming recursive-mode work, read `.codex/AGENTS.md` and the canonical `.recursive/RECURSIVE.md` before acting. Durable workflow memory lives under `.recursive/memory/`.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "runtime:test-router": "corepack pnpm --filter @role-model-router/runtime-host-bridge run test:router && corepack pnpm --filter @role-model-router/trace test && corepack pnpm --filter @role-model-router/usage test && corepack pnpm run runtime:validate-routing && corepack pnpm run runtime:validate-observability",
     "runtime:test-full": "corepack pnpm run runtime:test-critical && corepack pnpm run runtime:test-browser",
     "build": "corepack pnpm run types:generate && corepack pnpm -r --if-present build",
-    "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present test",
+    "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present --filter=./** --filter=!@try-works/pi-role-model test && corepack pnpm --filter @try-works/pi-role-model test",
     "test:release-workflows": "node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs",
     "test:rust": "cargo test --manifest-path role-model-router/rust/Cargo.toml --workspace",
     "smoke": "corepack pnpm --filter @role-model-router/gateway-smoke exec tsx src/index.ts",

--- a/role-model-router/apps/runtime-host-bridge/test/endpoint-rehydration.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/endpoint-rehydration.test.ts
@@ -250,12 +250,13 @@ describe("endpoint rehydration", () => {
           let health = await restartedBackend.readHealthStatus?.();
           for (
             let attempt = 0;
-            attempt < 20 && health?.sessionBootstrap.status === "running";
+            attempt < 200 && health?.sessionBootstrap.status === "running";
             attempt += 1
           ) {
             await delay(50);
             health = await restartedBackend.readHealthStatus?.();
           }
+          expect(health?.sessionBootstrap.status).not.toBe("running");
 
           expect(
             listRuntimeEndpoints({ databasePath })
@@ -395,6 +396,7 @@ describe("endpoint rehydration", () => {
           const url =
             typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
           if (url.endsWith("/models")) {
+            await delay(1_250);
             throw new Error("timeout while probing remote endpoint");
           }
           throw new Error(`Unexpected network request during endpoint health test: ${url}`);
@@ -404,12 +406,13 @@ describe("endpoint rehydration", () => {
           let health = await restartedBackend.readHealthStatus?.();
           for (
             let attempt = 0;
-            attempt < 20 && health?.sessionBootstrap.status === "running";
+            attempt < 200 && health?.sessionBootstrap.status === "running";
             attempt += 1
           ) {
             await delay(50);
             health = await restartedBackend.readHealthStatus?.();
           }
+          expect(health?.sessionBootstrap.status).not.toBe("running");
 
           await expect(restartedBackend.listEndpoints()).resolves.toEqual(
             expect.arrayContaining([

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+const packageManifest = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
 
 test("CI is scoped to long-lived branches with stable cancellable lanes", () => {
   assert.match(workflow, /push:\s*\n\s*branches:\s*\n\s*- dev\s*\n\s*- stage\s*\n\s*- main/);
@@ -31,4 +34,11 @@ test("promotion guard encodes dev to stage to main with a hotfix exception", () 
   assert.match(workflow, /BASE_REF.*main[\s\S]*HEAD_REF.*stage/);
   assert.match(workflow, /hotfix\//);
   assert.match(workflow, /Invalid promotion source/);
+});
+
+test("workspace tests isolate the resource-heavy Pi runtime proof", () => {
+  assert.match(
+    packageManifest.scripts.test,
+    /--filter=\.\/\*\* --filter=!@try-works\/pi-role-model test.*--filter @try-works\/pi-role-model test/,
+  );
 });


### PR DESCRIPTION
## What changed

- runs the resource-heavy pi-role-model rebuilt-runtime proof after the other workspace tests instead of inside their concurrent fan-out
- adds a contract test for the stable sequencing
- adds root AGENTS.md instructions for the dev -> stage -> main workflow and runtime channel isolation
- records the Phase 5 upstream gap discovered by live promotion QA

## Why

Two GitHub runners terminated pi-role-model without a failed assertion while workspace tests were competing for resources. The package passes reliably in isolation.

## Real behavior proof

- node --test scripts/ci-workflow.test.mjs
- corepack pnpm test
- 42 non-Pi workspace projects completed first
- pi-role-model completed 15 files and 95 tests afterward
- generated vendor binaries were restored and are not included