### PR TITLE
ci: serialize runtime host integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "runtime:test-router": "corepack pnpm --filter @role-model-router/runtime-host-bridge run test:router && corepack pnpm --filter @role-model-router/trace test && corepack pnpm --filter @role-model-router/usage test && corepack pnpm run runtime:validate-routing && corepack pnpm run runtime:validate-observability",
     "runtime:test-full": "corepack pnpm run runtime:test-critical && corepack pnpm run runtime:test-browser",
     "build": "corepack pnpm run types:generate && corepack pnpm -r --if-present build",
-    "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present --filter=./** --filter=!@try-works/pi-role-model test && corepack pnpm --filter @try-works/pi-role-model test",
+    "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present --filter=./** --filter=!@role-model-router/runtime-host-bridge --filter=!@try-works/pi-role-model test && corepack pnpm --filter @role-model-router/runtime-host-bridge test && corepack pnpm --filter @try-works/pi-role-model test",
     "test:release-workflows": "node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs",
     "test:rust": "cargo test --manifest-path role-model-router/rust/Cargo.toml --workspace",
     "smoke": "corepack pnpm --filter @role-model-router/gateway-smoke exec tsx src/index.ts",

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -36,9 +36,9 @@ test("promotion guard encodes dev to stage to main with a hotfix exception", () 
   assert.match(workflow, /Invalid promotion source/);
 });
 
-test("workspace tests isolate the resource-heavy Pi runtime proof", () => {
+test("workspace tests serialize the resource-heavy runtime proofs", () => {
   assert.match(
     packageManifest.scripts.test,
-    /--filter=\.\/\*\* --filter=!@try-works\/pi-role-model test.*--filter @try-works\/pi-role-model test/,
+    /--filter=\.\/\*\* --filter=!@role-model-router\/runtime-host-bridge --filter=!@try-works\/pi-role-model test.*--filter @role-model-router\/runtime-host-bridge test.*--filter @try-works\/pi-role-model test/,
   );
 });


### PR DESCRIPTION
The promotion rollout exposed intermittent runtime-host config failures when that integration-heavy workspace ran concurrently with the rest of the monorepo.

This change:
- excludes runtime-host-bridge from the parallel workspace batch
- runs the runtime-host suite next
- keeps Pi last
- adds a workflow contract assertion for the order

Validation:
- contract test demonstrated RED before the script change
- full local pnpm test passed: 41 ordinary projects, 63/570 runtime-host files/tests, 15/95 Pi files/tests

Tracker: #61