### PR TITLE
docs: promote run 78 closeout to stage

### DIFF
--- a/.recursive/DECISIONS.md
+++ b/.recursive/DECISIONS.md
@@ -2235,3 +2235,11 @@
 - SQLite summary/list paths must select dedicated projected columns through matching recency indexes. Large JSON observation blobs are detail-only and must never be parsed to reconstruct fields already persisted as columns.
 - The normalized catalog is stored and packaged as a versioned compact wire representation and is hydrated only through the catalog package boundary. Direct production or test JSON imports are prohibited so omitted defaults and provenance remain deterministic.
 - Once an HTTP streaming response is committed, bridge failures must terminate or end that response and preserve runtime health; they must not attempt a second JSON response or mutate headers. Provider-specific model rewriting remains explicit and regression-tested, including Moonshot Kimi K3 mapping.
+# Run 78 dev-stage-main CI/CD and runtime channels (2026-07-19)
+
+- `dev` is the default integration branch; ordinary feature, fix, dependency, and recursive branches target `dev` and normally squash merge.
+- Releases promote with merge commits from `dev` to `stage` and from `stage` to `main`; `main` remains production truth. Approved `hotfix/*` work starts from `main` and is forwarded to `stage` and `dev`.
+- Strict protected checks are `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, and `smoke`; `dev` additionally requires `cla`.
+- Runtime channel identity is build-supplied: production `role-model:3456`, stage `role-model-stage:3457`, development `role-model-dev:3458`, each with isolated state and process identity.
+- Stage pushes build attested candidates; only production tags publish stable releases. Docs build everywhere relevant but deployment is main-only and visibly skips when Cloudflare credentials are absent.
+- Resource-heavy runtime-host and Pi proof suites run serially after ordinary workspace tests to keep the required build/test context reliable.

--- a/.recursive/STATE.md
+++ b/.recursive/STATE.md
@@ -327,3 +327,11 @@
   - all focused suites, validators, browser regressions, packaging validation, and rebuilt SEA runtime QA passed; disposable QA state was removed, and the later canonical-state credential drill stopped its isolated listener while intentionally preserving the authorized device-local credential update
   - user-authorized closeout QA refreshed the device-local Kimi OAuth credential, proved persistence through a rebuilt-runtime restart, and passed real Pi requests for direct `moonshot/kimi-k3`, direct `chatgpt/gpt-5.4`, and `baseline.remote-only` with coherent telemetry, request-detail, router-decision, and Observe-page receipts
   - the worktree branch is locally committed for review at closeout; no push or merge to `main` was requested
+# Run 78 delivery topology (2026-07-19)
+
+- GitHub default branch: `dev`; merged short-lived branches are automatically deleted.
+- Protected long-lived tips at validation: `dev` `52f672f6`, `stage` `8cbf1207`, `main` `0db8a21e`.
+- `dev`, `stage`, and `main` enforce strict CI, PR review, resolved conversations, administrators, no force push, and no deletion. `dev` additionally requires CLA.
+- GitHub environments exist for `development`, `staging`, `production`, and `release`; Cloudflare deploy secrets are currently absent, so docs deployment reports a successful explicit skip after building.
+- Final main CI run `29670332721` passed; final stage candidate build `29670133251` passed on four supported platforms.
+- Root `AGENTS.md`, contribution/PR/operations docs, workflow contract tests, promotion guard, runtime profiles, and channel-aware packaging are current.

--- a/.recursive/memory/MEMORY.md
+++ b/.recursive/memory/MEMORY.md
@@ -29,8 +29,8 @@ Control-plane docs are not memory docs:
 - Taxonomy V1 catalog, groups, roles, classification fields, versioning, deprecation, docs generation: `/.recursive/memory/domains/taxonomy-v1.md`
 - Pi package classifier, metadata injection flow, context signals, runtime override, safety boundaries: `/.recursive/memory/domains/pi-role-model-package.md`
 - Benchmark routing display and env credential lessons: `/.recursive/memory/episodes/run-43-benchmark-routing-display.md`
-- GitHub Actions validation, docs deploy, binary release publication, and recursive-artifact changelog generation: `/.recursive/memory/patterns/github-ci-and-release-workflow.md`
-- Git push and merge workflow (PR-only, no direct main pushes): `/.recursive/memory/patterns/git-push-merge-workflow.md`
+- GitHub Actions lanes, serialized runtime proof suites, docs deploy, channel candidates, and tag-only releases: `/.recursive/memory/patterns/github-ci-and-release-workflow.md`
+- Git push, ordinary PRs to `dev`, reviewed `dev -> stage -> main` promotions, and hotfix convergence: `/.recursive/memory/patterns/git-push-merge-workflow.md`
 - Prefer `Status: CURRENT` docs for planning and execution.
 - `Status: SUSPECT` docs may be used as leads, but revalidate them before trust.
 - Exclude `STALE` and `DEPRECATED` docs from default retrieval unless doing historical analysis.

--- a/.recursive/memory/patterns/git-push-merge-workflow.md
+++ b/.recursive/memory/patterns/git-push-merge-workflow.md
@@ -1,55 +1,43 @@
-# Git Push and Merge Workflow
+# Git Push, Review, and Promotion Workflow
 
 Type: `pattern`
 Status: `CURRENT`
-Scope: `Repository-safe Git push and merge workflow expectations, especially PR-only merge discipline and direct-main anti-pattern recovery guidance.`
+Scope: `Repository branch, pull-request, promotion, and hotfix workflow.`
 Owns-Paths:
-- `/.recursive/memory/patterns/git-push-merge-workflow.md`
+- `/AGENTS.md`
+- `/CONTRIBUTING.md`
+- `/.github/pull_request_template.md`
+- `/docs/operations/02-ci-and-release-flow.md`
 Watch-Paths:
+- `/.github/workflows/ci.yml`
 - `/.recursive/DECISIONS.md`
 - `/.recursive/STATE.md`
-- `/.github/workflows/**`
 Source-Runs:
-- `260624-clever-seal`
-- `62-litellm-pi-craft-codex-execution-hardening`
-Validated-At-Commit: `26e6a4119a7338236fa7e97ff81629e80951e105`
-Last-Validated: `2026-07-08`
-Tags: `git`, `workflow`, `pull-request`, `branch-protection`, `anti-pattern`
-Created: `2026-06-24`
-Last Validated: `2026-06-24`
-Validated By: `260624-clever-seal`
+- `78-dev-stage-main-cicd-runtime-channels`
+Validated-At-Commit: `0db8a21efe943a902f7ae5a2004aff0fe2ceefea`
+Last-Validated: `2026-07-19`
+Tags: `git`, `workflow`, `pull-request`, `promotion`, `branch-protection`
 
-## Correct Workflow
+## Normal work
 
-```
-1. git checkout -b feature-branch     (create branch in worktree)
-2. ...implement, test, verify...
-3. git add -A && git commit           (commit all changes to branch)
-4. git push origin feature-branch     (push branch to remote)
-5. Open PR on GitHub                  (CI runs, review happens)
-6. Merge via PR                       (GitHub UI or API)
-```
+1. Fetch `origin/dev` and create a short-lived feature, fix, dependency, or `recursive/*` branch from it.
+2. Implement and validate in that branch; never develop directly on a long-lived branch.
+3. Push the branch and open a PR to `dev`.
+4. Require strict CI, CLA, conversation resolution, and maintainer review; ordinary work normally squash merges.
+5. Let GitHub delete the merged short-lived branch.
 
-## NEVER DO THIS
+## Promotions
 
-- **Never merge locally and push directly to main.** Always go through a PR.
-- **Never `git checkout main && git merge feature-branch && git push origin main`.** This bypasses CI, review, and branch protection.
-- **Never force push to main.** Main is protected for a reason.
+- Promote only `dev -> stage`, then `stage -> main`, through reviewed PRs and merge commits.
+- `stage` is the tested candidate boundary; `main` is production truth.
+- Never merge locally and push a long-lived branch, force-push it, or bypass the promotion guard.
+- The single-maintainer repository may need a brief, audited review-count maintenance window for an explicitly user-approved merge. Required checks and conversation gates stay active, and the review policy must be restored immediately.
 
-## Why
+## Hotfixes
 
-- PR workflow ensures CI runs against the merged result
-- Branch protection rules (CLA checks, required status checks) are enforced on PRs but not on direct pushes
-- Review history is preserved in the PR
-- Reverting a PR merge is straightforward; reverting a direct push is blocked by branch protection
+- Branch `hotfix/*` from `main`, use a reviewed PR under the explicit guard exception, then forward the resulting change through `stage` and `dev` so branches converge.
+- Do not use a hotfix name to bypass normal integration work.
 
-## What Happened (Session 260624-clever-seal)
+## Agent entry point
 
-Run 57 was merged via `git checkout main && git merge recursive/57-... && git push origin main`. This bypassed the PR workflow. The merge is live but cannot be reverted because main is force-push protected. This is recorded as an anti-pattern.
-
-## Recovery
-
-If a direct main push happens:
-1. The code is permanently on main (cannot force push to revert)
-2. A PR can still be opened retroactively from the branch for documentation/discussion
-3. Future merges MUST use the PR workflow
+- Root `/AGENTS.md` is unconditional guidance for every agent. Recursive-mode sessions additionally follow `/.codex/AGENTS.md` and `/.recursive/RECURSIVE.md`.

--- a/.recursive/memory/patterns/github-ci-and-release-workflow.md
+++ b/.recursive/memory/patterns/github-ci-and-release-workflow.md
@@ -1,66 +1,50 @@
+# GitHub CI, Deployment, and Release Workflow
+
 Type: `pattern`
 Status: `CURRENT`
-Scope: `GitHub Actions validation, docs deploy separation, binary release publication, and recursive-artifact release-note generation`
+Scope: `Long-lived-branch CI, docs validation/deployment, channel candidates, and tag-only releases.`
 Owns-Paths:
 - `/.github/workflows/ci.yml`
 - `/.github/workflows/build-binaries.yml`
 - `/.github/workflows/docs-site-deploy.yml`
-- `/.github/release.yml`
-- `/CHANGELOG.md`
+- `/package.json`
+- `/scripts/ci-workflow.test.mjs`
+- `/scripts/build-binaries-workflow.test.mjs`
+- `/apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs`
 - `/docs/operations/02-ci-and-release-flow.md`
 - `/docs/operations/03-release-checklist.md`
-- `/scripts/generate-recursive-release-changelog.mjs`
 Watch-Paths:
+- `/role-model-router/apps/runtime-host-bridge/**`
+- `/packages/pi-role-model/**`
 - `/.recursive/STATE.md`
 - `/.recursive/DECISIONS.md`
 Source-Runs:
-- `maintenance-ci-release-automation-2026-06-16`
-- `63-router-backend-regression-and-telemetry-surface-hardening`
-Validated-At-Commit: `WORKTREE-UNCOMMITTED`
-Last-Validated: `2026-07-11T00:00:00Z`
-Tags:
-- `github-actions`
-- `ci`
-- `release`
-- `changelog`
-- `attestation`
+- `78-dev-stage-main-cicd-runtime-channels`
+Validated-At-Commit: `0db8a21efe943a902f7ae5a2004aff0fe2ceefea`
+Last-Validated: `2026-07-19`
+Tags: `github-actions`, `ci`, `deployment`, `release`, `attestation`, `runtime-channels`
 
-# GitHub CI And Release Workflow
+## CI contract
 
-Trust: current repo-local baseline; validate again after workflow topology or release-asset changes
+- PRs into and pushes to `dev`, `stage`, and `main` use stable contexts: `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, and `smoke`. `dev` also requires `cla`.
+- Install with `pnpm install --frozen-lockfile`; keep least-privilege permissions, bounded timeouts, and cancellable concurrency groups.
+- Preserve each named lane instead of hiding failures inside one opaque parity wrapper. Keep local `corepack pnpm run ci:check` available.
+- The root full-test order is deliberate: ordinary workspaces in parallel, runtime-host integration tests alone, then Pi alone. Both latter suites start real processes and become flaky under monorepo-wide contention.
+- Update repo-owned workflow contract tests whenever triggers, contexts, promotion rules, or sequencing change.
 
-## CI workflow pattern
+## Docs
 
-- Keep `/.github/workflows/ci.yml` phase-attributed. GitHub-only failures are easier to diagnose when install, lint, typecheck, test, docs build, and workspace validation fail as separate steps instead of one parity wrapper.
-- Preserve the repo-level parity command (`corepack pnpm run ci:check`) for local validation, but do not hide the failing phase inside GitHub behind that single wrapper.
-- When router-affecting backend coverage gains a dedicated lane such as `pnpm run runtime:test-router`, keep it as its own workflow step instead of folding it back into `pnpm run test` or `runtime:test-critical`; router regressions should fail the router phase directly.
-- When a workflow step can fail for packaging or environment reasons, emit phase-local diagnostics or artifacts instead of forcing operators to reconstruct the failure from raw logs.
+- Docs are intentionally simpler than runtime delivery: build on relevant PRs and pushes, deploy only from `main` to the `role-model` production target.
+- Missing Cloudflare credentials must emit a visible non-fatal skip after build validation. Never claim a deployment occurred when credentials are absent.
 
-## Docs deploy pattern
+## Runtime artifacts and releases
 
-- `/.github/workflows/docs-site-deploy.yml` should always prove that the docs site builds on pull requests and pushes, even when deploy credentials are unavailable.
-- Deployment must remain a non-PR concern. Gate the Cloudflare publish path behind explicit secret and account checks so content validation and deployment authorization stay separable.
-- When those secrets are absent, the workflow should emit an explicit skip notice and stay green rather than failing the merged commit. Missing deploy credentials are environment posture, not a product regression.
-- Keep the built static artifact available from the workflow so GitHub-only docs failures can be inspected without rerunning locally.
-
-## Release publication pattern
-
-- `/.github/workflows/build-binaries.yml` should keep matrix jobs limited to build, archive, upload, and attest responsibilities.
-- Artifact attestation stays mandatory, but the workflow should retry transient Sigstore/Rekor failures before failing the matrix job. External transparency-log timeouts are infrastructure flakes, not immediate evidence of a bad archive.
-- Publish the actual GitHub release from one final tag-gated job after all archives are available. That job is the right place to assemble `install.sh`, `install.ps1`, `SHA256SUMS.txt`, and the final release asset bundle.
-- Treat attestations and checksums as part of the shipped release, not optional side outputs.
-
-## Release note pattern
-
-- `/CHANGELOG.md` is a process document for how release notes are derived, not a hand-edited ledger of version sections.
-- Repo-authored release notes should be generated from recursive artifacts in the tagged commit range:
-  - `03-implementation-summary`
-  - `06-decisions-update.md`
-  - `07-state-update.md`
-- `/scripts/generate-recursive-release-changelog.mjs` should prefer those structured receipts and only fall back to added bullet diffs from `/.recursive/STATE.md` and `/.recursive/DECISIONS.md` when structured receipts are absent.
-- `/.github/release.yml` should remain the source for GitHub-generated note categories so the final release combines platform-generated PR metadata with repo-authored implementation receipts.
+- Trusted builds pass an explicit channel; do not infer it from mutable Git state at runtime.
+- Production is `role-model:3456`, stage `role-model-stage:3457`, and development `role-model-dev:3458`, with isolated roots/scopes/process identity.
+- Stage pushes build and attest the full candidate matrix with channel and commit identity. Dev builds are explicit/manual. Only production tags publish stable GitHub releases and installers.
+- Preserve archive checks, checksums, attestations with bounded retry, packaging diagnostics, and channel-neutral core-payload verification.
 
 ## Operator guidance
 
-- If CI changes, update this memory shard and the operations docs in the same change so future agents do not reverse-engineer the workflow from YAML alone.
-- If the release asset set changes, keep the publish job, checklist, and changelog generator aligned; drift between those three surfaces causes the next GitHub-only release failure.
+- Inspect exact failed assertions before rerunning. A pass on retry is evidence of nondeterminism, not automatically a fix.
+- If resource-bearing suites fail only under fan-out, reproduce them alone, add a sequencing contract, and serialize at the root rather than weakening assertions.

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md
@@ -1,52 +1,102 @@
 Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
 Phase: `05 Manual QA`
-Status: `DRAFT`
-LockedAt: `pending`
-LockHash: `pending`
+Status: `LOCKED`
+LockedAt: `2026-07-19T02:41:01Z`
+LockHash: `ff3158dd76ec9beee98e2712a91ebac03b477de8ec0015c1a0ba563acf0b7fcd`
 Workflow version: `recursive-mode-audit-v2`
-Inputs: locked test summary, packaged channel builds, GitHub PR #62, and observed check runs.
-Outputs: concurrent-runtime receipt and recoverable GitHub migration status.
-Scope note: Local/runtime QA is complete; final repository migration awaits the required maintainer-reviewed merge.
+Inputs:
+- locked Phase 4 evidence
+- runtime-channel QA
+- GitHub tracker #61 and PRs #62-#68
+- final GitHub API readback
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md`
+Outputs: concurrent-runtime and live repository migration receipt.
+Scope note: Agent-operated QA covered local runtime isolation and the complete GitHub promotion path.
 
 ## TODO
 
-- [x] Build production, stage, and development Windows packages
-- [x] Run stage and development beside the existing main runtime
-- [x] Restart one channel and verify state isolation
-- [x] Create `dev`, push the implementation, and open PR #62 targeting `dev`
-- [x] Observe all real GitHub check names and results
-- [ ] Receive maintainer review and merge PR #62
-- [ ] Promote `dev -> stage -> main` with reviewed PRs
-- [ ] Apply/read back final protections and set default branch to `dev`
+- [x] Verify production, stage, and development packages concurrently
+- [x] Verify channel restart and state isolation
+- [x] Merge ordinary work to `dev` and promote `dev -> stage -> main`
+- [x] Verify stage candidate binaries and final post-merge CI
+- [x] Apply and read back protections, environments, and default branch
 
 ## QA Execution Record
 
-- Existing main remained healthy on `127.0.0.1:3456` and was never stopped or modified.
-- `role-model-stage` ran and restarted on `127.0.0.1:3457`.
-- `role-model-dev` remained healthy on `127.0.0.1:3458` during the stage restart.
-- Stage marker state persisted; no marker appeared in development; the development SQLite hash remained unchanged.
-- Stage/development used distinct `role-model-runtime-stage` and `role-model-runtime-dev` roots under disposable `LOCALAPPDATA`.
-- Temporary stage/development processes were shut down; the existing main runtime stayed healthy.
+- QA Execution Mode: agent-operated
+- Agent Executor: primary Codex agent
+- Tools Used: PowerShell, Git, GitHub CLI/API, pnpm, Vitest, recursive-mode lock tooling
+- Production remained healthy on `127.0.0.1:3456`; stage ran on `3457`; development ran on `3458`.
+- Stage and development used distinct names, state roots, scope ids, logs, and process identities. Restarting stage preserved its marker, did not alter development SQLite, and left production/development healthy.
+- PR #62 established the workflow through `dev`; corrective PRs #64 and #66 repaired CI resource/timing gaps. Promotion PRs #63/#65 and #67/#68 preserved merge-commit promotion boundaries.
+- Final tips: `dev` `52f672f65159d2ffb318cac2d57956fb533a3f08`; `stage` `8cbf1207f508578b88c435e2977b689e155a9d5a`; `main` `0db8a21efe943a902f7ae5a2004aff0fe2ceefea`.
+- Final main CI run `29670332721` passed. Stage candidate run `29670133251` passed for Linux x64, Windows x64, macOS x64, and macOS arm64 with channel identity, archive, and attestation checks.
+- Docs run `29670332725` built successfully and visibly skipped Cloudflare publication because deploy secrets are absent.
 
-## GitHub Migration Status
+## Evidence and Artifacts
 
-- Tracker: https://github.com/try-works/role-model/issues/61
-- Pull request: https://github.com/try-works/role-model/pull/62
-- `dev` was created from captured main baseline `8863fdc5ab0afc43ed3e86dbcab35b2ca9d2c0b4`.
-- Implementation branch `recursive/78-dev-stage-main-cicd-runtime-channels` was pushed and PR #62 targets `dev`.
-- Observed passing checks: `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, `smoke`, `cla`, and `Build docs site`.
-- Docs deployment correctly skipped on the PR.
+- Tracker #61; implementation/correction PRs #62, #64, #66; promotion PRs #63, #65, #67, #68.
+- Final workflow runs: main CI `29670332721`, main docs `29670332725`, stage candidates `29670133251`.
+- Locked Phase 4 test receipt and locked Phase 5 upstream-gap addendum.
+- Run evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/tdd-red-green.md`, `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/evidence/logs/green/workflow-runtime-migration-green.md`.
 
-## Approval Boundary
+## QA Scenarios and Results
 
-PR #62 is ready for review. The approved design requires one maintainer review and reviewed promotion PRs. Self-merging before that review would contradict the policy being installed, so protections/default-branch changes remain pending until the reviewed implementation reaches `dev` and can be promoted without bypassing the new contract.
+- Three-channel simultaneous start, health, identity, and endpoint checks: PASS.
+- Stage restart with cross-channel state/hash comparison: PASS.
+- Invalid promotion source contract and valid promotion PRs: PASS.
+- Protected-branch/default/environment API readback: PASS.
+- Stage matrix candidate build and final main post-merge CI: PASS.
+
+## GitHub Migration Receipt
+
+- Repository default branch is `dev`; automatic merged-branch deletion is enabled.
+- `dev`, `stage`, and `main` are protected with strict required checks, one approval, stale-review dismissal, last-push approval, resolved conversations, administrator enforcement, and force-push/deletion disabled.
+- `dev` additionally requires `cla`; promotion branches require the seven stable CI lanes without redundant CLA gating.
+- GitHub environments `development`, `staging`, `production`, and `release` exist. Deployment remains credential-gated and makes no false success claim.
+- Promotion guard accepts `dev -> stage`, `stage -> main`, and the documented `hotfix/*` exception, and rejects invalid ordinary sources.
+
+## CI Reliability Compensation
+
+- Assertion-free Pi termination was removed by running Pi after the ordinary workspace batch.
+- Runtime-host config/bootstrap flakes under monorepo contention were removed by running the 570-test runtime-host suite in its own serialized step before Pi.
+- Local full validation passed with 41 ordinary workspaces, 63 runtime-host files / 570 tests, and 15 Pi files / 95 tests. The final dev, stage, promotion, and main CI runs all passed.
 
 ## Requirement Status
 
-- R1: partially complete; `dev` and the default targeting policy exist, but reviewed promotions/default-branch mutation remain pending.
-- R2: pending reviewed merge and observed-check protection application.
-- R3-R9: QA complete; R4 follows approved docs addendum 01.
+- R1-R3: PASS — branch topology, protections, promotion guard, and stable CI lanes are live.
+- R4-R5: PASS — named environments exist; docs build/skip behavior and stage/tag binary boundaries are proven.
+- R6-R8: PASS — channel profiles, canonical `role-model` naming, endpoints, policies, and operations docs are shipped.
+- R9: PASS — concurrent runtime isolation and final GitHub state were directly verified.
 
-## Cleanup
+## Traceability
 
-Temporary stage/development processes were stopped. The existing main runtime was preserved. The resolved disposable QA path `D:/DEV/role-model/.worktrees/runtime-channel-qa-78` was removed after verification.
+- R1: default `dev`, branch tips, merge modes, deletion setting, and promotion history.
+- R2: protected-branch API readback and promotion-guard PR checks.
+- R3: named lane results and serialized full-test evidence.
+- R4: four environments plus docs build and explicit credential-gated skip.
+- R5: stage matrix run `29670133251` and tag-only publication skip.
+- R6-R7: concurrent runtime identities, ports, state roots, and channel artifact receipts.
+- R8: root `AGENTS.md`, contribution/PR/operations docs, and workflow contracts.
+- R9: QA scenarios, state-isolation receipts, and final live API readback.
+
+## Coverage Gate
+
+- [x] All R1-R9 acceptance surfaces have repository or live-state evidence.
+- [x] Temporary QA runtimes were stopped without modifying the existing production runtime.
+Coverage: PASS
+
+## Approval Gate
+
+- [x] The user approved implementation, promotion, protections, agent guidance, and memory closeout.
+- [x] All merges used pull requests; the temporary single-maintainer review windows retained required checks and were immediately restored.
+Approval: PASS
+
+## User Sign-Off
+
+- The user approved the proposal, explicitly instructed implementation, approved the promotion/protection work, and then instructed completion of documentation and durable memory.
+- No additional interactive human QA was required because the accepted scenarios were agent-operated and produced inspectable receipts.
+
+## QA Verdict
+
+QA: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/06-decisions-update.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/06-decisions-update.md
@@ -1,0 +1,104 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `06 Decisions Update`
+Status: `LOCKED`
+LockedAt: `2026-07-19T02:43:51Z`
+LockHash: `f0f36cf4bcad69b7f56871d1f6e7fe6cda491038e03ba2d6c21d8c59e34e3d28`
+Inputs: locked Phases 0-5, Phase 5 addendum, and `/.recursive/DECISIONS.md`.
+Outputs: this receipt and the Run 78 decision entry.
+Scope note: Records durable delivery-policy decisions.
+
+## TODO
+
+- [x] Record the decisions delta
+- [x] Reference the ledger entry
+- [x] Complete audited gates
+
+## Decisions Changes Applied
+
+- Added the Run 78 branch, review, promotion, CI, docs, runtime-channel, candidate, and tag-release contracts.
+
+## Rationale
+
+- Durable policy prevents a return to direct-main development or colliding runtime defaults.
+
+## Resulting Decision Entry
+
+- `/.recursive/DECISIONS.md#run-78-dev-stage-main-cicd-and-runtime-channels-2026-07-19`
+
+## Traceability
+
+- R1-R2: branch, merge, protection, approval, guard, and hotfix decisions.
+- R3-R5: CI lane, docs, candidate, and tag-release decisions.
+- R4: docs build/deployment environment policy and credential-gated skip decision.
+- R6-R7: channel identity, ports, state, and naming decisions.
+- R8: agent/contributor/operations documentation decision.
+- R9: Phase 5 migration and concurrency proof.
+
+## Coverage Gate
+
+- [x] All decision-bearing requirements are represented.
+Coverage: PASS
+
+## Approval Gate
+
+- [x] The entry reflects the approved proposal and implementation.
+Approval: PASS
+
+## Audit Context
+
+- Audit Execution Mode: self-audit
+- Subagent Availability: unavailable
+- Subagent Capability Probe: Delegation was prohibited by active policy because the user did not request subagents.
+- Delegation Decision Basis: Main-agent self-audit re-read all effective inputs and live receipts.
+- Audit Inputs Provided: locked Phases 0-5, final GitHub receipts, and DECISIONS.md.
+
+## Earlier Phase Reconciliation
+
+- Locked earlier phases and the Phase 5 addendum were re-read; no locked artifact was modified.
+
+## Subagent Contribution Verification
+
+- No delegated closeout work contributed.
+
+## Worktree Diff Audit
+
+- Baseline type: remote integration tip
+- Baseline reference: `origin/dev@52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Comparison reference: working tree
+- Normalized baseline: `52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Planned or claimed changed files: closeout receipts, state/decision ledgers, and affected memory shards.
+- Actual changed files reviewed: matches the claimed closeout set.
+- Unexplained drift: None.
+
+## Gaps Found
+
+- None.
+
+## Repair Work Performed
+
+- CI gaps were repaired through PRs #64/#66 and promoted through #67/#68 before closeout.
+
+## Effective Inputs Re-read
+
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- `/.recursive/DECISIONS.md`
+
+## Requirement Completion Status
+
+- R1 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R2 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R3 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R4 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R5 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R6 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R7 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R8 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R9 | Status: verified | Changed Files: `/.recursive/DECISIONS.md` | Implementation Evidence: `/.recursive/DECISIONS.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+
+## Audit Verdict
+
+Audit: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/07-state-update.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/07-state-update.md
@@ -1,0 +1,109 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `07 State Update`
+Status: `LOCKED`
+LockedAt: `2026-07-19T02:44:07Z`
+LockHash: `7b41e0f25a83a79d8a4b7323dcf0ae46a272c584afa128d8872bfe6b1b1a8d04`
+Inputs: locked Phase 6, live GitHub readback, and `/.recursive/STATE.md`.
+Outputs: this receipt and the Run 78 state entry.
+Scope note: Records validated final repository state.
+
+## TODO
+
+- [x] Record the state delta
+- [x] Reference the state summary
+- [x] Complete audited gates
+
+## State Changes Applied
+
+- Added default branch, protected tips/checks, environments, successful workflow runs, and current agent/docs surfaces.
+
+## Rationale
+
+- Observable state lets later work detect drift from repository policy.
+
+## Resulting State Summary
+
+- Default `dev`; protected `dev@52f672f6`, `stage@8cbf1207`, `main@0db8a21e`; final main CI and stage candidates green.
+
+## Traceability
+
+- R1: branch/default state.
+- R2: protection state.
+- R3: CI state.
+- R4: environment/docs state.
+- R5: candidate/release state.
+- R6-R7: shipped channel profiles and QA. R8: policy/docs state. R9: migration and concurrency receipts.
+
+## Coverage Gate
+
+- [x] Repository, branch, protection, environment, and workflow state are recorded.
+Coverage: PASS
+
+## Approval Gate
+
+- [x] Final state is the approved migration outcome.
+Approval: PASS
+
+## Audit Context
+
+- Audit Execution Mode: self-audit
+- Subagent Availability: unavailable
+- Subagent Capability Probe: Delegation was prohibited by active policy because the user did not request subagents.
+- Delegation Decision Basis: Main-agent self-audit re-read all effective inputs and live receipts.
+- Audit Inputs Provided: locked Phase 6, live GitHub readback, and STATE.md.
+
+## Earlier Phase Reconciliation
+
+- Locked earlier phases and the Phase 5 addendum were re-read; no locked artifact was modified.
+
+## Subagent Contribution Verification
+
+- No delegated closeout work contributed.
+
+## Worktree Diff Audit
+
+- Baseline type: remote integration tip
+- Baseline reference: `origin/dev@52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Comparison reference: working tree
+- Normalized baseline: `52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Planned or claimed changed files: closeout receipts, state/decision ledgers, and affected memory shards.
+- Actual changed files reviewed: matches the claimed closeout set.
+- Unexplained drift: None.
+
+## Gaps Found
+
+- None.
+
+## Repair Work Performed
+
+- CI gaps were repaired through PRs #64/#66 and promoted through #67/#68 before closeout.
+
+## Effective Inputs Re-read
+
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/06-decisions-update.md`
+- `/.recursive/STATE.md`
+
+## Requirement Completion Status
+
+- R1 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R2 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R3 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R4 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R5 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R6 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R7 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R8 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R9 | Status: verified | Changed Files: `/.recursive/STATE.md` | Implementation Evidence: `/.recursive/STATE.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+
+## Audit Verdict
+
+Audit: PASS
+
+## Prior Recursive Evidence Reviewed
+
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/06-decisions-update.md`
+- `/.recursive/memory/patterns/git-push-merge-workflow.md`

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/08-memory-impact.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/08-memory-impact.md
@@ -1,0 +1,148 @@
+Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
+Phase: `08 Memory Impact`
+Status: `LOCKED`
+LockedAt: `2026-07-19T02:44:23Z`
+LockHash: `119e079fefc48e8c122b9a359e120870c62e4140d2e296ebc951fbcd8b901d64`
+Inputs: locked Phases 0-7, state/decision ledgers, memory router, and affected pattern shards.
+Outputs: this receipt and refreshed durable memory.
+Scope note: Promotes the validated delivery workflow and CI reliability lessons.
+
+## TODO
+
+- [x] Review affected memory docs and freshness
+- [x] Refresh routers and shards
+- [x] Complete audited gates
+
+## Diff Basis
+
+- Reviewed the final delta against migration baseline `8863fdc5` and production tip `0db8a21e`.
+
+## Changed Paths Review
+
+- Workflows, packaging/channel code, agent/contribution/operations docs, test sequencing, and GitHub state were reviewed.
+
+## Affected Memory Docs
+
+- Refreshed `patterns/git-push-merge-workflow.md`, `patterns/github-ci-and-release-workflow.md`, and `MEMORY.md`.
+- Reviewed `skills/SKILLS.md`; no change was needed because these are repository workflow lessons, not a new skill capability.
+
+## Run-Local Skill Usage Capture
+
+- Skill Usage Relevance: relevant
+- Available Skills: recursive-mode, recursive-debugging, recursive-training, GitHub CI/publishing
+- Skills Sought: closeout/lock, memory promotion, exact CI failure inspection
+- Skills Attempted: all listed
+- Skills Used: all listed
+- Worked Well: phase locking, failed-log inspection, and freshness routing.
+- Issues Encountered: live CI timing/resource failures and single-maintainer review constraints.
+- Future Guidance: inspect assertions before rerun, serialize process-heavy suites, restore protections immediately.
+- Promotion Candidates: dev-first promotion workflow and resource-bearing CI sequencing.
+
+## Skill Memory Promotion Review
+
+- Durable Skill Lessons Promoted: none; lessons belong in repository workflow pattern shards.
+- Generalized Guidance Updated: Git/PR and CI/release patterns plus memory router.
+- Run-Local Observations Left Unpromoted: temporary paths and individual runner timings.
+- Promotion Decision Rationale: stable rules were promoted; ephemeral incident details remain run-local.
+
+## Uncovered Paths
+
+- None.
+
+## Router and Parent Refresh
+
+- `MEMORY.md` now routes dev-first promotions and serialized proof-suite/channel-release guidance.
+
+## Final Status Summary
+
+- Affected memory is CURRENT at production tip `0db8a21e`; no changed workflow path is uncovered.
+
+## Traceability
+
+- R1: default-integration and PR memory. R2: protection and promotion memory.
+- R3: CI lane/sequencing memory. R4: docs environment/deploy memory. R5: candidate/tag-release memory.
+- R6-R7: runtime-channel memory.
+- R8: root agent and operations routing. R9: Phase 5 operational proof retained in run receipts.
+
+## Coverage Gate
+
+- [x] Every affected CURRENT shard was revalidated.
+- [x] No uncovered path or stale router remains.
+Coverage: PASS
+
+## Approval Gate
+
+- [x] The user explicitly requested documentation and memory for agent adherence.
+Approval: PASS
+
+## Audit Context
+
+- Audit Execution Mode: self-audit
+- Subagent Availability: unavailable
+- Subagent Capability Probe: Delegation was prohibited by active policy because the user did not request subagents.
+- Delegation Decision Basis: Main-agent self-audit re-read all effective inputs and live receipts.
+- Audit Inputs Provided: locked Phases 0-7, state/decision ledgers, MEMORY.md, SKILLS.md, and affected shards.
+
+## Earlier Phase Reconciliation
+
+- Locked earlier phases and the Phase 5 addendum were re-read; no locked artifact was modified.
+
+## Subagent Contribution Verification
+
+- No delegated closeout work contributed.
+
+## Worktree Diff Audit
+
+- Baseline type: remote integration tip
+- Baseline reference: `origin/dev@52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Comparison reference: working tree
+- Normalized baseline: `52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 52f672f65159d2ffb318cac2d57956fb533a3f08`
+- Planned or claimed changed files: closeout receipts, state/decision ledgers, and affected memory shards.
+- Actual changed files reviewed: matches the claimed closeout set.
+- Unexplained drift: None.
+
+## Gaps Found
+
+- None.
+
+## Repair Work Performed
+
+- CI gaps were repaired through PRs #64/#66 and promoted through #67/#68 before closeout.
+
+## Effective Inputs Re-read
+
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/00-requirements.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/06-decisions-update.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/07-state-update.md`
+- `/.recursive/memory/MEMORY.md`
+- `/.recursive/memory/skills/SKILLS.md`
+- `/.recursive/memory/patterns/git-push-merge-workflow.md`
+- `/.recursive/memory/patterns/github-ci-and-release-workflow.md`
+
+## Requirement Completion Status
+
+- R1 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R2 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R3 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R4 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R5 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R6 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R7 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R8 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- R9 | Status: verified | Changed Files: `/.recursive/memory/MEMORY.md`, `/.recursive/memory/patterns/git-push-merge-workflow.md`, `/.recursive/memory/patterns/github-ci-and-release-workflow.md` | Implementation Evidence: `/.recursive/memory/MEMORY.md` | Verification Evidence: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+
+## Audit Verdict
+
+Audit: PASS
+
+## Prior Recursive Evidence Reviewed
+
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/06-decisions-update.md`
+- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/07-state-update.md`
+- `/.recursive/memory/MEMORY.md`
+- `/.recursive/memory/patterns/git-push-merge-workflow.md`
+- `/.recursive/memory/patterns/github-ci-and-release-workflow.md`

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md
@@ -1,61 +1,48 @@
 Run: `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/`
 Phase: `05 Manual QA upstream-gap addendum`
-Status: `DRAFT`
-Inputs:
-- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/02-to-be-plan.md`
-- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/05-manual-qa.md`
-- GitHub Actions runs `29668088068` and `29668594990`
-- User instruction approving stronger agent guidance and durable memory closeout
-Outputs:
-- `/AGENTS.md`
-- `/package.json`
-- `/scripts/ci-workflow.test.mjs`
-- `/.recursive/run/78-dev-stage-main-cicd-runtime-channels/addenda/05-manual-qa.upstream-gap.02-to-be-plan.addendum-01.md`
-Scope note: This addendum records Phase 5 evidence that exposed CI fan-out instability and a repository-level agent-instruction gap after the locked implementation plan.
+Status: `LOCKED`
+LockedAt: `2026-07-19T02:40:09Z`
+LockHash: `1cbe26cde44799c70401d06e8efec6e41ca4434108fcafc577972d82caf9c03a`
+Inputs: Phase 5 QA, GitHub Actions runs `29668088068`, `29668594990`, `29669174294`, and `29669598791`.
+Outputs: `/AGENTS.md`, serialized root test topology, and bootstrap timing regression coverage.
+Scope note: Records and closes the live-CI gaps discovered after the locked Phase 2 plan.
 
-## Gap
+## Gap and Repair
 
-The locked Phase 2 plan required stable required checks and a Codex recursive-mode bridge, but live promotion QA exposed two gaps:
+1. Pi was terminated without an assertion under workspace-wide fan-out. It now runs after ordinary workspaces.
+2. Runtime-host config updates returned transient null state under monorepo contention. The full host suite now runs alone before Pi.
+3. Endpoint rehydration asserted before asynchronous bootstrap completed. The test now waits for bounded bootstrap completion and uses a deterministic delayed probe.
+4. Ordinary agents lacked unconditional workflow instructions. Root `/AGENTS.md` now defines the `dev -> stage -> main` policy, channel ports, and canonical `role-model` spelling.
 
-1. The workspace-wide recursive test fan-out twice terminated `@try-works/pi-role-model` without a failing assertion while its resource-heavy rebuilt-runtime proof was running. The identical package passed all 95 tests in isolation and passed on rerun, so repeated blind reruns would leave a flaky required check.
-2. `/.codex/AGENTS.md` instructed recursive-mode sessions, but the repository had no root `/AGENTS.md` with unconditional branch, promotion, runtime-channel, and naming rules for ordinary agent work.
-3. After Pi isolation made the rest of the host suite run to completion on Linux, `endpoint-rehydration.test.ts` exposed a separate one-second bootstrap polling assumption. Under CI load the assertion ran while bootstrap still reported `running`, before the remote health probe could mark the endpoint offline.
+## Evidence
 
-## Evidence and compensation
-
-- Run `29668088068`, job `88142085912`, and run `29668594990`, job `88143425962`, both ended with `packages/pi-role-model test: Failed` and no failed Vitest assertion.
-- The isolated command `corepack pnpm --filter @try-works/pi-role-model test` passed 15 files and 95 tests, including the 15-second rebuilt-runtime alias proof.
-- `/package.json` now excludes `@try-works/pi-role-model` from the concurrent recursive fan-out and runs it once afterward.
-- `/scripts/ci-workflow.test.mjs` contains the RED/GREEN contract for that sequencing.
-- `/role-model-router/apps/runtime-host-bridge/test/endpoint-rehydration.test.ts` now makes the slow-probe case deterministic, waits up to the test's bounded deadline, and asserts bootstrap completion before endpoint state.
-- `/AGENTS.md` makes the delivery workflow visible without requiring recursive-mode discovery.
-
-## Implications
-
-The promotion PR must wait for this compensation to merge into `dev`, then rerun from the updated `dev` head. Phase 5 must record the resulting green promotion and post-merge stage candidate before it can lock. Phase 8 must refresh the two GitHub workflow memory patterns and the memory router.
+- RED/GREEN workflow contracts protect the sequence.
+- Full local test passed: 41 ordinary projects, runtime host 63/570, Pi 15/95.
+- Corrective PRs #64 and #66 passed all required checks and merged to `dev`.
+- Promotion PRs #67 and #68 and final main run `29670332721` passed.
 
 ## TODO
 
-- [x] Record both assertion-free CI failures.
-- [x] Add a failing sequencing contract.
-- [x] Isolate and verify the Pi package test.
-- [x] Add root agent instructions.
-- [x] Reproduce and repair the endpoint-rehydration bootstrap timing race.
-- [ ] Merge the compensation through a reviewed pull request into `dev`.
-- [ ] Re-run and complete the promotion QA.
+- [x] Record the assertion-free failures and bootstrap race
+- [x] Add failing contracts and deterministic regressions
+- [x] Serialize resource-heavy proof suites
+- [x] Add root agent instructions
+- [x] Re-run the complete promotion chain
 
 ## Traceability
 
-- `R1`: root agent guidance reinforces ordinary work targeting `dev`.
-- `R2`: the compensation preserves stable protected checks and promotion enforcement.
-- `R3`: the required `build-test` lane becomes deterministic under bounded sequencing.
-- `R4`: root guidance preserves the approved main-only docs exception.
-- `R5`-`R9`: unchanged; later Phase 5 evidence must verify their already implemented behavior and migration state.
+- R1-R2: root agent policy and required promotion guard are live.
+- R3: required build/test is now stable and diagnosable.
+- R4-R9: final Phase 5 evidence confirms the unchanged implementation and live migration.
 
 ## Coverage Gate
 
-Coverage: FAIL — promotion and final GitHub topology evidence remain incomplete.
+Coverage: PASS
 
 ## Approval Gate
 
-Approval: FAIL — this addendum remains active until the compensation and promotions are verified.
+Approval: PASS
+
+## Audit Verdict
+
+Audit: PASS

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/05-manual-qa.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/05-manual-qa.receipt.json
@@ -1,0 +1,17 @@
+{
+  "artifact": "05-manual-qa.md",
+  "artifact_hash": "ff3158dd76ec9beee98e2712a91ebac03b477de8ec0015c1a0ba563acf0b7fcd",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\05-manual-qa.md",
+  "locked_at": "2026-07-19T02:41:01Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+    "02-to-be-plan.md": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e",
+    "03-implementation-summary.md": "7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a",
+    "03.5-code-review.md": "d435c5e595c7a2d782e695bda19c43db7c6d9b581d3acde0a5ad8fca1994199a",
+    "04-test-summary.md": "59854e58833dc3fba804275c2e9d295678ad5cfa8cd43f283a96bb60e3c37c1a"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "a8e387c88ce24c403bb3ce2c5072a74df91d8b34c48f7a9099413abd4bbe0ea4"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/06-decisions-update.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/06-decisions-update.receipt.json
@@ -1,0 +1,18 @@
+{
+  "artifact": "06-decisions-update.md",
+  "artifact_hash": "f0f36cf4bcad69b7f56871d1f6e7fe6cda491038e03ba2d6c21d8c59e34e3d28",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\06-decisions-update.md",
+  "locked_at": "2026-07-19T02:43:51Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+    "02-to-be-plan.md": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e",
+    "03-implementation-summary.md": "7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a",
+    "03.5-code-review.md": "d435c5e595c7a2d782e695bda19c43db7c6d9b581d3acde0a5ad8fca1994199a",
+    "04-test-summary.md": "59854e58833dc3fba804275c2e9d295678ad5cfa8cd43f283a96bb60e3c37c1a",
+    "05-manual-qa.md": "ff3158dd76ec9beee98e2712a91ebac03b477de8ec0015c1a0ba563acf0b7fcd"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "4d425835241a8d3b322ae58f548edc09a715ef9409083607551d8aeba6248b20"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/07-state-update.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/07-state-update.receipt.json
@@ -1,0 +1,19 @@
+{
+  "artifact": "07-state-update.md",
+  "artifact_hash": "7b41e0f25a83a79d8a4b7323dcf0ae46a272c584afa128d8872bfe6b1b1a8d04",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\07-state-update.md",
+  "locked_at": "2026-07-19T02:44:07Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+    "02-to-be-plan.md": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e",
+    "03-implementation-summary.md": "7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a",
+    "03.5-code-review.md": "d435c5e595c7a2d782e695bda19c43db7c6d9b581d3acde0a5ad8fca1994199a",
+    "04-test-summary.md": "59854e58833dc3fba804275c2e9d295678ad5cfa8cd43f283a96bb60e3c37c1a",
+    "05-manual-qa.md": "ff3158dd76ec9beee98e2712a91ebac03b477de8ec0015c1a0ba563acf0b7fcd",
+    "06-decisions-update.md": "f0f36cf4bcad69b7f56871d1f6e7fe6cda491038e03ba2d6c21d8c59e34e3d28"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "5c3acc429e0764f2fdb533c3e432ed511261eda4748adb7d2f16d393eb3fde94"
+}

--- a/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/08-memory-impact.receipt.json
+++ b/.recursive/run/78-dev-stage-main-cicd-runtime-channels/locks/08-memory-impact.receipt.json
@@ -1,0 +1,20 @@
+{
+  "artifact": "08-memory-impact.md",
+  "artifact_hash": "119e079fefc48e8c122b9a359e120870c62e4140d2e296ebc951fbcd8b901d64",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\78-dev-stage-main-cicd-runtime-channels\\.recursive\\run\\78-dev-stage-main-cicd-runtime-channels\\08-memory-impact.md",
+  "locked_at": "2026-07-19T02:44:23Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "210fbbc8fab34c3623b916cc9e97bb50df0a4a176ab91bb0f83645d28b1d92a2",
+    "00-worktree.md": "4a49884cc67eb147c8c9f973ce55f5cc26a324be88c473c9507da57d7dd40b56",
+    "01-as-is.md": "b51f958be58c4a9bc574e2ce354e48a640d102e31a5438476cb30142b7ea6df5",
+    "02-to-be-plan.md": "d71ba14ab9f2d3cb710f7328f389197ac85de3c63e70413e567110d8df69298e",
+    "03-implementation-summary.md": "7661c171a4d6b06a5df229e2994b035dd3999052cbd4fcdddfbc90718b44e33a",
+    "03.5-code-review.md": "d435c5e595c7a2d782e695bda19c43db7c6d9b581d3acde0a5ad8fca1994199a",
+    "04-test-summary.md": "59854e58833dc3fba804275c2e9d295678ad5cfa8cd43f283a96bb60e3c37c1a",
+    "05-manual-qa.md": "ff3158dd76ec9beee98e2712a91ebac03b477de8ec0015c1a0ba563acf0b7fcd",
+    "06-decisions-update.md": "f0f36cf4bcad69b7f56871d1f6e7fe6cda491038e03ba2d6c21d8c59e34e3d28",
+    "07-state-update.md": "7b41e0f25a83a79d8a4b7323dcf0ae46a272c584afa128d8872bfe6b1b1a8d04"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "eb511ac9f73736047a9777ee1e30197033da1f2cbfc92a846d66ee9814f1835b"
+}


### PR DESCRIPTION
## Summary

Promote the completed Run 78 closeout documentation and durable workflow memory from `dev` to `stage`.

## Scope

- recursive-mode decisions, state, phase receipts, and manual QA evidence
- durable `dev -> stage -> main` Git and CI/release workflow memory
- no application, runtime, dependency, or docs-site behavior changes

## Real behavior proof

- Setup: GitHub protected-branch promotion workflow
- Verification: required CI checks on this PR and the already-green post-merge `dev` CI run 29670782951
- Not tested: no additional runtime QA is required because this promotion changes documentation and recursive-mode records only