### PR TITLE
Harden Track B follow-ups after Run 00 merge

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,8 @@
       "**/testdata/catalog/models-dev-snapshot.json",
       "**/vendor/**",
       "**/target/**",
-      "**/runtime-output/**"
+      "**/runtime-output/**",
+      "**/test-results/**"
     ]
   },
   "overrides": [

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
@@ -20,6 +20,8 @@ describe("ExtensionsRoute", () => {
       "Opt out & clear queue",
       "Active pack",
       "Download & validate latest",
+      "Validate & apply",
+      "Applied",
       "secondaryButtonClassName",
     ])
       expect(routeSource).toContain(token);

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
@@ -315,6 +315,7 @@ export function ExtensionsRouteView() {
                   className={`${secondaryButtonClassName} mt-3`}
                   disabled={
                     busy ||
+                    row.status === "applied" ||
                     !row.signatureValid ||
                     !row.policyAllowed ||
                     contribution?.recommendationAccess !== "preview_and_apply"
@@ -322,7 +323,7 @@ export function ExtensionsRouteView() {
                   onClick={() => void apply(row.id)}
                   type="button"
                 >
-                  Validate & apply
+                  {row.status === "applied" ? "Applied" : "Validate & apply"}
                 </button>
               </article>
             ))}

--- a/role-model-router/apps/runtime-ui/e2e/track-b-operations.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/track-b-operations.spec.ts
@@ -30,5 +30,8 @@ test("operates disclosure, opt-out, retention, recommendations, and failure isol
   await page.getByRole("button", { name: "Dry-run" }).click();
   await expect(page.getByText(/0 affected · 0 B ·/)).toBeVisible();
   await page.getByRole("button", { name: "Execute plan" }).click();
-  await expect(page.getByText(/running · 0%|completed · 100%/)).toBeVisible();
+  // QA bridge has no private operations sidecar; execute must fail closed (same boundary as unit tests).
+  await expect(
+    page.getByText(/private operations endpoint is required for retention execution/i),
+  ).toBeVisible();
 });

--- a/role-model-router/apps/runtime-ui/playwright.config.ts
+++ b/role-model-router/apps/runtime-ui/playwright.config.ts
@@ -19,6 +19,8 @@ const browserChannel = process.platform === "win32" && !process.env.CI ? "msedge
 export default defineConfig({
   testDir: "./e2e",
   timeout: 60_000,
+  // Live packaged runtime shares mutable contribution/recommendation state across specs.
+  workers: liveBaseUrl ? 1 : undefined,
   expect: {
     timeout: 10_000,
   },


### PR DESCRIPTION
## Summary
- Disable the recommendation Apply button and show **Applied** once status is applied
- Assert QA retention Execute fails closed without a private operations sidecar
- Force Playwright `workers: 1` for live packaged-runtime runs
- Ignore Playwright `test-results` in Biome

## Test plan
- [ ] CI green on `dev`-targeted PR
- [ ] Extensions UI: applied recommendation shows disabled Applied button
- [ ] `track-b-operations` Playwright: Execute shows private-ops fail-closed message