### PR TITLE
fix: promote reproducible release payloads to main

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -276,6 +276,10 @@ export function resolveGoCommand(): string {
   return process.env.GO_BINARY ?? "go";
 }
 
+export function createLlamaSwapBuildArgs(outputPath: string): string[] {
+  return ["build", "-trimpath", "-buildvcs=false", "-ldflags=-buildid=", "-o", outputPath, "."];
+}
+
 function resolvePackagedRuntimeName(name: string): string {
   return process.platform === "win32" ? `${name}.exe` : name;
 }
@@ -310,7 +314,7 @@ async function buildLlamaSwapAsset(target: BuildTarget): Promise<void> {
   );
   await ensureGoCache();
   await mkdir(path.dirname(outputPath), { recursive: true });
-  runOrThrow(goCommand, ["build", "-o", outputPath, "."], vendorRoot, {
+  runOrThrow(goCommand, createLlamaSwapBuildArgs(outputPath), vendorRoot, {
     GO111MODULE: "on",
     GOWORK: "off",
     GOPATH: goCacheRoot,

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -150,6 +150,24 @@ describe("runtime-host-bridge executable packaging", () => {
     ).toBe("C:\\tools\\go\\bin\\go.exe");
   });
 
+  test("builds bundled llama-swap without commit or checkout-path identity", () => {
+    expect(
+      (
+        packageSea as {
+          createLlamaSwapBuildArgs: (outputPath: string) => readonly string[];
+        }
+      ).createLlamaSwapBuildArgs("/tmp/llama-swap"),
+    ).toEqual([
+      "build",
+      "-trimpath",
+      "-buildvcs=false",
+      "-ldflags=-buildid=",
+      "-o",
+      "/tmp/llama-swap",
+      ".",
+    ]);
+  });
+
   test("declares a runtime export condition for the built runtime dependency graph", async () => {
     const runtimeGraph = await collectRuntimeDependencyGraph();
 


### PR DESCRIPTION
## Summary

Promote the verified reproducible release-payload fix from `stage` to `main`.

## Verification

- PR #72 and PR #73 passed all protected checks
- stage candidate run 29679217837 built, attested, and uploaded all four platform artifacts successfully
- no runtime behavior changes; this only removes VCS/build-path identity from the embedded Go asset

## Real behavior proof

The stage matrix completed on Linux, Windows, Intel macOS, and Apple Silicon. The corrected `v0.0.7` tag build will independently compare each production payload against these exact stage candidates before publication.