### PR TITLE
run 79: extension mutate/dismiss + readiness fixes

### DIFF
--- a/.recursive/run/79-extension-control-and-recommendations-qa/00-requirements.md
+++ b/.recursive/run/79-extension-control-and-recommendations-qa/00-requirements.md
@@ -1,0 +1,216 @@
+Run: `/.recursive/run/79-extension-control-and-recommendations-qa/`
+Phase: `00 Requirements`
+Status: `LOCKED`
+LockedAt: `2026-07-24T07:28:21Z`
+LockHash: `921c3135c451cce43b9cf3068f63b31c2864ed8320fd1f3eb60a66e21640fbe4`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- User-approved next-run proposal (2026-07-24): public extension enable/disable mutation API + Extensions UI wiring + live recommendations apply/dismiss QA; KW `productionActivation` remains hard-off
+- Public run numbering: highest existing public run `78-dev-stage-main-cicd-runtime-channels` → this run id is `79`
+- `D:/DEV/role-model-internal/.recursive/STATE.md`
+- `D:/DEV/role-model-internal/.recursive/DECISIONS.md`
+- `D:/DEV/role-model-internal/.recursive/memory/MEMORY.md`
+- `D:/DEV/role-model-internal/.recursive/memory/domains/direct-track-b.md`
+- Closed proposal corpus authorities for host mutation and recommendations:
+  - `.../proposals/crowdsourced-evals/docs/guidance/02_extension_ui_manifest_host.md`
+  - `.../proposals/crowdsourced-evals/docs/guidance/15_crowdsourced_learning_client.md`
+  - `.../proposals/crowdsourced-evals/docs/guidance/16_crowdsourced_evidence_recommendations.md`
+  - `.../proposals/crowdsourced-evals/docs/guidance/17_server_return_artifacts_client_usage.md`
+  - `.../proposals/crowdsourced-evals/docs/guidance/product-defaults.json`
+  - `.../proposals/crowdsourced-evals/docs/guidance/product-state-transitions.json`
+  - `.../proposals/crowdsourced-evals/docs/guidance/server-return-contracts.schema.json`
+- Predecessor run OOS / limitations: `00-direct-track-b-v1-1-implementation` (no public enable/disable mutation API; recommendations apply/dismiss against live service pending; KW productionActivation locked off)
+Outputs:
+- `/.recursive/run/79-extension-control-and-recommendations-qa/00-requirements.md`
+Scope note: Defines the requirements for unlocking first-party extension enable/disable (mode) control in the public runtime, wiring the Extensions UI to that authority, closing live signed-recommendation apply/dismiss verification against bound cloud, and proving the result on a rebuilt packaged runtime under strict TDD. Does not unlock Knowledge Worker production activation.
+
+## TODO
+
+- [x] Elicit requirements from user/context and post-v1.1 proposal
+- [x] Align run id with public repo highest run (`78` → `79`)
+- [x] Define requirement identifiers (`R1`–`R7`)
+- [x] Write observable acceptance criteria for each requirement
+- [x] Require strict TDD and rebuilt packaged-runtime verification
+- [x] Document out of scope items (`OOS1`–`OOS8`)
+- [x] List constraints and assumptions
+- [x] User approves this draft (2026-07-24)
+- [x] Create run folders in public + private worktrees via `recursive-init`
+- [x] Replace scaffolded `00-requirements.md` with this approved content
+- [x] Complete Coverage Gate checklist after approval
+- [x] Complete Approval Gate checklist after approval
+
+## Background
+
+### Goal
+
+Operators using the public runtime can enable, disable, and set first-party extension modes through a real host/runtime API and the Extensions UI, and can complete the signed recommendations pull → verify → apply and dismiss/reject flow against a bound cloud track. All of that is proven with failing-first tests and against a freshly rebuilt packaged runtime—not only against source-level unit tests.
+
+### Problem
+
+Run `00-direct-track-b-v1-1-implementation` shipped the Direct Track B substrate and a diagnostics-only Extensions UI. Documented limitations remain:
+
+1. No public first-party extension enable/disable mutation API (UI reports host lifecycle only).
+2. Recommendations list/download/apply client paths exist, but live apply/dismiss against a bound recommendation service was never closed as release evidence; dismiss is not yet a first-class public API.
+3. Knowledge Worker / route-package production activation remains intentionally hard-off and must stay that way.
+
+### Scope
+
+- Public repository `try-works/role-model` and private repository `try-works/role-model-internal`.
+- Run id `79-extension-control-and-recommendations-qa` mirrored in both repos.
+- Implementation branches stay on `dev` until the user explicitly promotes to `stage` or `main`.
+- Current activity: requirements drafting only until this document is user-approved and the run is initialized.
+
+## Requirements
+
+### `R1` Public first-party extension enable/disable (mode) mutation API
+
+Description:
+Expose a first-party, audited public host/runtime HTTP API that mutates per-extension enablement and `enabledMode` for installed first-party extensions. The API is the sole public mutation authority for this surface; the UI must not invent a parallel state store. Behavior follows product-state independent axes and Guidance 02 dependency rules (hard/mode deps block; soft deps degrade).
+
+Acceptance criteria:
+- Public runtime exposes documented mutation endpoints (or equivalent typed host operations) for per-extension enable, disable, and mode change over `enabledMode` values `disabled | shadow | advisory | bounded | active`.
+- Successful mutations persist across runtime restart for the active channel/scope and are visible on subsequent `GET /api/role-model/extensions` (or successor list API).
+- Mutations emit durable audit/receipt evidence (who/what/when/mode/result) retrievable from runtime state or evidence logs recorded by the run.
+- Hard or mode-required dependency failures refuse the mutation with a fail-closed error; soft dependency gaps may leave the target degraded without falsely reporting healthy active.
+- Enabling an extension does not cascade `allowCloudUpload`, rich capture, `trainingUse`, or `externalRlExport` permissions.
+- Enabling `knowledge-worker` or `knowledge-store` does not set or imply `productionActivation` / production prompt injection.
+- Contract/unit tests cover happy path, unknown extension id, illegal mode, dependency block, and non-cascading axes.
+
+### `R2` Wire Extensions UI to the mutation authority
+
+Description:
+Replace the Extensions page “no public enable/disable mutation API / diagnostics only” posture with operator controls that call the `R1` APIs. Keep lifecycle/health diagnostics. Preserve the Knowledge Worker shadow-only boundary in copy and behavior.
+
+Acceptance criteria:
+- `/app/system/extensions` exposes enable/disable (and mode where applicable) controls for installed first-party extensions.
+- Controls call the public mutation API; UI state updates from the API response / refreshed list, not local-only toggles.
+- Dangerous mode changes that affect network, data, or routing influence require an explicit confirmation step before mutation.
+- Copy no longer claims the mutation API is absent for this release.
+- Copy and tests assert that enabling knowledge packages is not narrated as production prompt injection / `productionActivation`.
+- UI unit/component tests cover control presence, disabled states (busy, dependency blocked, managed lock if present), and the knowledge-boundary wording.
+
+### `R3` Recommendations apply and dismiss against bound cloud
+
+Description:
+Close the live recommendations operator loop: download/verify signed server-return recommendations, apply when policy allows, and dismiss/reject when the operator declines. Add any missing public dismiss/reject API. Prove the flow against a bound cloud track (dev required; stage allowed).
+
+Acceptance criteria:
+- Public API supports apply (existing) and dismiss/reject (new if absent) for a recommendation id, recording operator action and resulting status.
+- Apply remains blocked when signature invalid, local policy forbids apply, or `recommendationAccess` is not `preview_and_apply`.
+- Dismiss/reject does not apply the pack and leaves an auditable non-applied terminal or dismissed status.
+- Contribution opt-out alone does not revoke an already-imported compatible unexpired recommendation solely because upload stopped.
+- Live evidence on bound cloud `--track=dev` shows: publish/resolve or download → list → apply success path, and dismiss/reject path; evidence stored under the run evidence tree.
+- Optional stage track evidence may be recorded; production track harness remains refused.
+- Offline/unit tests cover apply success, policy block, signature failure, and dismiss/reject without requiring live cloud.
+
+### `R4` Keep Knowledge Worker production activation hard-off
+
+Description:
+This run must not unlock Knowledge Worker / route-package production activation. Shadow learning and enablement of the extension package remain distinct from production prompt injection.
+
+Acceptance criteria:
+- `KnowledgeWorker.productionActivation` remains `false` (or equivalent immutable guard).
+- Any activate / inject / production prompt-injection path still fails closed with an explicit error.
+- Regression tests (including the existing TB10 activation-guard style assertions) remain green.
+- Extensions UI and API docs/copy introduced in this run do not claim production activation is available.
+- System/product state after the run still lists KW production activation as out of scope / locked off in STATE/DECISIONS updates.
+
+### `R5` Strict TDD for all in-scope product changes
+
+Description:
+Phase 3 uses `TDD Mode: strict`. No production implementation for `R1`–`R4` lands without a failing test first, then minimum green, then refactor with suites still green.
+
+Acceptance criteria:
+- Every in-scope production code change cites RED evidence (failing test against predecessor behavior), GREEN evidence (passing after minimal implementation), and REFACTOR confirmation.
+- Unit and contract layers are mandatory for mutation API and recommendation dismiss/reject.
+- UI component/route tests are mandatory for Extensions controls and knowledge-boundary copy.
+- Integration or browser tests cover at least one enable→list round-trip and one recommendations apply or dismiss path.
+- Quarantined, skipped, or structurally green-only tests cannot satisfy a requirement gate.
+- Phase 3 artifact declares `TDD Mode: strict` and links RED/GREEN evidence paths under the run evidence tree.
+
+### `R6` Verify against a rebuilt packaged runtime
+
+Description:
+Acceptance is not complete until the changed public runtime is rebuilt into the packaged distribution used for live operator verification, and the private Track B runtime distribution is rebuilt when private packages or sidecar paths change. Live/browser verification must target the rebuilt artifacts, not an stale binary.
+
+Acceptance criteria:
+- Public rebuild command `pnpm runtime:package-sea` (and `pnpm runtime:validate-packaging` when packaging contracts change) succeeds from the public worktree after implementation.
+- Private rebuild command `pnpm build:run00-runtime` succeeds from the private worktree when private extension/sidecar distribution inputs change (or an explicit evidence note records why private distribution was unchanged).
+- Packaged public runtime (`role-model-dev` / channel-appropriate SEA) is started from the freshly built artifact for verification.
+- Browser/live verification for Extensions mutation controls and recommendations apply/dismiss runs against that rebuilt runtime (`RUNTIME_LIVE_BASE_URL` or equivalent), not against an older packaged binary.
+- Evidence records include: rebuild command, exit code, artifact path or hash, runtime start metadata, and test command results.
+- A stale binary (rebuild skipped while relevant sources changed) fails the verification gate.
+
+### `R7` Dual-repo paired delivery on `dev` with synced run id
+
+Description:
+Land public contract/host/UI changes and private pins/tests as a paired delivery on `dev`, using the same run id in both repositories. Do not auto-promote to `stage` or `main`.
+
+Acceptance criteria:
+- Run folder `/.recursive/run/79-extension-control-and-recommendations-qa/` exists in both public and private repos after init.
+- Public contract/host/UI changes merge (or are ready to merge) to public `dev` before private consumers pin that public revision when a pin is required.
+- Private implementation pins the public revision when cross-repo contracts change.
+- No promotion to `stage` or `main` is performed by this run unless the user explicitly authorizes it later.
+- Phase 6/7 update DECISIONS/STATE so the former “no mutation API” limitation is cleared and KW activation remains listed as OOS.
+
+## Out of Scope
+
+- `OOS1`: Knowledge Worker / route-package `productionActivation` or production prompt injection (requires a later dedicated policy/lifecycle run).
+- `OOS2`: Enabling rich capture, training-use, external RL export, or external archive by default.
+- `OOS3`: Lifting the live Cloudflare harness ban on `--track=production`.
+- `OOS4`: Building a full CD promotion pipeline beyond proving rebuilt-runtime verification for this run.
+- `OOS5`: Capacity/performance CI gating and production benchmarking campaigns.
+- `OOS6`: Track A residual code deletion / cleanup sweep.
+- `OOS7`: Third-party / untrusted extension marketplace or sandbox isolation beyond first-party trusted bundles.
+- `OOS8`: TB11 `predecessorReceipts` maxItems upstream schema fix (localized compensation remains as previously locked unless separately authorized).
+
+## Constraints
+
+- Machine authorities win for product axes and recommendation contracts: `product-defaults.json`, `product-state-transitions.json`, `server-return-contracts.schema.json`, destination-authorization contracts. Do not invent a UI-only enablement store.
+- Independent axes remain independent: installed ≠ enabled ≠ capture ≠ upload ≠ training-use ≠ contribution tier ≠ recommendation access.
+- Enabling an extension is never narrated or implemented as Knowledge Worker production activation.
+- Live cloud E2E remains opt-in and limited to `dev` and `stage`; default `pnpm test` / CI stay offline-only unless this run adds an explicitly scoped offline suite.
+- Work stays on `dev` until explicit user promotion.
+- Diff basis for the run is recorded in `00-worktree.md` and not silently substituted later.
+- Phase 3 `TDD Mode: strict` is mandatory (`R5`).
+- Verification of operator-facing behavior requires rebuilt packaged runtime evidence (`R6`).
+
+## Assumptions
+
+- Cloud stage/production resources already provisioned by predecessor addenda remain available; this run does not re-provision Cloudflare infrastructure as a primary goal.
+- Bound-cloud material/secrets for `--track=dev` are available to the operator/agent executing live verification (values stay out of git).
+- Public highest run remains `78` at init time; if a newer public run appears before init, renumber to `max+1` before creating folders.
+- Dismiss/reject semantics may map to a new `/api/role-model/recommendations/dismiss` (or equivalent) if no suitable endpoint exists today.
+
+## Coverage Gate
+
+- Effective inputs reviewed:
+  - User-approved proposal for extension control + recommendations QA
+  - Private STATE / DECISIONS / domain memory
+  - Guidance 02, 15–17 and product-state / server-return authorities
+  - Current public Extensions UI / runtime-api / host-bridge recommendation and extension list surfaces
+- Requirement coverage check:
+  - `R1`: mutation API
+  - `R2`: UI wiring
+  - `R3`: live recommendations apply/dismiss
+  - `R4`: KW activation remains off
+  - `R5`: strict TDD
+  - `R6`: rebuilt packaged runtime verification
+  - `R7`: dual-repo synced run id on `dev`
+- Out-of-scope confirmation:
+  - `OOS1`–`OOS8`: unchanged and explicit
+
+Coverage: PASS
+
+## Approval Gate
+
+- Objective readiness checks:
+  - User approved draft 2026-07-24
+  - Run id synced to public max+1 (79)
+  - TDD and rebuilt-runtime verification are first-class requirements
+  - Acceptance criteria are observable
+  - Paired worktrees created from clean origin/dev baselines
+- Remaining blockers:
+  - none for Phase 0 requirements lock
+
+Approval: PASS

--- a/.recursive/run/79-extension-control-and-recommendations-qa/00-worktree.md
+++ b/.recursive/run/79-extension-control-and-recommendations-qa/00-worktree.md
@@ -1,0 +1,95 @@
+Run: `/.recursive/run/79-extension-control-and-recommendations-qa/`
+Phase: `00 Worktree Isolation`
+Status: `LOCKED`
+LockedAt: `2026-07-24T07:29:11Z`
+LockHash: `e0ee8fdc809af826239532440af30b183f6aef5c24441dcabb89679910d17297`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/79-extension-control-and-recommendations-qa/00-requirements.md`
+- Paired private controller worktree at `D:/DEV/role-model-internal/.worktrees/79-extension-control-and-recommendations-qa`
+Outputs:
+- `/.recursive/run/79-extension-control-and-recommendations-qa/00-worktree.md`
+Scope note: Public paired implementation worktree for run 79, created from clean public `origin/dev`. Recursive phase control remains in the private controller worktree.
+
+## TODO
+
+- [x] Confirm the selected worktree location and isolation approach
+- [x] Confirm the base branch and worktree branch values
+- [x] Run setup and verify the clean test baseline
+- [x] Confirm the diff basis fields still match live git state
+- [x] Complete Coverage Gate checklist
+- [x] Complete Approval Gate checklist
+
+## Directory Selection
+
+- Repository root (parent): `D:/DEV/role-model`
+- Selected worktree location: `D:/DEV/role-model/.worktrees/79-extension-control-and-recommendations-qa`
+- Controller worktree: `D:/DEV/role-model-internal/.worktrees/79-extension-control-and-recommendations-qa`
+
+## Safety Verification
+
+- Public `.worktrees/` is gitignored (`git check-ignore -v .worktrees/79-extension-control-and-recommendations-qa` PASS)
+- Parent checkout remains on `dev`; run work uses the feature-branch worktree only
+
+## Worktree Creation
+
+- Creation command: `git worktree add -b recursive/79-extension-control-and-recommendations-qa .worktrees/79-extension-control-and-recommendations-qa origin/dev`
+- Starting commit: `b6e80d681f6bdf316e175b850016749e8f5e145c`
+- Branch: `recursive/79-extension-control-and-recommendations-qa`
+
+## Main Branch Protection
+
+- Base branch source of truth: `origin/dev` @ `b6e80d681f6bdf316e175b850016749e8f5e145c`
+- No implementation on parent `dev`/`main`; no auto-promotion to `stage`/`main`
+
+## Project Setup
+
+- Command: `corepack pnpm install`
+- Result: PASS (`PUBLIC_INSTALL_EXIT=0`), log `D:/TEMP/run79-public-pnpm-install.log`
+
+## Test Baseline Verification
+
+- Command: `corepack pnpm --filter @role-model-router/runtime-ui exec vitest run app/routes/extensions.test.tsx`
+- Result: PASS 2/2 (`PUBLIC_EXT_TEST_EXIT=0`), log `D:/TEMP/run79-public-baseline-extensions.log`
+
+## Worktree Context
+
+- Base branch: `origin/dev`
+- Worktree branch: `recursive/79-extension-control-and-recommendations-qa`
+- Base commit: `b6e80d681f6bdf316e175b850016749e8f5e145c`
+- Controller pointer: private worktree owns recursive phase locks and AS-IS/plan/implementation summaries
+
+## Diff Basis For Later Audits
+
+- Baseline type: `local commit`
+- Baseline reference: `b6e80d681f6bdf316e175b850016749e8f5e145c`
+- Comparison reference: `working-tree`
+- Normalized baseline: `b6e80d681f6bdf316e175b850016749e8f5e145c`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only b6e80d681f6bdf316e175b850016749e8f5e145c`
+- Base branch: `origin/dev`
+- Worktree branch: `recursive/79-extension-control-and-recommendations-qa`
+
+## Traceability
+
+- `R7` -> public paired worktree + synced run id 79 | Evidence: this artifact
+- Public `R1`/`R2`/`R3`/`R6` surfaces change here; private controller traces them from its run folder
+
+## Coverage Gate
+
+- Worktree location and branch context are recorded
+- Setup and clean baseline verification are recorded
+- Diff basis fields are executable against live git state
+
+Coverage: PASS
+
+## Approval Gate
+
+- Objective readiness checks:
+  - Public worktree created from clean `origin/dev`
+  - Diff basis executable
+  - Controller ownership documented
+- Remaining blockers:
+  - none for Phase 0 worktree lock
+
+Approval: PASS

--- a/.recursive/run/79-extension-control-and-recommendations-qa/01-as-is.md
+++ b/.recursive/run/79-extension-control-and-recommendations-qa/01-as-is.md
@@ -1,0 +1,89 @@
+Run: `/.recursive/run/79-extension-control-and-recommendations-qa/`
+Phase: `01 AS-IS`
+Status: `DRAFT`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- Private controller `01-as-is.md` (authoritative)
+Outputs:
+- `/.recursive/run/79-extension-control-and-recommendations-qa/01-as-is.md`
+Scope note: Public mirror pointer. Authoritative AS-IS lives in the private controller worktree.
+
+See: `D:/DEV/role-model-internal/.worktrees/79-extension-control-and-recommendations-qa/.recursive/run/79-extension-control-and-recommendations-qa/01-as-is.md`
+
+## TODO
+
+- [x] Point to private controller AS-IS
+
+## Reproduction Steps (Novice-Runnable)
+
+1. Follow the private controller `01-as-is.md` reproduction steps using this public worktree for public surfaces.
+
+## Current Behavior by Requirement
+
+- Deferred to private controller AS-IS (same run id).
+
+## Relevant Code Pointers
+
+- Public surfaces are inventoried in the private controller `01-as-is.md`.
+
+## Known Unknowns
+
+- none beyond private controller AS-IS
+
+## Evidence
+
+- Private controller Phase 1 artifact
+
+## Traceability
+
+- `R1`-`R7` -> private controller `01-as-is.md`
+
+## Coverage Gate
+
+Coverage: PASS
+
+## Approval Gate
+
+Approval: PASS
+
+## Audit Context
+
+Audit Execution Mode: self-audit
+Subagent Availability: unavailable
+Subagent Capability Probe: public mirror only; no independent audit
+Delegation Decision Basis: mirror pointer; audit owned by private controller artifact
+Audit Inputs Provided:
+- private controller `01-as-is.md`
+
+## Effective Inputs Re-read
+
+- private controller `01-as-is.md`
+
+## Earlier Phase Reconciliation
+
+- `00-requirements.md` / `00-worktree.md` locked in this public run folder
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `b6e80d681f6bdf316e175b850016749e8f5e145c`
+- Comparison reference: `working-tree`
+- Normalized baseline: `b6e80d681f6bdf316e175b850016749e8f5e145c`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only b6e80d681f6bdf316e175b850016749e8f5e145c`
+
+## Requirement Completion Status
+
+- `R1`-`R7` | Status: deferred to private controller AS-IS for detailed status
+
+## Gaps Found
+
+- none
+
+## Repair Work Performed
+
+- none
+
+## Audit
+
+Audit: PASS

--- a/.recursive/run/79-extension-control-and-recommendations-qa/locks/00-requirements.receipt.json
+++ b/.recursive/run/79-extension-control-and-recommendations-qa/locks/00-requirements.receipt.json
@@ -1,0 +1,9 @@
+{
+  "artifact": "00-requirements.md",
+  "artifact_hash": "921c3135c451cce43b9cf3068f63b31c2864ed8320fd1f3eb60a66e21640fbe4",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\79-extension-control-and-recommendations-qa\\.recursive\\run\\79-extension-control-and-recommendations-qa\\00-requirements.md",
+  "locked_at": "2026-07-24T07:28:21Z",
+  "prerequisite_hashes": {},
+  "previous_receipt_hash": null,
+  "receipt_hash": "80f52a5caa88f40ef7b27c9ada0e4aa70c458b41729c116ff8f00fea5a10bd4e"
+}

--- a/.recursive/run/79-extension-control-and-recommendations-qa/locks/00-worktree.receipt.json
+++ b/.recursive/run/79-extension-control-and-recommendations-qa/locks/00-worktree.receipt.json
@@ -1,0 +1,11 @@
+{
+  "artifact": "00-worktree.md",
+  "artifact_hash": "e0ee8fdc809af826239532440af30b183f6aef5c24441dcabb89679910d17297",
+  "artifact_path": "D:\\DEV\\role-model\\.worktrees\\79-extension-control-and-recommendations-qa\\.recursive\\run\\79-extension-control-and-recommendations-qa\\00-worktree.md",
+  "locked_at": "2026-07-24T07:29:11Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "921c3135c451cce43b9cf3068f63b31c2864ed8320fd1f3eb60a66e21640fbe4"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "a89cbb375d6162c35aa7cac1ae59017e6aaff00e0fb395161f0bc1723e5eca7c"
+}

--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -43,6 +43,7 @@ type CliBackend = Pick<
   | "listProviders"
   | "listModels"
   | "listExtensions"
+  | "mutateExtension"
   | "readStorageRetention"
   | "dryRunStorageRetention"
   | "updateStorageRetentionPolicy"
@@ -54,6 +55,7 @@ type CliBackend = Pick<
   | "listRecommendations"
   | "downloadRecommendations"
   | "applyRecommendation"
+  | "dismissRecommendation"
   | "readActivePack"
   | "listRoles"
   | "listAccounts"
@@ -296,6 +298,9 @@ export function createCliServerOptions(
     listExtensions: bindBackendMethod(
       "listExtensions",
     ) as StartBridgeServerOptions["listExtensions"],
+    mutateExtension: bindBackendMethod(
+      "mutateExtension",
+    ) as StartBridgeServerOptions["mutateExtension"],
     readStorageRetention: bindBackendMethod(
       "readStorageRetention",
     ) as StartBridgeServerOptions["readStorageRetention"],
@@ -329,6 +334,9 @@ export function createCliServerOptions(
     applyRecommendation: bindBackendMethod(
       "applyRecommendation",
     ) as StartBridgeServerOptions["applyRecommendation"],
+    dismissRecommendation: bindBackendMethod(
+      "dismissRecommendation",
+    ) as StartBridgeServerOptions["dismissRecommendation"],
     readActivePack: bindBackendMethod(
       "readActivePack",
     ) as StartBridgeServerOptions["readActivePack"],

--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -673,6 +673,9 @@ export async function main(): Promise<void> {
     ReturnType<typeof createPackagedProductionRuntime<RuntimeBridgeBackend>>
   > | null = null;
   let extensionRuntime: Awaited<ReturnType<typeof createProductionExtensionRuntime>> | null = null;
+  const extensionRuntimeRef: {
+    current: Awaited<ReturnType<typeof createProductionExtensionRuntime>> | null;
+  } = { current: null };
   const bootstrapState: CliBootstrapState = { status: "pending" };
   let shutdownPromise: Promise<void> | null = null;
   const shutdown = async (): Promise<void> => {
@@ -758,20 +761,20 @@ export async function main(): Promise<void> {
         unifiedRuntimeConfigPath: options.unifiedRuntimeConfigPath,
         ...(trackBOperationsEndpoint ? { trackBOperationsEndpoint } : {}),
         ...(trackBOperationsToken ? { trackBOperationsToken } : {}),
-        ...(extensionRuntime
-          ? {
-              trackBExtensionHealth: (() => {
-                const runtime = extensionRuntime;
-                return () => {
-                  const health = runtime.health();
-                  return {
-                    host: health.host as { readonly extensions?: readonly string[] },
-                    supervisor: health.supervisor,
-                  };
-                };
-              })(),
-            }
-          : {}),
+        trackBExtensionHealth: () => {
+          const runtime = extensionRuntimeRef.current;
+          if (!runtime) {
+            return {
+              host: { extensions: [] as const },
+              supervisor: {},
+            };
+          }
+          const health = runtime.health();
+          return {
+            host: health.host as { readonly extensions?: readonly string[] },
+            supervisor: health.supervisor,
+          };
+        },
       });
     if (trackBManifestText && trackBManifestPath) {
       const manifest = JSON.parse(trackBManifestText) as {
@@ -792,7 +795,10 @@ export async function main(): Promise<void> {
       }
       const distributionRoot = path.dirname(trackBManifestPath);
       const trackBStateRoot = path.join(options.runtimeStateRoot, options.scopeId, "track-b");
-      extensionRuntime = await createProductionExtensionRuntime({
+      // Start extension-host registration in parallel with sidecar/backend bring-up, but
+      // mark core APIs ready as soon as the packaged backend exists. Waiting on all
+      // packaged extensions previously kept /api/role-model/* at 503 runtime_initializing.
+      const extensionRuntimePromise = createProductionExtensionRuntime({
         stateRoot: path.join(trackBStateRoot, "extensions"),
         authorizationEpoch: 1,
         repoRoot: options.repoRoot,
@@ -827,15 +833,25 @@ export async function main(): Promise<void> {
           createBackend(trackBOperationsEndpoint, trackBOperationsToken),
       });
       backend = packagedRuntime.backend;
+      bootstrapState.status = "ready";
+      delete bootstrapState.message;
+      try {
+        extensionRuntime = await extensionRuntimePromise;
+        extensionRuntimeRef.current = extensionRuntime;
+      } catch (error) {
+        console.error("[role-model] extension host failed after core runtime was ready:", error);
+      }
     } else {
       backend = await createBackend();
+      bootstrapState.status = "ready";
+      delete bootstrapState.message;
     }
-    bootstrapState.status = "ready";
-    delete bootstrapState.message;
   } catch (error) {
-    bootstrapState.status = "failed";
-    bootstrapState.message =
-      error instanceof Error ? error.message : "runtime backend initialization failed";
+    if (bootstrapState.status !== "ready") {
+      bootstrapState.status = "failed";
+      bootstrapState.message =
+        error instanceof Error ? error.message : "runtime backend initialization failed";
+    }
     console.error("runtime backend initialization failed", error);
   }
 }

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -2595,6 +2595,7 @@ export interface StartBridgeServerOptions {
   readonly listProviders?: () => Promise<readonly unknown[]>;
   readonly listModels?: () => Promise<readonly unknown[]>;
   readonly listExtensions?: () => Promise<readonly unknown[]>;
+  readonly mutateExtension?: (body: Record<string, unknown>) => Promise<unknown>;
   readonly readStorageRetention?: () => Promise<unknown>;
   readonly dryRunStorageRetention?: () => Promise<unknown>;
   readonly updateStorageRetentionPolicy?: (body: Record<string, unknown>) => Promise<unknown>;
@@ -2606,6 +2607,7 @@ export interface StartBridgeServerOptions {
   readonly listRecommendations?: () => Promise<readonly unknown[]>;
   readonly downloadRecommendations?: () => Promise<readonly unknown[]>;
   readonly applyRecommendation?: (body: Record<string, unknown>) => Promise<unknown>;
+  readonly dismissRecommendation?: (body: Record<string, unknown>) => Promise<unknown>;
   readonly readActivePack?: () => Promise<unknown>;
   readonly listRoles?: () => Promise<readonly unknown[]>;
   readonly listAccounts?: () => Promise<readonly unknown[]>;
@@ -2793,6 +2795,7 @@ export interface RuntimeBridgeBackend {
   >;
   listModels(): Promise<readonly BridgeRuntimeModelRecord[]>;
   listExtensions(): Promise<readonly unknown[]>;
+  mutateExtension(body: Record<string, unknown>): Promise<unknown>;
   readStorageRetention(): Promise<unknown>;
   dryRunStorageRetention(): Promise<unknown>;
   updateStorageRetentionPolicy(body: Record<string, unknown>): Promise<unknown>;
@@ -2804,6 +2807,7 @@ export interface RuntimeBridgeBackend {
   listRecommendations(): Promise<readonly unknown[]>;
   downloadRecommendations(): Promise<readonly unknown[]>;
   applyRecommendation(body: Record<string, unknown>): Promise<unknown>;
+  dismissRecommendation(body: Record<string, unknown>): Promise<unknown>;
   readActivePack(): Promise<unknown>;
   listRoles(): Promise<
     readonly {
@@ -14060,6 +14064,11 @@ function createRequestHandler(options: StartBridgeServerOptions) {
             : options.updateContributionState,
         body: request.method !== "GET",
       },
+      "/api/role-model/extensions/mutate": {
+        method: "POST",
+        callback: options.mutateExtension,
+        body: true,
+      },
       "/api/role-model/recommendations": {
         method: "GET",
         callback: options.listRecommendations,
@@ -14073,6 +14082,11 @@ function createRequestHandler(options: StartBridgeServerOptions) {
       "/api/role-model/recommendations/apply": {
         method: "POST",
         callback: options.applyRecommendation,
+        body: true,
+      },
+      "/api/role-model/recommendations/dismiss": {
+        method: "POST",
+        callback: options.dismissRecommendation,
         body: true,
       },
       "/api/role-model/recommendations/active-pack": {
@@ -22460,33 +22474,71 @@ export async function createRuntimeBridgeBackend(
         const routingDependency = Boolean(
           row.routingDependency ?? priorHealth.routingDependency ?? false,
         );
+        // Unregistered catalog rows default enabled:false; host overlay still marks them
+        // ready unless an installed bridge row explicitly disables them.
+        const enabled = !(row.installed === true && row.enabled === false);
+        const enabledMode =
+          typeof row.enabledMode === "string" && row.enabledMode.length > 0
+            ? row.enabledMode
+            : enabled
+              ? "active"
+              : "disabled";
         const reason =
           typeof priorHealth.reason === "string" && priorHealth.reason.length > 0
             ? priorHealth.reason
-            : "hosted_extension_ready";
+            : enabled
+              ? "hosted_extension_ready"
+              : "operator_disabled";
         return {
           ...row,
           installed: true,
-          enabled: true,
-          lifecycle: "ready",
+          enabled,
+          enabledMode,
+          lifecycle: enabled ? "ready" : "stopped",
           health: {
             ...priorHealth,
-            available: true,
+            available: enabled,
             routingDependency,
             probe:
               typeof priorHealth.probe === "string" && priorHealth.probe.length > 0
                 ? priorHealth.probe
-                : "hosted_extension_ready",
+                : enabled
+                  ? "hosted_extension_ready"
+                  : "operator_disabled",
             summary:
               typeof priorHealth.summary === "string" && priorHealth.summary.length > 0
                 ? priorHealth.summary
-                : routingDependency
-                  ? "Hosted extension is ready and marked as a routing dependency."
-                  : "Hosted extension is ready; core routing continues if this worker degrades.",
+                : enabled
+                  ? routingDependency
+                    ? "Hosted extension is ready and marked as a routing dependency."
+                    : "Hosted extension is ready; core routing continues if this worker degrades."
+                  : "Extension disabled by operator; core routing continues independently.",
             reason,
           },
         };
       });
+    },
+    async mutateExtension(body: Record<string, unknown>): Promise<unknown> {
+      const contract = JSON.parse(
+        await readFile(
+          path.join(
+            options.repoRoot,
+            "packages",
+            "protocol-types",
+            "generated",
+            "product-contracts.json",
+          ),
+          "utf8",
+        ),
+      ) as { extensions?: readonly Record<string, unknown>[] };
+      return createTrackBOperations({
+        statePath: path.join(
+          options.runtimeStateRoot,
+          options.scopeId,
+          "track-b-production-bridge.json",
+        ),
+        catalog: contract.extensions ?? [],
+      }).mutateExtension(body);
     },
     async readStorageRetention(): Promise<unknown> {
       return createTrackBOperations({
@@ -22679,6 +22731,16 @@ export async function createRuntimeBridgeBackend(
         ),
         catalog: [],
       }).applyRecommendation(body);
+    },
+    async dismissRecommendation(body: Record<string, unknown>): Promise<unknown> {
+      return createTrackBOperations({
+        statePath: path.join(
+          options.runtimeStateRoot,
+          options.scopeId,
+          "track-b-production-bridge.json",
+        ),
+        catalog: [],
+      }).dismissRecommendation(body);
     },
     async readActivePack(): Promise<unknown> {
       return createTrackBOperations({

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -22483,12 +22483,29 @@ export async function createRuntimeBridgeBackend(
             : enabled
               ? "active"
               : "disabled";
-        const reason =
-          typeof priorHealth.reason === "string" && priorHealth.reason.length > 0
-            ? priorHealth.reason
-            : enabled
-              ? "hosted_extension_ready"
-              : "operator_disabled";
+        const reason = enabled
+          ? priorHealth.reason === "operator_disabled"
+            ? "hosted_extension_ready"
+            : typeof priorHealth.reason === "string" && priorHealth.reason.length > 0
+              ? priorHealth.reason
+              : "hosted_extension_ready"
+          : "operator_disabled";
+        const probe = enabled
+          ? priorHealth.probe === "operator_disabled"
+            ? "hosted_extension_ready"
+            : typeof priorHealth.probe === "string" && priorHealth.probe.length > 0
+              ? priorHealth.probe
+              : "hosted_extension_ready"
+          : "operator_disabled";
+        const summary = enabled
+          ? typeof priorHealth.summary === "string" &&
+            priorHealth.summary.length > 0 &&
+            !priorHealth.summary.includes("disabled by operator")
+            ? priorHealth.summary
+            : routingDependency
+              ? "Hosted extension is ready and marked as a routing dependency."
+              : "Hosted extension is ready; core routing continues if this worker degrades."
+          : "Extension disabled by operator; core routing continues independently.";
         return {
           ...row,
           installed: true,
@@ -22499,20 +22516,8 @@ export async function createRuntimeBridgeBackend(
             ...priorHealth,
             available: enabled,
             routingDependency,
-            probe:
-              typeof priorHealth.probe === "string" && priorHealth.probe.length > 0
-                ? priorHealth.probe
-                : enabled
-                  ? "hosted_extension_ready"
-                  : "operator_disabled",
-            summary:
-              typeof priorHealth.summary === "string" && priorHealth.summary.length > 0
-                ? priorHealth.summary
-                : enabled
-                  ? routingDependency
-                    ? "Hosted extension is ready and marked as a routing dependency."
-                    : "Hosted extension is ready; core routing continues if this worker degrades."
-                  : "Extension disabled by operator; core routing continues independently.",
+            probe,
+            summary,
             reason,
           },
         };

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -6,6 +6,7 @@ type LifecycleRecord = {
   readonly id: string;
   readonly lifecycle: "ready" | "degraded" | "stopped";
   readonly enabled: boolean;
+  readonly enabledMode?: ExtensionMode;
   readonly channel: string;
   readonly scope: string;
   readonly authorizationEpoch: number;
@@ -15,6 +16,27 @@ type LifecycleRecord = {
     readonly reason?: string;
   };
 };
+type ExtensionMode = "disabled" | "shadow" | "advisory" | "bounded" | "active";
+type ExtensionMutationReceipt = {
+  readonly id: string;
+  readonly at: string;
+  readonly who: string;
+  readonly extensionId: string;
+  readonly action: "enable" | "disable" | "set_mode";
+  readonly mode: ExtensionMode;
+  readonly result: "applied";
+};
+const EXTENSION_MODES = new Set<ExtensionMode>([
+  "disabled",
+  "shadow",
+  "advisory",
+  "bounded",
+  "active",
+]);
+const asExtensionMode = (value: unknown, fallback: ExtensionMode = "active"): ExtensionMode =>
+  typeof value === "string" && EXTENSION_MODES.has(value as ExtensionMode)
+    ? (value as ExtensionMode)
+    : fallback;
 type StorageRecord = {
   readonly id: string;
   readonly category: string;
@@ -56,6 +78,7 @@ type BridgeState = {
   readonly contribution?: ContributionState;
   readonly recommendations?: readonly RecommendationRecord[];
   readonly recommendationRevision?: number;
+  readonly extensionMutationReceipts?: readonly ExtensionMutationReceipt[];
   readonly activePack?: {
     readonly id: string;
     readonly version: string;
@@ -95,7 +118,7 @@ type ContributionState = {
 type RecommendationRecord = {
   readonly id: string;
   readonly version: string;
-  readonly status: "downloaded" | "validated" | "applied" | "rejected";
+  readonly status: "downloaded" | "validated" | "applied" | "rejected" | "dismissed";
   readonly signatureValid: boolean;
   readonly policyAllowed: boolean;
   readonly provenance: string;
@@ -141,6 +164,7 @@ const EMPTY_STATE: BridgeState = {
   contribution: EMPTY_CONTRIBUTION,
   recommendations: [],
   recommendationRevision: 0,
+  extensionMutationReceipts: [],
   activePack: null,
 };
 const validate = (value: BridgeState): BridgeState => {
@@ -235,6 +259,7 @@ export async function seedTrackBExtensionBridgeState(options: {
       id,
       lifecycle: "ready",
       enabled: true,
+      enabledMode: "active",
       channel,
       scope,
       authorizationEpoch,
@@ -456,11 +481,17 @@ export function createTrackBOperations({
         const id = String(entry.id ?? "");
         const actual = byId.get(id);
         return actual
-          ? { ...entry, ...actual, installed: true }
+          ? {
+              ...entry,
+              ...actual,
+              installed: true,
+              enabledMode: actual.enabledMode ?? (actual.enabled ? "active" : "disabled"),
+            }
           : {
               ...entry,
               installed: false,
               enabled: false,
+              enabledMode: "disabled",
               lifecycle: "unavailable",
               channel: "production",
               scope: "global",
@@ -472,6 +503,206 @@ export function createTrackBOperations({
               },
             };
       });
+    },
+    async mutateExtension(input: Record<string, unknown>): Promise<unknown> {
+      const id = String(input.id ?? "");
+      const action = String(input.action ?? "");
+      if (!id) throw new Error("extension id is required");
+      if (!["enable", "disable", "set_mode"].includes(action))
+        throw new Error("extension mutation action must be enable, disable, or set_mode");
+      let state = await readState(statePath);
+      const catalogEntry = catalog.find((entry) => String(entry.id ?? "") === id);
+      let index = state.extensions.findIndex((row) => row.id === id);
+      if (!catalogEntry) throw new Error(`extension not found: ${id}`);
+      if (index < 0) {
+        const seeded: LifecycleRecord = {
+          id,
+          lifecycle: "stopped",
+          enabled: false,
+          enabledMode: "disabled",
+          channel: String(catalogEntry.channel ?? "production"),
+          scope: String(catalogEntry.scope ?? "global"),
+          authorizationEpoch: Number(catalogEntry.authorizationEpoch ?? 0) || 0,
+          health: {
+            available: false,
+            routingDependency: Boolean(catalogEntry.routingDependency),
+            reason: "operator_unregistered_pending_mutation",
+          },
+        };
+        state = {
+          ...state,
+          extensions: [...state.extensions, seeded],
+        };
+        index = state.extensions.length - 1;
+      }
+      const current = state.extensions[index]!;
+      let enabled = current.enabled;
+      let enabledMode = asExtensionMode(current.enabledMode, current.enabled ? "active" : "disabled");
+      if (action === "disable") {
+        enabled = false;
+        enabledMode = "disabled";
+      } else if (action === "enable" || action === "set_mode") {
+        const requested = asExtensionMode(
+          input.mode,
+          action === "enable" ? "active" : enabledMode,
+        );
+        if (typeof input.mode === "string" && !EXTENSION_MODES.has(input.mode as ExtensionMode))
+          throw new Error(`illegal extension mode: ${String(input.mode)}`);
+        if (action === "set_mode" && input.mode == null)
+          throw new Error("mode is required for set_mode");
+        const dependsOn = Array.isArray(catalogEntry.dependsOn)
+          ? catalogEntry.dependsOn.map((value) => String(value))
+          : [];
+        const modeDependsOn = Array.isArray(catalogEntry.modeDependsOn)
+          ? catalogEntry.modeDependsOn
+          : [];
+        if (requested !== "disabled" && (dependsOn.length > 0 || modeDependsOn.length > 0)) {
+          const byId = new Map(state.extensions.map((row) => [row.id, row]));
+          const missingHard = dependsOn.filter((depId) => {
+            const dep = byId.get(depId);
+            return !dep || !dep.enabled || (dep.enabledMode ?? "disabled") === "disabled";
+          });
+          if (missingHard.length > 0)
+            throw new Error(
+              `extension dependency not enabled: ${missingHard.join(", ")} required by ${id}`,
+            );
+          const missingMode = modeDependsOn.flatMap((raw) => {
+            if (!raw || typeof raw !== "object") return ["invalid-mode-dependency"];
+            const depId = String((raw as { id?: unknown }).id ?? "");
+            const allowed = Array.isArray((raw as { modes?: unknown }).modes)
+              ? ((raw as { modes: unknown[] }).modes.map((value) => String(value)) as ExtensionMode[])
+              : (["active", "bounded", "advisory", "shadow"] as ExtensionMode[]);
+            const dep = byId.get(depId);
+            if (!dep || !dep.enabled || (dep.enabledMode ?? "disabled") === "disabled")
+              return [depId || "unknown"];
+            const mode = dep.enabledMode ?? "active";
+            if (!allowed.includes(mode)) return [`${depId}:${mode}`];
+            return [];
+          });
+          if (missingMode.length > 0)
+            throw new Error(
+              `extension mode dependency not satisfied: ${missingMode.join(", ")} required by ${id}`,
+            );
+        }
+        enabled = requested !== "disabled";
+        enabledMode = requested;
+      }
+      const lifecycle: LifecycleRecord["lifecycle"] = enabled
+        ? current.lifecycle === "stopped"
+          ? "ready"
+          : current.lifecycle
+        : "stopped";
+      const nextRow: LifecycleRecord = {
+        ...current,
+        enabled,
+        enabledMode,
+        lifecycle,
+        health: {
+          ...current.health,
+          available: enabled && (lifecycle === "ready" || current.health.available),
+          reason: enabled ? current.health.reason : "operator_disabled",
+        },
+      };
+      const extensions = state.extensions.map((row, rowIndex) =>
+        rowIndex === index ? nextRow : row,
+      );
+      // Fix health consistency for validate(): available must match lifecycle === ready
+      const normalized: LifecycleRecord[] = extensions.map((row) => {
+        if (!row.enabled) {
+          return {
+            ...row,
+            enabled: false,
+            enabledMode: "disabled" as const,
+            lifecycle: "stopped" as const,
+            health: {
+              ...row.health,
+              available: false,
+              reason: row.health.reason ?? "operator_disabled",
+            },
+          };
+        }
+        const nextLifecycle = row.lifecycle === "stopped" ? ("ready" as const) : row.lifecycle;
+        return {
+          ...row,
+          enabled: true,
+          enabledMode: row.enabledMode ?? "active",
+          lifecycle: nextLifecycle,
+          health: {
+            ...row.health,
+            available: nextLifecycle === "ready",
+            reason: row.health.reason ?? "operator_enabled",
+          },
+        };
+      });
+      const receipt: ExtensionMutationReceipt = {
+        id: `ext-mut-${createHash("sha256")
+          .update(JSON.stringify([id, action, enabledMode, state.revision + 1]))
+          .digest("hex")
+          .slice(0, 16)}`,
+        at: new Date().toISOString(),
+        who: "local-operator",
+        extensionId: id,
+        action: action as ExtensionMutationReceipt["action"],
+        mode: enabledMode,
+        result: "applied",
+      };
+      const receipts = [...(state.extensionMutationReceipts ?? []), receipt].slice(-100);
+      const next: BridgeState = {
+        ...state,
+        revision: state.revision + 1,
+        generatedAt: new Date().toISOString(),
+        extensions: normalized,
+        extensionMutationReceipts: receipts,
+      };
+      await writeState(statePath, validate(next));
+      const byId = new Map(normalized.map((row) => [row.id, row]));
+      const listed = catalog.map((entry) => {
+        const entryId = String(entry.id ?? "");
+        const actual = byId.get(entryId);
+        return actual
+          ? {
+              ...entry,
+              ...actual,
+              installed: true,
+              enabledMode: actual.enabledMode ?? (actual.enabled ? "active" : "disabled"),
+            }
+          : {
+              ...entry,
+              installed: false,
+              enabled: false,
+              enabledMode: "disabled",
+              lifecycle: "unavailable",
+              channel: "production",
+              scope: "global",
+              authorizationEpoch: 0,
+              health: {
+                available: false,
+                routingDependency: Boolean(entry.routingDependency),
+                reason: "not_registered_with_private_supervisor",
+              },
+            };
+      });
+      return { extensions: listed, receipts };
+    },
+    async dismissRecommendation(input: Record<string, unknown>): Promise<unknown> {
+      const state = await readState(statePath);
+      const id = String(input.id ?? "");
+      const rows = [...(state.recommendations ?? [])];
+      const index = rows.findIndex((row) => row.id === id);
+      if (index < 0) throw new Error("recommendation not found");
+      const current = rows[index]!;
+      if (current.status === "applied")
+        throw new Error("applied recommendation cannot be dismissed");
+      if (current.status === "dismissed")
+        return { recommendations: rows, activePack: state.activePack ?? null };
+      rows[index] = { ...current, status: "dismissed" };
+      await writeState(statePath, {
+        ...state,
+        revision: state.revision + 1,
+        generatedAt: new Date().toISOString(),
+        recommendations: rows,
+      });
+      return { recommendations: rows, activePack: state.activePack ?? null };
     },
     async readStorageRetention(): Promise<unknown> {
       const remote = await requestPrivate("storage-retention");
@@ -818,6 +1049,10 @@ export function createTrackBOperations({
       const index = rows.findIndex((row) => row.id === id);
       const row = rows[index];
       if (!row) throw new Error("recommendation not found");
+      if (row.status === "dismissed")
+        throw new Error("dismissed recommendation cannot be applied");
+      if (row.status === "rejected")
+        throw new Error("rejected recommendation cannot be applied");
       if (!row.signatureValid) throw new Error("recommendation signature validation failed");
       if (!row.policyAllowed) throw new Error("recommendation application blocked by local policy");
       if ((state.contribution ?? EMPTY_CONTRIBUTION).recommendationAccess !== "preview_and_apply")

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -535,17 +535,18 @@ export function createTrackBOperations({
         };
         index = state.extensions.length - 1;
       }
-      const current = state.extensions[index]!;
+      const current = state.extensions[index];
+      if (!current) throw new Error(`extension state missing for ${id}`);
       let enabled = current.enabled;
-      let enabledMode = asExtensionMode(current.enabledMode, current.enabled ? "active" : "disabled");
+      let enabledMode = asExtensionMode(
+        current.enabledMode,
+        current.enabled ? "active" : "disabled",
+      );
       if (action === "disable") {
         enabled = false;
         enabledMode = "disabled";
       } else if (action === "enable" || action === "set_mode") {
-        const requested = asExtensionMode(
-          input.mode,
-          action === "enable" ? "active" : enabledMode,
-        );
+        const requested = asExtensionMode(input.mode, action === "enable" ? "active" : enabledMode);
         if (typeof input.mode === "string" && !EXTENSION_MODES.has(input.mode as ExtensionMode))
           throw new Error(`illegal extension mode: ${String(input.mode)}`);
         if (action === "set_mode" && input.mode == null)
@@ -570,7 +571,9 @@ export function createTrackBOperations({
             if (!raw || typeof raw !== "object") return ["invalid-mode-dependency"];
             const depId = String((raw as { id?: unknown }).id ?? "");
             const allowed = Array.isArray((raw as { modes?: unknown }).modes)
-              ? ((raw as { modes: unknown[] }).modes.map((value) => String(value)) as ExtensionMode[])
+              ? ((raw as { modes: unknown[] }).modes.map((value) =>
+                  String(value),
+                ) as ExtensionMode[])
               : (["active", "bounded", "advisory", "shadow"] as ExtensionMode[]);
             const dep = byId.get(depId);
             if (!dep || !dep.enabled || (dep.enabledMode ?? "disabled") === "disabled")
@@ -600,7 +603,11 @@ export function createTrackBOperations({
         health: {
           ...current.health,
           available: enabled && (lifecycle === "ready" || current.health.available),
-          reason: enabled ? current.health.reason : "operator_disabled",
+          reason: enabled
+            ? current.health.reason === "operator_disabled"
+              ? "operator_enabled"
+              : (current.health.reason ?? "operator_enabled")
+            : "operator_disabled",
         },
       };
       const extensions = state.extensions.map((row, rowIndex) =>
@@ -630,7 +637,10 @@ export function createTrackBOperations({
           health: {
             ...row.health,
             available: nextLifecycle === "ready",
-            reason: row.health.reason ?? "operator_enabled",
+            reason:
+              row.health.reason === "operator_disabled"
+                ? "operator_enabled"
+                : (row.health.reason ?? "operator_enabled"),
           },
         };
       });
@@ -690,7 +700,8 @@ export function createTrackBOperations({
       const rows = [...(state.recommendations ?? [])];
       const index = rows.findIndex((row) => row.id === id);
       if (index < 0) throw new Error("recommendation not found");
-      const current = rows[index]!;
+      const current = rows[index];
+      if (!current) throw new Error("recommendation not found");
       if (current.status === "applied")
         throw new Error("applied recommendation cannot be dismissed");
       if (current.status === "dismissed")
@@ -1049,10 +1060,8 @@ export function createTrackBOperations({
       const index = rows.findIndex((row) => row.id === id);
       const row = rows[index];
       if (!row) throw new Error("recommendation not found");
-      if (row.status === "dismissed")
-        throw new Error("dismissed recommendation cannot be applied");
-      if (row.status === "rejected")
-        throw new Error("rejected recommendation cannot be applied");
+      if (row.status === "dismissed") throw new Error("dismissed recommendation cannot be applied");
+      if (row.status === "rejected") throw new Error("rejected recommendation cannot be applied");
       if (!row.signatureValid) throw new Error("recommendation signature validation failed");
       if (!row.policyAllowed) throw new Error("recommendation application blocked by local policy");
       if ((state.contribution ?? EMPTY_CONTRIBUTION).recommendationAccess !== "preview_and_apply")

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -33,6 +33,7 @@ export interface PackagedProductionBackendOptions {
 
 const trackBServerOperationNames = [
   "listExtensions",
+  "mutateExtension",
   "readStorageRetention",
   "dryRunStorageRetention",
   "updateStorageRetentionPolicy",
@@ -44,6 +45,7 @@ const trackBServerOperationNames = [
   "listRecommendations",
   "downloadRecommendations",
   "applyRecommendation",
+  "dismissRecommendation",
   "readActivePack",
 ] as const;
 

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -13,7 +13,10 @@ import { LegacySqliteMigration } from "../../../packages/sqlite-memory/src/legac
 
 import { applyRecommendationServiceLauncherConfig } from "../src/cli.js";
 import { createRuntimeBridgeBackend, startBridgeServer } from "../src/index.js";
-import { seedTrackBExtensionBridgeState } from "../src/track-b-operations.js";
+import {
+  createTrackBOperations,
+  seedTrackBExtensionBridgeState,
+} from "../src/track-b-operations.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..", "..");
 const fixtureRoot = path.join(import.meta.dirname, "fixtures");
@@ -957,5 +960,228 @@ describe("Track B operations APIs", () => {
     expect(process.env.ROLE_MODEL_RECOMMENDATION_CHANNEL).toBe("development");
     expect(process.env.ROLE_MODEL_RECOMMENDATION_VERIFICATION_KEY).toBe("public-spki-fixture");
     expect(process.env.ROLE_MODEL_RECOMMENDATION_SERVICE_TOKEN).toBe("service-token-fixture");
+  });
+
+  test("run79 mutateExtension upserts catalog rows absent from bridge state", async () => {
+    const root = path.join(os.tmpdir(), `track-b-mutate-upsert-${Date.now()}`);
+    roots.push(root);
+    await mkdir(root, { recursive: true });
+    const statePath = path.join(root, "bridge.json");
+    const ops = createTrackBOperations({
+      statePath,
+      catalog: [
+        {
+          id: "event-log",
+          packageClass: "canonical_extension",
+          dependsOn: [],
+          routingDependency: false,
+        },
+      ],
+    });
+    const enabled = (await ops.mutateExtension({
+      id: "event-log",
+      action: "enable",
+      mode: "shadow",
+    })) as {
+      extensions: readonly { id: string; enabled: boolean; enabledMode?: string }[];
+      receipts: readonly unknown[];
+    };
+    const row = enabled.extensions.find((entry) => entry.id === "event-log");
+    expect(row).toMatchObject({ enabled: true, enabledMode: "shadow" });
+    expect(enabled.receipts).toHaveLength(1);
+  });
+
+  test("run79 mutateExtension enables disables and sets mode with audit receipts", async () => {
+    const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run79-mutate-${Date.now()}`);
+    roots.push(runtimeStateRoot);
+    const statePath = path.join(runtimeStateRoot, "track-b-production-bridge.json");
+    const catalog = [
+      {
+        id: "event-log",
+        packageClass: "canonical_extension",
+        routingDependency: true,
+      },
+      {
+        id: "knowledge-worker",
+        packageClass: "canonical_extension",
+        routingDependency: false,
+        dependsOn: ["event-log"],
+        modeDependsOn: [{ id: "event-log", modes: ["active", "bounded"] }],
+      },
+    ];
+    await seedTrackBExtensionBridgeState({ statePath, catalog });
+    const ops = createTrackBOperations({ statePath, catalog });
+    const disabled = (await ops.mutateExtension({
+      id: "knowledge-worker",
+      action: "disable",
+    })) as {
+      extensions: readonly { id: string; enabled: boolean; enabledMode: string }[];
+      receipts: readonly { action: string; extensionId: string }[];
+    };
+    expect(disabled.extensions.find((row) => row.id === "knowledge-worker")).toMatchObject({
+      enabled: false,
+      enabledMode: "disabled",
+    });
+    expect(disabled.receipts.at(-1)).toMatchObject({
+      action: "disable",
+      extensionId: "knowledge-worker",
+      who: "local-operator",
+    });
+    await ops.mutateExtension({ id: "event-log", action: "disable" });
+    await expect(
+      ops.mutateExtension({ id: "knowledge-worker", action: "enable", mode: "active" }),
+    ).rejects.toThrow(/dependenc/i);
+    await ops.mutateExtension({ id: "event-log", action: "enable", mode: "shadow" });
+    await expect(
+      ops.mutateExtension({ id: "knowledge-worker", action: "enable", mode: "active" }),
+    ).rejects.toThrow(/mode dependency/i);
+    await ops.mutateExtension({ id: "event-log", action: "set_mode", mode: "active" });
+    const enabled = (await ops.mutateExtension({
+      id: "knowledge-worker",
+      action: "set_mode",
+      mode: "shadow",
+    })) as {
+      extensions: readonly { id: string; enabled: boolean; enabledMode: string }[];
+    };
+    expect(enabled.extensions.find((row) => row.id === "knowledge-worker")).toMatchObject({
+      enabled: true,
+      enabledMode: "shadow",
+    });
+    await expect(ops.mutateExtension({ id: "missing", action: "enable" })).rejects.toThrow(
+      /not found|unknown/i,
+    );
+    await expect(
+      ops.mutateExtension({ id: "event-log", action: "set_mode", mode: "nope" }),
+    ).rejects.toThrow(/mode|illegal|invalid/i);
+  });
+
+  test("run79 dismissRecommendation marks row dismissed without applying pack", async () => {
+    const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run79-dismiss-${Date.now()}`);
+    roots.push(runtimeStateRoot);
+    const statePath = path.join(runtimeStateRoot, "track-b-production-bridge.json");
+    await mkdir(runtimeStateRoot, { recursive: true });
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        schemaVersion: "role-model.track-b-production-bridge.v1",
+        protocolVersion: "1.0",
+        revision: 1,
+        generatedAt: new Date().toISOString(),
+        extensions: [],
+        storageServices: [],
+        retention: { managedPolicy: false, receipts: [], activeJob: null },
+        contribution: {
+          mode: "contributor",
+          contributionTier: "advanced",
+          recommendationTier: "advanced",
+          recommendationAccess: "preview_and_apply",
+          allowCloudUpload: true,
+          authorizationState: "active",
+          revocationEpoch: 0,
+          queuedCount: 0,
+          managed: false,
+        },
+        recommendations: [
+          {
+            id: "pack-dismiss",
+            version: "1",
+            status: "validated",
+            signatureValid: true,
+            policyAllowed: true,
+            provenance: "cloud:bundle-dismiss",
+          },
+        ],
+        recommendationRevision: 1,
+        activePack: null,
+      }),
+    );
+    const ops = createTrackBOperations({ statePath, catalog: [] });
+    const result = (await ops.dismissRecommendation({ id: "pack-dismiss" })) as {
+      recommendations: readonly { id: string; status: string }[];
+      activePack: unknown;
+    };
+    expect(result.recommendations.find((row) => row.id === "pack-dismiss")).toMatchObject({
+      status: "dismissed",
+    });
+    expect(result.activePack).toBeNull();
+    await expect(ops.applyRecommendation({ id: "pack-dismiss" })).rejects.toThrow(/dismissed/i);
+    await expect(ops.dismissRecommendation({ id: "missing" })).rejects.toThrow(/not found/i);
+  });
+
+  test("run79 HTTP exposes extensions mutate and recommendations dismiss routes", async () => {
+    const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run79-http-${Date.now()}`);
+    roots.push(runtimeStateRoot);
+    const statePath = path.join(runtimeStateRoot, "production", "track-b-production-bridge.json");
+    const contract = JSON.parse(
+      await readFile(
+        path.join(repoRoot, "packages", "protocol-types", "generated", "product-contracts.json"),
+        "utf8",
+      ),
+    ) as { extensions: readonly Record<string, unknown>[] };
+    await seedTrackBExtensionBridgeState({
+      statePath,
+      catalog: contract.extensions,
+    });
+    await mkdir(path.dirname(statePath), { recursive: true });
+    const existing = JSON.parse(await readFile(statePath, "utf8")) as {
+      recommendations?: unknown[];
+      [key: string]: unknown;
+    };
+    existing.recommendations = [
+      {
+        id: "pack-http-dismiss",
+        version: "1",
+        status: "validated",
+        signatureValid: true,
+        policyAllowed: true,
+        provenance: "cloud:http",
+      },
+    ];
+    await writeFile(statePath, `${JSON.stringify(existing, null, 2)}\n`);
+    const backend = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot,
+      runtimeStateRoot,
+      scopeId: "production",
+    });
+    const server = await startBridgeServer({
+      host: "127.0.0.1",
+      port: 0,
+      listExtensions: () => backend.listExtensions(),
+      mutateExtension: (body) => backend.mutateExtension(body),
+      listRecommendations: () => backend.listRecommendations(),
+      dismissRecommendation: (body) => backend.dismissRecommendation(body),
+      applyRecommendation: (body) => backend.applyRecommendation(body),
+    });
+    try {
+      const base = `http://127.0.0.1:${server.port}`;
+      const mutateResponse = await fetch(`${base}/api/role-model/extensions/mutate`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "artifact-store", action: "disable" }),
+      });
+      expect(mutateResponse.status).toBe(200);
+      const mutateBody = (await mutateResponse.json()) as {
+        extensions: readonly { id: string; enabled: boolean }[];
+      };
+      expect(mutateBody.extensions.find((row) => row.id === "artifact-store")?.enabled).toBe(
+        false,
+      );
+      const dismissResponse = await fetch(`${base}/api/role-model/recommendations/dismiss`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "pack-http-dismiss" }),
+      });
+      expect(dismissResponse.status).toBe(200);
+      const dismissBody = (await dismissResponse.json()) as {
+        recommendations: readonly { id: string; status: string }[];
+      };
+      expect(dismissBody.recommendations.find((row) => row.id === "pack-http-dismiss")?.status).toBe(
+        "dismissed",
+      );
+    } finally {
+      await server.close();
+      await backend.shutdown();
+    }
   });
 });

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -1027,6 +1027,13 @@ describe("Track B operations APIs", () => {
       extensionId: "knowledge-worker",
       who: "local-operator",
     });
+    const disabledRow = disabled.extensions.find((row) => row.id === "knowledge-worker") as {
+      health?: { reason?: string; available?: boolean };
+    };
+    expect(disabledRow.health).toMatchObject({
+      available: false,
+      reason: "operator_disabled",
+    });
     await ops.mutateExtension({ id: "event-log", action: "disable" });
     await expect(
       ops.mutateExtension({ id: "knowledge-worker", action: "enable", mode: "active" }),
@@ -1041,11 +1048,33 @@ describe("Track B operations APIs", () => {
       action: "set_mode",
       mode: "shadow",
     })) as {
-      extensions: readonly { id: string; enabled: boolean; enabledMode: string }[];
+      extensions: readonly {
+        id: string;
+        enabled: boolean;
+        enabledMode: string;
+        health?: { reason?: string; available?: boolean };
+      }[];
     };
     expect(enabled.extensions.find((row) => row.id === "knowledge-worker")).toMatchObject({
       enabled: true,
       enabledMode: "shadow",
+      health: {
+        available: true,
+        reason: "operator_enabled",
+      },
+    });
+    const reenabled = (await ops.mutateExtension({
+      id: "event-log",
+      action: "enable",
+      mode: "active",
+    })) as {
+      extensions: readonly {
+        id: string;
+        health?: { reason?: string; probe?: string; summary?: string };
+      }[];
+    };
+    expect(reenabled.extensions.find((row) => row.id === "event-log")?.health).toMatchObject({
+      reason: expect.not.stringMatching(/operator_disabled/),
     });
     await expect(ops.mutateExtension({ id: "missing", action: "enable" })).rejects.toThrow(
       /not found|unknown/i,
@@ -1164,9 +1193,7 @@ describe("Track B operations APIs", () => {
       const mutateBody = (await mutateResponse.json()) as {
         extensions: readonly { id: string; enabled: boolean }[];
       };
-      expect(mutateBody.extensions.find((row) => row.id === "artifact-store")?.enabled).toBe(
-        false,
-      );
+      expect(mutateBody.extensions.find((row) => row.id === "artifact-store")?.enabled).toBe(false);
       const dismissResponse = await fetch(`${base}/api/role-model/recommendations/dismiss`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1176,9 +1203,9 @@ describe("Track B operations APIs", () => {
       const dismissBody = (await dismissResponse.json()) as {
         recommendations: readonly { id: string; status: string }[];
       };
-      expect(dismissBody.recommendations.find((row) => row.id === "pack-http-dismiss")?.status).toBe(
-        "dismissed",
-      );
+      expect(
+        dismissBody.recommendations.find((row) => row.id === "pack-http-dismiss")?.status,
+      ).toBe("dismissed");
     } finally {
       await server.close();
       await backend.shutdown();

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -369,6 +369,7 @@ describe("production Track B composition", () => {
   test("exposes every Track B mutation and recommendation operation to the production server", () => {
     const names = [
       "listExtensions",
+      "mutateExtension",
       "readStorageRetention",
       "dryRunStorageRetention",
       "updateStorageRetentionPolicy",
@@ -380,6 +381,7 @@ describe("production Track B composition", () => {
       "listRecommendations",
       "downloadRecommendations",
       "applyRecommendation",
+      "dismissRecommendation",
       "readActivePack",
     ] as const;
     const backend = Object.fromEntries(names.map((name) => [name, async () => name]));

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.test.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.test.ts
@@ -2921,4 +2921,54 @@ describe("role assignment helpers", () => {
     });
     expect(requests[4]?.body).toEqual({ action: "opt_out" });
   });
+
+  test("run79 posts extension mutate and recommendation dismiss bodies", async () => {
+    const requests: Array<{ url: string; method: string; body: unknown }> = [];
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.pathname : input.url;
+      requests.push({
+        url,
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return jsonResponse({
+        extensions: [],
+        recommendations: [],
+        activePack: null,
+      });
+    });
+    await runtimeApiModule.mutateExtension(
+      { id: "event-log", action: "enable", mode: "shadow" },
+      fetcher,
+    );
+    await runtimeApiModule.mutateExtension({ id: "event-log", action: "disable" }, fetcher);
+    await runtimeApiModule.mutateExtension(
+      { id: "event-log", action: "set_mode", mode: "advisory" },
+      fetcher,
+    );
+    await runtimeApiModule.dismissRecommendation("pack-dismiss", fetcher);
+    expect(requests).toEqual([
+      {
+        url: "/api/role-model/extensions/mutate",
+        method: "POST",
+        body: { id: "event-log", action: "enable", mode: "shadow" },
+      },
+      {
+        url: "/api/role-model/extensions/mutate",
+        method: "POST",
+        body: { id: "event-log", action: "disable" },
+      },
+      {
+        url: "/api/role-model/extensions/mutate",
+        method: "POST",
+        body: { id: "event-log", action: "set_mode", mode: "advisory" },
+      },
+      {
+        url: "/api/role-model/recommendations/dismiss",
+        method: "POST",
+        body: { id: "pack-dismiss" },
+      },
+    ]);
+  });
 });

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
@@ -1224,9 +1224,34 @@ async function fetchJson<TValue>(
 }
 
 const RUNTIME_SUMMARY_RETRY_DELAYS_MS = [150, 300] as const;
+const RUNTIME_INITIALIZING_RETRY_DELAYS_MS = [200, 500, 1000, 2000] as const;
 
 async function sleep(delayMs: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function isRuntimeInitializingError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("runtime_initializing");
+}
+
+async function withRuntimeInitializingRetry<TValue>(
+  operation: () => Promise<TValue>,
+): Promise<TValue> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= RUNTIME_INITIALIZING_RETRY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await sleep(RUNTIME_INITIALIZING_RETRY_DELAYS_MS[attempt - 1]);
+    }
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isRuntimeInitializingError(error)) {
+        throw error;
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("Runtime API is still initializing.");
 }
 
 async function fetchRuntimeSummaryWithRetry(fetcher: RuntimeFetcher): Promise<RuntimeSummary> {
@@ -1315,13 +1340,17 @@ export async function fetchRuntimeDeviceAuthorizations(
 export async function fetchRuntimeEndpoints(
   fetcher: RuntimeFetcher = fetch,
 ): Promise<readonly RuntimeEndpoint[]> {
-  return fetchJson<RuntimeEndpoint[]>("/api/role-model/endpoints", fetcher);
+  return withRuntimeInitializingRetry(() =>
+    fetchJson<RuntimeEndpoint[]>("/api/role-model/endpoints", fetcher),
+  );
 }
 
 export async function fetchRuntimeRoles(
   fetcher: RuntimeFetcher = fetch,
 ): Promise<readonly RuntimeRoleDefinition[]> {
-  return fetchJson<RuntimeRoleDefinition[]>("/api/role-model/roles", fetcher);
+  return withRuntimeInitializingRetry(() =>
+    fetchJson<RuntimeRoleDefinition[]>("/api/role-model/roles", fetcher),
+  );
 }
 
 export async function fetchRuntimeRequests(

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
@@ -1354,6 +1354,7 @@ export interface RuntimeExtensionStatus {
     | "stopped";
   readonly installed: boolean;
   readonly enabled: boolean;
+  readonly enabledMode?: "disabled" | "shadow" | "advisory" | "bounded" | "active";
   readonly channel: string;
   readonly scope: string;
   readonly authorizationEpoch: number;
@@ -1375,6 +1376,27 @@ export async function fetchExtensions(
   fetcher: RuntimeFetcher = fetch,
 ): Promise<readonly RuntimeExtensionStatus[]> {
   return fetchJson<RuntimeExtensionStatus[]>("/api/role-model/extensions", fetcher);
+}
+
+export type RuntimeExtensionMode = "disabled" | "shadow" | "advisory" | "bounded" | "active";
+
+export async function mutateExtension(
+  input: {
+    readonly id: string;
+    readonly action: "enable" | "disable" | "set_mode";
+    readonly mode?: RuntimeExtensionMode;
+  },
+  fetcher: RuntimeFetcher = fetch,
+): Promise<{
+  readonly extensions: readonly RuntimeExtensionStatus[];
+  readonly extension?: RuntimeExtensionStatus;
+  readonly receipts?: readonly unknown[];
+}> {
+  return fetchJson("/api/role-model/extensions/mutate", fetcher, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
 }
 
 export interface RuntimeStorageRetentionSummary {
@@ -1562,6 +1584,19 @@ export async function applyRecommendation(
   readonly activePack: RuntimeActivePack;
 }> {
   return fetchJson("/api/role-model/recommendations/apply", fetcher, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id }),
+  });
+}
+export async function dismissRecommendation(
+  id: string,
+  fetcher: RuntimeFetcher = fetch,
+): Promise<{
+  readonly recommendations: readonly RuntimeRecommendation[];
+  readonly activePack: RuntimeActivePack | null;
+}> {
+  return fetchJson("/api/role-model/recommendations/dismiss", fetcher, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ id }),

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
@@ -34,7 +34,14 @@ describe("ExtensionsRoute", () => {
     expect(routeSource).toContain("LIFECYCLE_COPY");
     expect(routeSource).toContain("operatorBoundaryNote");
     expect(routeSource).toContain("production prompt injection");
-    expect(routeSource).toContain("enable/disable mutation API");
+    expect(routeSource).not.toContain("do not expose a public enable/disable mutation API");
+    expect(routeSource).toContain("mutateExtension");
+    expect(routeSource).toContain("dismissRecommendation");
+    expect(routeSource).toContain("Enable");
+    expect(routeSource).toContain("Disable");
+    expect(routeSource).toContain("Set mode");
+    expect(routeSource).toContain("Dismiss");
+    expect(routeSource).toContain("confirm(");
   });
   test("renders the existing design-system loading shell before operational state arrives", () => {
     const html = renderToStaticMarkup(<ExtensionsRouteView />);

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
@@ -37,11 +37,17 @@ describe("ExtensionsRoute", () => {
     expect(routeSource).not.toContain("do not expose a public enable/disable mutation API");
     expect(routeSource).toContain("mutateExtension");
     expect(routeSource).toContain("dismissRecommendation");
-    expect(routeSource).toContain("Enable");
-    expect(routeSource).toContain("Disable");
+    expect(routeSource).toContain("SelectField");
+    expect(routeSource).toContain("formatModeLabel");
     expect(routeSource).toContain("Set mode");
+    expect(routeSource).not.toMatch(/>\s*Enable\s*</);
+    expect(routeSource).not.toMatch(/>\s*Disable\s*</);
     expect(routeSource).toContain("Dismiss");
     expect(routeSource).toContain("confirm(");
+    expect(routeSource).toContain("isOperatorDisabled");
+    expect(routeSource).toContain("lifecyclePillTone");
+    expect(routeSource).toContain("Mode draft is");
+    expect(routeSource).toContain("applyMode");
   });
   test("renders the existing design-system loading shell before operational state arrives", () => {
     const html = renderToStaticMarkup(<ExtensionsRouteView />);

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
@@ -19,16 +19,26 @@ import {
 import {
   type RuntimeActivePack,
   type RuntimeContributionState,
+  type RuntimeExtensionMode,
   type RuntimeExtensionStatus,
   type RuntimeRecommendation,
   applyRecommendation,
+  dismissRecommendation,
   downloadRecommendations,
   fetchActivePack,
   fetchContributionState,
   fetchExtensions,
   fetchRecommendations,
+  mutateExtension,
   updateContributionState,
 } from "../lib/runtime-api";
+
+const EXTENSION_MODES: readonly RuntimeExtensionMode[] = [
+  "shadow",
+  "advisory",
+  "bounded",
+  "active",
+];
 
 const LIFECYCLE_COPY: Record<
   RuntimeExtensionStatus["lifecycle"] | "unavailable",
@@ -100,6 +110,9 @@ const healthSummary = (extension: RuntimeExtensionStatus): string => {
     : "Available; not a routing dependency.";
 };
 
+const requiresDangerousModeConfirm = (mode: RuntimeExtensionMode): boolean =>
+  mode === "active" || mode === "bounded";
+
 export function ExtensionsRouteView() {
   const [extensions, setExtensions] = useState<readonly RuntimeExtensionStatus[] | null>(null);
   const [contribution, setContribution] = useState<RuntimeContributionState | null>(null);
@@ -107,6 +120,7 @@ export function ExtensionsRouteView() {
   const [activePack, setActivePack] = useState<RuntimeActivePack | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [modeDraft, setModeDraft] = useState<Record<string, RuntimeExtensionMode>>({});
   const load = useCallback(async () => {
     try {
       const [extensionRows, contributionState, recommendationRows, pack] = await Promise.all([
@@ -163,11 +177,50 @@ export function ExtensionsRouteView() {
       setBusy(false);
     }
   };
+  const dismiss = async (id: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await dismissRecommendation(id);
+      setRecommendations(next.recommendations);
+      setActivePack(next.activePack);
+    } catch (value) {
+      setError(message(value));
+    } finally {
+      setBusy(false);
+    }
+  };
   const download = async () => {
     setBusy(true);
     setError(null);
     try {
       setRecommendations(await downloadRecommendations());
+    } catch (value) {
+      setError(message(value));
+    } finally {
+      setBusy(false);
+    }
+  };
+  const mutate = async (
+    id: string,
+    action: "enable" | "disable" | "set_mode",
+    mode?: RuntimeExtensionMode,
+  ) => {
+    if (
+      mode &&
+      requiresDangerousModeConfirm(mode) &&
+      typeof window !== "undefined" &&
+      !window.confirm(
+        `Apply mode "${mode}" to ${id}? This can change network, data, or routing exposure for the extension boundary.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await mutateExtension({ id, action, mode });
+      await load();
     } catch (value) {
       setError(message(value));
     } finally {
@@ -311,20 +364,31 @@ export function ExtensionsRouteView() {
                     ) : null}
                   </dl>
                 ) : null}
-                <button
-                  className={`${secondaryButtonClassName} mt-3`}
-                  disabled={
-                    busy ||
-                    row.status === "applied" ||
-                    !row.signatureValid ||
-                    !row.policyAllowed ||
-                    contribution?.recommendationAccess !== "preview_and_apply"
-                  }
-                  onClick={() => void apply(row.id)}
-                  type="button"
-                >
-                  {row.status === "applied" ? "Applied" : "Validate & apply"}
-                </button>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    className={secondaryButtonClassName}
+                    disabled={
+                      busy ||
+                      row.status === "applied" ||
+                      row.status === "dismissed" ||
+                      !row.signatureValid ||
+                      !row.policyAllowed ||
+                      contribution?.recommendationAccess !== "preview_and_apply"
+                    }
+                    onClick={() => void apply(row.id)}
+                    type="button"
+                  >
+                    {row.status === "applied" ? "Applied" : "Validate & apply"}
+                  </button>
+                  <button
+                    className={secondaryButtonClassName}
+                    disabled={busy || row.status === "applied" || row.status === "dismissed"}
+                    onClick={() => void dismiss(row.id)}
+                    type="button"
+                  >
+                    {row.status === "dismissed" ? "Dismissed" : "Dismiss"}
+                  </button>
+                </div>
               </article>
             ))}
           </div>
@@ -332,7 +396,7 @@ export function ExtensionsRouteView() {
       </SectionCard>
       <SectionCard
         title="Extension boundary"
-        description="Install, enablement, lifecycle, health, and contribution/recommendation policy are separate. Hosted first-party packages do not expose a public enable/disable mutation API in this release; lifecycle is reported from the host bridge."
+        description="Install, enablement, lifecycle, health, and contribution/recommendation policy are separate. Use Enable, Disable, and Set mode to mutate hosted packages through the public extension control API; Knowledge Worker productionActivation stays hard-off."
       >
         {extensions === null ? (
           <LoadingState label="Loading extension lifecycle…" />
@@ -355,6 +419,13 @@ export function ExtensionsRouteView() {
                 !extension.health.available ||
                 lifecycleKey === "unavailable" ||
                 extension.lifecycle === "stopped";
+              const draftMode =
+                modeDraft[extension.id] ??
+                (extension.enabledMode && extension.enabledMode !== "disabled"
+                  ? extension.enabledMode
+                  : "shadow");
+              const canEnable = true;
+              const canDisableOrMode = extension.installed || extension.enabled;
               return (
                 <article className={`${mutedPanelClassName} min-w-0 p-4 md:p-5`} key={extension.id}>
                   <div className="flex flex-wrap items-start justify-between gap-3">
@@ -389,6 +460,53 @@ export function ExtensionsRouteView() {
                       />
                     </div>
                   ) : null}
+                  <div className="mt-4 flex flex-wrap items-center gap-2">
+                    <label className={`${utilityLabelClassName} text-[var(--rm-muted)]`}>
+                      Mode
+                      <select
+                        aria-label={`Mode for ${extension.id}`}
+                        className={`ml-2 rounded border border-[var(--rm-border)] bg-[var(--rm-surface)] px-2 py-1 ${supportingTextClassName}`}
+                        disabled={busy || !canEnable}
+                        onChange={(event) =>
+                          setModeDraft((current) => ({
+                            ...current,
+                            [extension.id]: event.target.value as RuntimeExtensionMode,
+                          }))
+                        }
+                        value={draftMode}
+                      >
+                        {EXTENSION_MODES.map((mode) => (
+                          <option key={mode} value={mode}>
+                            {mode}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <button
+                      className={secondaryButtonClassName}
+                      disabled={busy || !canEnable || extension.enabled}
+                      onClick={() => void mutate(extension.id, "enable", draftMode)}
+                      type="button"
+                    >
+                      Enable
+                    </button>
+                    <button
+                      className={secondaryButtonClassName}
+                      disabled={busy || !canDisableOrMode || !extension.enabled}
+                      onClick={() => void mutate(extension.id, "disable")}
+                      type="button"
+                    >
+                      Disable
+                    </button>
+                    <button
+                      className={secondaryButtonClassName}
+                      disabled={busy || !canDisableOrMode || !extension.enabled}
+                      onClick={() => void mutate(extension.id, "set_mode", draftMode)}
+                      type="button"
+                    >
+                      Set mode
+                    </button>
+                  </div>
                   <dl className="mt-5 grid gap-x-4 gap-y-3 sm:grid-cols-2">
                     <Detail
                       label="Channel / scope"
@@ -397,6 +515,10 @@ export function ExtensionsRouteView() {
                     <Detail
                       label="Authorization epoch"
                       value={String(extension.authorizationEpoch)}
+                    />
+                    <Detail
+                      label="Enabled mode"
+                      value={extension.enabledMode ?? (extension.enabled ? "active" : "disabled")}
                     />
                     <Detail
                       label="Health"

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
@@ -6,6 +6,7 @@ import {
   FactCard,
   LoadingState,
   SectionCard,
+  SelectField,
   StatusPill,
 } from "../components/page-primitives";
 import {
@@ -34,11 +35,15 @@ import {
 } from "../lib/runtime-api";
 
 const EXTENSION_MODES: readonly RuntimeExtensionMode[] = [
+  "disabled",
   "shadow",
   "advisory",
   "bounded",
   "active",
 ];
+
+const formatModeLabel = (mode: RuntimeExtensionMode): string =>
+  `${mode.charAt(0).toUpperCase()}${mode.slice(1)}`;
 
 const LIFECYCLE_COPY: Record<
   RuntimeExtensionStatus["lifecycle"] | "unavailable",
@@ -113,12 +118,31 @@ const healthSummary = (extension: RuntimeExtensionStatus): string => {
 const requiresDangerousModeConfirm = (mode: RuntimeExtensionMode): boolean =>
   mode === "active" || mode === "bounded";
 
+const isOperatorDisabled = (extension: RuntimeExtensionStatus): boolean =>
+  !extension.enabled || extension.enabledMode === "disabled";
+
+const appliedMode = (extension: RuntimeExtensionStatus): RuntimeExtensionMode =>
+  !extension.enabled || !extension.enabledMode || extension.enabledMode === "disabled"
+    ? "disabled"
+    : extension.enabledMode;
+
+const lifecyclePillTone = (
+  lifecycle: string,
+  operatorDisabled: boolean,
+): "success" | "warning" | "error" | "neutral" => {
+  if (operatorDisabled && (lifecycle === "stopped" || lifecycle === "installed_disabled")) {
+    return "neutral";
+  }
+  return lifecycleTone(lifecycle);
+};
+
 export function ExtensionsRouteView() {
   const [extensions, setExtensions] = useState<readonly RuntimeExtensionStatus[] | null>(null);
   const [contribution, setContribution] = useState<RuntimeContributionState | null>(null);
   const [recommendations, setRecommendations] = useState<readonly RuntimeRecommendation[]>([]);
   const [activePack, setActivePack] = useState<RuntimeActivePack | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [modeDraft, setModeDraft] = useState<Record<string, RuntimeExtensionMode>>({});
   const load = useCallback(async () => {
@@ -201,13 +225,8 @@ export function ExtensionsRouteView() {
       setBusy(false);
     }
   };
-  const mutate = async (
-    id: string,
-    action: "enable" | "disable" | "set_mode",
-    mode?: RuntimeExtensionMode,
-  ) => {
+  const applyMode = async (id: string, mode: RuntimeExtensionMode) => {
     if (
-      mode &&
       requiresDangerousModeConfirm(mode) &&
       typeof window !== "undefined" &&
       !window.confirm(
@@ -218,8 +237,15 @@ export function ExtensionsRouteView() {
     }
     setBusy(true);
     setError(null);
+    setNotice(null);
     try {
-      await mutateExtension({ id, action, mode });
+      await mutateExtension({ id, action: "set_mode", mode });
+      setNotice(
+        mode === "disabled"
+          ? `Set ${id} to disabled. Core routing continues without this worker.`
+          : `Set ${id} mode to ${mode}.`,
+      );
+      setModeDraft((current) => ({ ...current, [id]: mode }));
       await load();
     } catch (value) {
       setError(message(value));
@@ -254,6 +280,13 @@ export function ExtensionsRouteView() {
         />
       </div>
       {error ? <ErrorState label={error} /> : null}
+      {notice ? (
+        <output
+          className={`${mutedPanelClassName} block border-[var(--rm-border-strong)] p-4 ${supportingTextClassName} text-[var(--rm-fg)]`}
+        >
+          {notice}
+        </output>
+      ) : null}
       <SectionCard
         title="Contribution, disclosure, and opt-out"
         description="Aggregate upload is independent from local recommendation use, training, external RL, and rich capture. Contribution policy is not extension enablement."
@@ -396,7 +429,7 @@ export function ExtensionsRouteView() {
       </SectionCard>
       <SectionCard
         title="Extension boundary"
-        description="Install, enablement, lifecycle, health, and contribution/recommendation policy are separate. Use Enable, Disable, and Set mode to mutate hosted packages through the public extension control API; Knowledge Worker productionActivation stays hard-off."
+        description="Install, enablement, lifecycle, health, and contribution/recommendation policy are separate. Choose a mode (including disabled) and click Set mode; Knowledge Worker productionActivation stays hard-off."
       >
         {extensions === null ? (
           <LoadingState label="Loading extension lifecycle…" />
@@ -414,18 +447,15 @@ export function ExtensionsRouteView() {
                     "Lifecycle reported by the host. Core routing continuity is independent of this worker unless marked as a routing dependency.",
                 } as const);
               const boundaryNote = operatorBoundaryNote(extension.id);
-              const degradedOrUnavailable =
-                extension.lifecycle === "degraded" ||
-                !extension.health.available ||
-                lifecycleKey === "unavailable" ||
-                extension.lifecycle === "stopped";
-              const draftMode =
-                modeDraft[extension.id] ??
-                (extension.enabledMode && extension.enabledMode !== "disabled"
-                  ? extension.enabledMode
-                  : "shadow");
-              const canEnable = true;
-              const canDisableOrMode = extension.installed || extension.enabled;
+              const operatorDisabled = isOperatorDisabled(extension);
+              const unexpectedWorkerIssue =
+                !operatorDisabled &&
+                (extension.lifecycle === "degraded" ||
+                  !extension.health.available ||
+                  lifecycleKey === "unavailable");
+              const currentMode = appliedMode(extension);
+              const draftMode = modeDraft[extension.id] ?? currentMode;
+              const modeDirty = draftMode !== currentMode;
               return (
                 <article className={`${mutedPanelClassName} min-w-0 p-4 md:p-5`} key={extension.id}>
                   <div className="flex flex-wrap items-start justify-between gap-3">
@@ -442,14 +472,22 @@ export function ExtensionsRouteView() {
                       <StatusPill tone={extension.enabled ? "success" : "neutral"}>
                         {extension.enabled ? "enabled" : "disabled"}
                       </StatusPill>
-                      <StatusPill tone={lifecycleTone(lifecycleKey)}>{lifecycle.label}</StatusPill>
+                      <StatusPill tone={lifecyclePillTone(lifecycleKey, operatorDisabled)}>
+                        {lifecycle.label}
+                      </StatusPill>
                     </div>
                   </div>
                   <p className={`mt-3 ${supportingTextClassName}`}>{lifecycle.routingMeaning}</p>
                   {boundaryNote ? (
                     <p className={`mt-2 ${supportingTextClassName}`}>{boundaryNote}</p>
                   ) : null}
-                  {degradedOrUnavailable ? (
+                  {operatorDisabled ? (
+                    <p className={`mt-3 ${supportingTextClassName}`}>
+                      {extension.health.summary?.trim() ||
+                        "Extension is disabled by the operator. Core routing continues independently."}
+                    </p>
+                  ) : null}
+                  {unexpectedWorkerIssue ? (
                     <div className="mt-3">
                       <ErrorState
                         label={
@@ -460,53 +498,44 @@ export function ExtensionsRouteView() {
                       />
                     </div>
                   ) : null}
-                  <div className="mt-4 flex flex-wrap items-center gap-2">
-                    <label className={`${utilityLabelClassName} text-[var(--rm-muted)]`}>
-                      Mode
-                      <select
-                        aria-label={`Mode for ${extension.id}`}
-                        className={`ml-2 rounded border border-[var(--rm-border)] bg-[var(--rm-surface)] px-2 py-1 ${supportingTextClassName}`}
-                        disabled={busy || !canEnable}
-                        onChange={(event) =>
+                  <div className="mt-4 flex flex-wrap items-end gap-3">
+                    <div className="min-w-[12rem] flex-1 sm:max-w-[16rem]">
+                      <SelectField
+                        className={busy ? "pointer-events-none opacity-60" : undefined}
+                        label="Mode"
+                        onChange={(value) => {
+                          if (busy) {
+                            return;
+                          }
                           setModeDraft((current) => ({
                             ...current,
-                            [extension.id]: event.target.value as RuntimeExtensionMode,
-                          }))
-                        }
+                            [extension.id]: value as RuntimeExtensionMode,
+                          }));
+                        }}
                         value={draftMode}
                       >
                         {EXTENSION_MODES.map((mode) => (
                           <option key={mode} value={mode}>
-                            {mode}
+                            {formatModeLabel(mode)}
                           </option>
                         ))}
-                      </select>
-                    </label>
+                      </SelectField>
+                    </div>
                     <button
-                      className={secondaryButtonClassName}
-                      disabled={busy || !canEnable || extension.enabled}
-                      onClick={() => void mutate(extension.id, "enable", draftMode)}
-                      type="button"
-                    >
-                      Enable
-                    </button>
-                    <button
-                      className={secondaryButtonClassName}
-                      disabled={busy || !canDisableOrMode || !extension.enabled}
-                      onClick={() => void mutate(extension.id, "disable")}
-                      type="button"
-                    >
-                      Disable
-                    </button>
-                    <button
-                      className={secondaryButtonClassName}
-                      disabled={busy || !canDisableOrMode || !extension.enabled}
-                      onClick={() => void mutate(extension.id, "set_mode", draftMode)}
+                      className={modeDirty ? primaryButtonClassName : secondaryButtonClassName}
+                      disabled={busy || !modeDirty}
+                      onClick={() => void applyMode(extension.id, draftMode)}
                       type="button"
                     >
                       Set mode
                     </button>
                   </div>
+                  {modeDirty ? (
+                    <p className={`mt-2 ${supportingTextClassName}`}>
+                      Mode draft is {draftMode}; applied mode is {currentMode}. Click Set mode to
+                      apply.
+                    </p>
+                  ) : null}
                   <dl className="mt-5 grid gap-x-4 gap-y-3 sm:grid-cols-2">
                     <Detail
                       label="Channel / scope"
@@ -518,14 +547,19 @@ export function ExtensionsRouteView() {
                     />
                     <Detail
                       label="Enabled mode"
-                      value={extension.enabledMode ?? (extension.enabled ? "active" : "disabled")}
+                      value={formatModeLabel(
+                        (extension.enabledMode ??
+                          (extension.enabled ? "active" : "disabled")) as RuntimeExtensionMode,
+                      )}
                     />
                     <Detail
                       label="Health"
                       value={
-                        extension.health.available
-                          ? `available · ${healthSummary(extension)}`
-                          : `unavailable · ${healthSummary(extension)}`
+                        operatorDisabled
+                          ? healthSummary(extension)
+                          : extension.health.available
+                            ? `available · ${healthSummary(extension)}`
+                            : `unavailable · ${healthSummary(extension)}`
                       }
                     />
                     <Detail

--- a/role-model-router/apps/runtime-ui/e2e/recursive-79-extension-control-and-recommendations-qa.sp4.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/recursive-79-extension-control-and-recommendations-qa.sp4.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("@recursive:79-extension-control-and-recommendations-qa @sp4", () => {
+  test("mutates extension enablement and can dismiss recommendations against live runtime", async ({
+    page,
+  }) => {
+    test.skip(!process.env.RUNTIME_LIVE_BASE_URL, "live packaged runtime URL required");
+
+    await page.goto("/app/system/extensions");
+    await expect(
+      page.getByRole("main").getByRole("heading", { name: "Extension boundary" }),
+    ).toBeVisible();
+
+    const disable = page.getByRole("button", { name: "Disable" }).first();
+    const enable = page.getByRole("button", { name: "Enable" }).first();
+    if (await disable.isEnabled()) {
+      const [mutateResponse] = await Promise.all([
+        page.waitForResponse(
+          (candidate) =>
+            candidate.url().includes("/api/role-model/extensions/mutate") &&
+            candidate.request().method() === "POST",
+        ),
+        disable.click(),
+      ]);
+      expect(mutateResponse.ok()).toBeTruthy();
+      await expect(page.getByText("disabled").first()).toBeVisible();
+      if (await enable.isEnabled()) {
+        page.once("dialog", (dialog) => void dialog.accept());
+        const [enableResponse] = await Promise.all([
+          page.waitForResponse(
+            (candidate) =>
+              candidate.url().includes("/api/role-model/extensions/mutate") &&
+              candidate.request().method() === "POST",
+          ),
+          enable.click(),
+        ]);
+        expect(enableResponse.ok()).toBeTruthy();
+      }
+    }
+
+    const dismiss = page.getByRole("button", { name: "Dismiss" }).first();
+    if (await dismiss.isVisible()) {
+      const [dismissResponse] = await Promise.all([
+        page.waitForResponse(
+          (candidate) =>
+            candidate.url().includes("/api/role-model/recommendations/dismiss") &&
+            candidate.request().method() === "POST",
+        ),
+        dismiss.click(),
+      ]);
+      expect(dismissResponse.ok()).toBeTruthy();
+      await expect(page.getByText("dismissed", { exact: true }).first()).toBeVisible();
+    } else {
+      // Offline packaged SEA may have no downloaded packs; mutate path above is the hard gate.
+      await expect(page.getByRole("button", { name: "Enable" }).first()).toBeVisible();
+    }
+  });
+});

--- a/role-model-router/apps/runtime-ui/e2e/track-b-operations.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/track-b-operations.spec.ts
@@ -21,6 +21,9 @@ test("operates disclosure, opt-out, retention, recommendations, and failure isol
   await expect(
     page.getByRole("main").getByRole("heading", { name: "Extension boundary" }),
   ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Enable" }).first()).toBeVisible();
+  await expect(page.getByRole("button", { name: "Disable" }).first()).toBeVisible();
+  await expect(page.getByRole("button", { name: "Set mode" }).first()).toBeVisible();
 
   await page.goto("/app/system/storage-retention");
   await expect(page.getByRole("heading", { name: "Retention policy editor" })).toBeVisible();


### PR DESCRIPTION
## Summary
- Add Extensions mutate/dismiss APIs and Extensions UI controls for Track B operators.
- Fix runtime readiness (`runtime_initializing`), clear stale `operator_disabled` health on enable, and polish Set mode / intentional-disable UX.

## Test plan
- [x] Local public `pnpm ci:check` PASS
- [ ] Smoke Extensions enable/disable/set_mode and recommendation dismiss on packaged Track B SEA
- [ ] Confirm PR targets `dev` only