### PR TITLE
promote: dev to stage (CI reliability)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "runtime:test-router": "corepack pnpm --filter @role-model-router/runtime-host-bridge run test:router && corepack pnpm --filter @role-model-router/trace test && corepack pnpm --filter @role-model-router/usage test && corepack pnpm run runtime:validate-routing && corepack pnpm run runtime:validate-observability",
     "runtime:test-full": "corepack pnpm run runtime:test-critical && corepack pnpm run runtime:test-browser",
     "build": "corepack pnpm run types:generate && corepack pnpm -r --if-present build",
-    "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present --filter=./** --filter=!@try-works/pi-role-model test && corepack pnpm --filter @try-works/pi-role-model test",
+    "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present --filter=./** --filter=!@role-model-router/runtime-host-bridge --filter=!@try-works/pi-role-model test && corepack pnpm --filter @role-model-router/runtime-host-bridge test && corepack pnpm --filter @try-works/pi-role-model test",
     "test:release-workflows": "node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs",
     "test:rust": "cargo test --manifest-path role-model-router/rust/Cargo.toml --workspace",
     "smoke": "corepack pnpm --filter @role-model-router/gateway-smoke exec tsx src/index.ts",

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -36,9 +36,9 @@ test("promotion guard encodes dev to stage to main with a hotfix exception", () 
   assert.match(workflow, /Invalid promotion source/);
 });
 
-test("workspace tests isolate the resource-heavy Pi runtime proof", () => {
+test("workspace tests serialize the resource-heavy runtime proofs", () => {
   assert.match(
     packageManifest.scripts.test,
-    /--filter=\.\/\*\* --filter=!@try-works\/pi-role-model test.*--filter @try-works\/pi-role-model test/,
+    /--filter=\.\/\*\* --filter=!@role-model-router\/runtime-host-bridge --filter=!@try-works\/pi-role-model test.*--filter @role-model-router\/runtime-host-bridge test.*--filter @try-works\/pi-role-model test/,
   );
 });


### PR DESCRIPTION
Promote the CI reliability correction from dev to stage.

- Source tip: 52f672f65159d2ffb318cac2d57956fb533a3f08
- Post-merge dev CI: passed
- Change: serialize runtime-host integration tests between the ordinary workspace batch and Pi

Tracker: #61