### PR TITLE
fix: make release payload builds reproducible

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -276,6 +276,10 @@ export function resolveGoCommand(): string {
   return process.env.GO_BINARY ?? "go";
 }
 
+export function createLlamaSwapBuildArgs(outputPath: string): string[] {
+  return ["build", "-trimpath", "-buildvcs=false", "-ldflags=-buildid=", "-o", outputPath, "."];
+}
+
 function resolvePackagedRuntimeName(name: string): string {
   return process.platform === "win32" ? `${name}.exe` : name;
 }
@@ -310,7 +314,7 @@ async function buildLlamaSwapAsset(target: BuildTarget): Promise<void> {
   );
   await ensureGoCache();
   await mkdir(path.dirname(outputPath), { recursive: true });
-  runOrThrow(goCommand, ["build", "-o", outputPath, "."], vendorRoot, {
+  runOrThrow(goCommand, createLlamaSwapBuildArgs(outputPath), vendorRoot, {
     GO111MODULE: "on",
     GOWORK: "off",
     GOPATH: goCacheRoot,

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -150,6 +150,24 @@ describe("runtime-host-bridge executable packaging", () => {
     ).toBe("C:\\tools\\go\\bin\\go.exe");
   });
 
+  test("builds bundled llama-swap without commit or checkout-path identity", () => {
+    expect(
+      (
+        packageSea as {
+          createLlamaSwapBuildArgs: (outputPath: string) => readonly string[];
+        }
+      ).createLlamaSwapBuildArgs("/tmp/llama-swap"),
+    ).toEqual([
+      "build",
+      "-trimpath",
+      "-buildvcs=false",
+      "-ldflags=-buildid=",
+      "-o",
+      "/tmp/llama-swap",
+      ".",
+    ]);
+  });
+
   test("declares a runtime export condition for the built runtime dependency graph", async () => {
     const runtimeGraph = await collectRuntimeDependencyGraph();
 


### PR DESCRIPTION
## Summary

Make the bundled `llama-swap` asset reproducible across promotion merge commits so the production core-payload gate can compare `stage` and `main` successfully.

## Root cause

Go's default build metadata stamped the current VCS revision into `llama-swap`. `stage` and `main` intentionally have different merge-commit SHAs even when their Git trees are identical, so every platform produced different SEA bytes and the `v0.0.7` publication gate correctly failed.

## Fix

- build `llama-swap` with `-trimpath`
- disable VCS stamping with `-buildvcs=false`
- clear the Go build ID with `-ldflags=-buildid=`
- contract-test the deterministic build arguments

## Real behavior proof

- Setup: Windows, Node 24, pnpm 10.6.5
- RED: executable packaging test failed because deterministic Go arguments were absent
- GREEN: `vitest run test/executable.test.ts` — 20/20 passed
- Additional: runtime-host TypeScript build, workflow contract tests, Biome, and `git diff --check` passed
- Not tested locally: cross-platform SEA byte equality; the stage candidate matrix and tag release gate are the authoritative cross-platform proof