### PR TITLE
fix: promote reproducible release payloads to stage

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -276,6 +276,10 @@ export function resolveGoCommand(): string {
   return process.env.GO_BINARY ?? "go";
 }
 
+export function createLlamaSwapBuildArgs(outputPath: string): string[] {
+  return ["build", "-trimpath", "-buildvcs=false", "-ldflags=-buildid=", "-o", outputPath, "."];
+}
+
 function resolvePackagedRuntimeName(name: string): string {
   return process.platform === "win32" ? `${name}.exe` : name;
 }
@@ -310,7 +314,7 @@ async function buildLlamaSwapAsset(target: BuildTarget): Promise<void> {
   );
   await ensureGoCache();
   await mkdir(path.dirname(outputPath), { recursive: true });
-  runOrThrow(goCommand, ["build", "-o", outputPath, "."], vendorRoot, {
+  runOrThrow(goCommand, createLlamaSwapBuildArgs(outputPath), vendorRoot, {
     GO111MODULE: "on",
     GOWORK: "off",
     GOPATH: goCacheRoot,

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -150,6 +150,24 @@ describe("runtime-host-bridge executable packaging", () => {
     ).toBe("C:\\tools\\go\\bin\\go.exe");
   });
 
+  test("builds bundled llama-swap without commit or checkout-path identity", () => {
+    expect(
+      (
+        packageSea as {
+          createLlamaSwapBuildArgs: (outputPath: string) => readonly string[];
+        }
+      ).createLlamaSwapBuildArgs("/tmp/llama-swap"),
+    ).toEqual([
+      "build",
+      "-trimpath",
+      "-buildvcs=false",
+      "-ldflags=-buildid=",
+      "-o",
+      "/tmp/llama-swap",
+      ".",
+    ]);
+  });
+
   test("declares a runtime export condition for the built runtime dependency graph", async () => {
     const runtimeGraph = await collectRuntimeDependencyGraph();
 


### PR DESCRIPTION
## Summary

Promote the release-payload reproducibility fix from `dev` to `stage`.

## Verification

- PR #72 passed all required CI checks
- deterministic Go build arguments are covered by a RED/GREEN packaging test
- the post-merge stage binary matrix is the authoritative cross-platform candidate proof before production

## Real behavior proof

No runtime behavior changes. This promotion is limited to deterministic packaging metadata and its contract test.