### PR TITLE
run 80: signed recommendation lifecycle + Mode alignment

### DIFF
--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md
@@ -1,0 +1,446 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `00 Requirements`
+Status: `LOCKED`
+LockedAt: `2026-07-24T10:52:36Z`
+LockHash: `efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- User direction (2026-07-24): create and strengthen run 80 requirements — consistent, comprehensive, thorough, detailed, verifiable, future-proof, and extensible; strengthen TDD and rebuilt-runtime verification
+- Prior recommendation: live `--track=dev` signed recommendation download → validate → preview → apply and dismiss; KW `productionActivation` remains OOS
+- Public run numbering: highest prior public run `79-extension-control-and-recommendations-qa` → this run id is `80`
+- `D:/DEV/role-model-internal/.recursive/STATE.md`
+- `D:/DEV/role-model-internal/.recursive/DECISIONS.md`
+- `D:/DEV/role-model-internal/.recursive/memory/MEMORY.md`
+- `D:/DEV/role-model-internal/.recursive/memory/domains/direct-track-b.md`
+- Predecessor runs:
+  - `00-direct-track-b-v1-1-implementation` (TB00–TB11 + PCR local/provisioned signed-apply evidence)
+  - `79-extension-control-and-recommendations-qa` (mutate/dismiss APIs + Extensions UI; **live cloud signed-material apply/dismiss deferred**)
+- Proposal / machine authorities:
+  - `.../proposals/crowdsourced-evals/docs/guidance/16_crowdsourced_evidence_recommendations.md`
+  - `.../proposals/crowdsourced-evals/docs/guidance/17_server_return_packets_client_usage.md`
+  - `.../proposals/crowdsourced-evals/docs/guidance/19_cloudflare_server_aggregation_and_recommendation_engine.md`
+  - `.../proposals/crowdsourced-evals/docs/guidance/server-return-contracts.schema.json`
+  - `.../proposals/crowdsourced-evals/docs/guidance/product-defaults.json`
+  - `.../proposals/crowdsourced-evals/docs/guidance/product-state-transitions.json`
+  - `.../proposals/crowdsourced-evals/docs/phase-specs/v1.1/phases/tb08_cloud-ingestion-history-aggregation-and-recommendations.md`
+- Operator docs and harnesses: `docs/testing.md`, `docs/cloudflare-cloud-path.md`, `scripts/track-b/launch-packaged-runtime.mjs`, `scripts/track-b/local-cloud-runtime.mjs`, `pnpm test:cloud:e2e`
+- Current public surfaces (AS-IS anchors, not invent-new unless defective):
+  - `POST /api/role-model/recommendations/download`
+  - `POST /api/role-model/recommendations/apply`
+  - `POST /api/role-model/recommendations/dismiss`
+  - `GET /api/role-model/recommendations/active-pack`
+  - host-bridge env: `ROLE_MODEL_RECOMMENDATION_SERVICE_URL`, `ROLE_MODEL_RECOMMENDATION_VERIFICATION_KEY`, `ROLE_MODEL_RECOMMENDATION_CHANNEL`, optional material file bindings
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+Scope note: Defines the authoritative Phase 0 requirements for closing the deferred **live bound-cloud** signed recommendation lifecycle on Cloudflare `--track=dev`, under **strict TDD**, with acceptance proven on a **freshly rebuilt packaged runtime** plus offline/local-cloud regression harnesses that remain extensible. Does not unlock Knowledge Worker production activation. Does not auto-promote to `stage`/`main`.
+
+## TODO
+
+- [x] Elicit requirements from user/context and proposal authorities
+- [x] Align run id with public max+1 (`79` → `80`)
+- [x] Author comprehensive `R1`–`R12` with observable acceptance criteria
+- [x] Add fixed decisions, open unknowns, lifecycle vocabulary, and API/env binding tables
+- [x] Strengthen strict TDD matrix (`R8`) and rebuilt-runtime + multi-layer verification (`R9`–`R11`)
+- [x] Add extensibility / future-proofing and evidence layout contracts
+- [x] Document out of scope (`OOS1`–`OOS10`)
+- [x] Confirm Status remains `DRAFT` (never locked; no unlock required)
+- [x] Mirror requirements to public + private run folders
+- [x] Complete Coverage Gate checklist
+- [x] Complete Approval Gate checklist
+
+## Background
+
+### Goal
+
+An operator (or agent-operated QA) using a **freshly rebuilt** public packaged runtime, bound to authentic Cloudflare **`--track=dev`** recommendation trust material, can complete the signed recommendation trust loop end-to-end:
+
+1. material is available and channel-bound;
+2. download / resolve imports a signed server-return snapshot;
+3. validation fails closed on bad trust;
+4. preview/list shows validated rows;
+5. apply succeeds only when policy allows;
+6. dismiss terminates without apply;
+7. receipts and evidence are durable and secret-free;
+
+…with offline and local-cloud suites remaining green so future tracks/channels can reuse the same harness shape.
+
+### Problem
+
+- Run 79 closed public dismiss + local SEA mutate/dismiss, but **explicitly deferred** live cloud signed-material apply/dismiss against bound `--track=dev` when material was unavailable.
+- Run 00 PCR proved signed apply against **local/provisioned** recommendation services; that evidence is **historical** and does **not** satisfy this run’s live permanent-dev closeout against a post-79 rebuilt runtime.
+- Proposal TB08 / Guidance 16–17/19 / `server-return-contracts.schema.json` treat signed return bundles, channel partitioning, keyring checks, and policy-gated apply as the recommendation trust path. That live bound-cloud PASS remains open.
+
+### Scope
+
+| Axis | In scope |
+|---|---|
+| Repos | `try-works/role-model` (public) + `try-works/role-model-internal` (private) |
+| Run id | `80-signed-recommendation-cloud-lifecycle` (mirrored) |
+| Branch | `dev` only unless user later authorizes promotion |
+| Cloud track for PASS | `--track=dev` required; `--track=stage` optional additive; `--track=production` refused |
+| Client APIs | Prefer existing download / apply / dismiss / active-pack; add only minimum fixes |
+| Server | Prefer existing recommendation-service / history / ingest permanent-dev workers; seed/repair/publish as needed |
+| Verification | Strict TDD + offline/local-cloud regression + **rebuilt SEA** live verification |
+
+### Non-goals (summary)
+
+See **Out of Scope**. Notably: KW production activation, production-track live writes, stage/main auto-promotion, proposal-corpus status rewrite, Extensions UI redesign, full Cloudflare reprovision epic.
+
+### Success definition (run-level)
+
+The run may claim Phase 4/5 PASS for recommendation lifecycle only when **all** of the following are true:
+
+1. Every in-scope `R#` has machine-checkable `Requirement Completion Status` reaching `verified` (or an explicit addendum-bound residual that does **not** claim PASS for that `R#`).
+2. `R8` RED/GREEN evidence exists for every in-scope production code change.
+3. `R9` rebuilt packaged runtime evidence exists and live `R2`/`R3`/`R4` hops targeted that artifact.
+4. `R11` evidence binder under the run tree lists hosts, recommendation ids, channel, rebuild hashes/paths, and commands without secrets.
+5. Historical PCR/local SEA proofs are cited only as predecessors, never as substitutes for `R2`/`R3` live `--track=dev` PASS.
+
+## Fixed Decisions
+
+| ID | Decision |
+|---|---|
+| `FD1` | Live PASS track for this run is Cloudflare `--track=dev` (`runtimeChannel=development`, `recommendations-dev.role-model.dev` / current documented permanent-dev binding). |
+| `FD2` | Prefer existing public recommendation APIs; do not invent parallel unsigned convenience endpoints for green evidence. |
+| `FD3` | Phase 3 `TDD Mode: strict` is mandatory for all in-scope production code changes. |
+| `FD4` | Operator-facing live verification must run against a freshly rebuilt packaged public SEA (stale binary = FAIL). |
+| `FD5` | Knowledge Worker `productionActivation` remains hard-off; recommendation apply ≠ production prompt injection. |
+| `FD6` | Secrets/keys stay out of git; evidence cites hosts, ids, digests, and receipt paths only. |
+| `FD7` | Local PCR / local-cloud signed-apply history from run 00 is non-substituting for this run’s live `--track=dev` closeout. |
+| `FD8` | Contribution opt-out alone must not revoke eligible already-imported compatible unexpired recommendations (proposal Q-TB-08 / Guidance 16–17). |
+| `FD9` | Independent product axes remain independent: installed ≠ enabled ≠ upload ≠ training-use ≠ recommendation access. |
+| `FD10` | Work stays on `dev`; no auto-promotion to `stage`/`main`. |
+
+## Open Unknowns (must resolve before claiming `R1`/`R2`/`R3` PASS)
+
+| ID | Unknown | Resolution rule |
+|---|---|---|
+| `U1` | Whether permanent-dev recommendation workers already hold publishable signed heads or need seed/publish | Resolve in Phase 1/3 via probe; if missing, implement/seed under `R1` without full reprovision epic (`OOS8`) |
+| `U2` | Exact verification key / channel env values for agent-operated QA | Resolve via local secrets / operator vault; never commit; record only that binding existed |
+| `U3` | Whether UI preview is a distinct page control vs list-after-download | Prefer existing UI; if absent, API-level preview/list after download satisfies preview for PASS, with optional UI evidence |
+| `U4` | Whether stage additive evidence will be collected | Optional; cannot replace `dev` PASS |
+
+## Canonical lifecycle vocabulary
+
+Use these statuses/terms consistently in tests, receipts, UI copy, and evidence. Map to existing code enums where present; do not invent conflicting synonyms without documenting the mapping.
+
+| Term | Meaning |
+|---|---|
+| `material` | Signed server-return snapshot / recommendation bundle resolvable from the bound recommendation service |
+| `download` | Client pull that resolves + imports signed material into local recommendation state |
+| `validated` | Local row/bundle passed signature + channel/scope checks (`signatureValid: true` or equivalent) |
+| `preview` | Operator-visible inspected state prior to apply (list/detail after download; optional dedicated preview API/UI) |
+| `applied` | Recommendation pack activated locally (`activePack` set; status `applied`) |
+| `dismissed` | Terminal non-applied decline (`status: dismissed`); must not set `activePack` for that id |
+| `rejected` | Existing terminal non-applied status if present; treat as non-applicable like dismissed for apply |
+| `recommendationAccess` | Local axis: `disabled` \| `download_only` \| `preview_and_apply` |
+| `channel` / `runtimeChannel` | Trust partition (`development` for `--track=dev`) |
+
+Forbidden for PASS narration: claiming “live cloud signed closeout” from local-only material file injection **unless** that injection is explicitly labeled offline fixture evidence and separate live hops still PASS.
+
+## Public API / env binding inventory (preferred surface)
+
+| Surface | Role |
+|---|---|
+| `POST /api/role-model/recommendations/download` | Resolve/import signed material |
+| `POST /api/role-model/recommendations/apply` | Policy-gated apply by `{ id }` |
+| `POST /api/role-model/recommendations/dismiss` | Terminal dismiss by `{ id }` |
+| `GET /api/role-model/recommendations/active-pack` | Observe applied pack |
+| `GET /api/role-model/recommendations` (if present) / list via download result | Observe validated/dismissed/applied rows |
+| `ROLE_MODEL_RECOMMENDATION_SERVICE_URL` | Bound recommendation service base URL |
+| `ROLE_MODEL_RECOMMENDATION_VERIFICATION_KEY` | Trust verification key (secret) |
+| `ROLE_MODEL_RECOMMENDATION_CHANNEL` | Expected channel (must match `--track=dev` binding for live PASS) |
+| `ROLE_MODEL_RECOMMENDATION_MATERIAL_FILE` | Offline/local fixture only; cannot alone satisfy live `R2`/`R3` |
+| `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT` | SEA packaging input for Track B extensions when required |
+
+## Requirements
+
+### `R1` Bound-cloud signed recommendation material on `--track=dev`
+
+Description:
+Make authentic signed recommendation / server-return material available and discoverable for the permanent-dev Cloudflare track so live client flows are not blocked by “material unavailable.” Material must match channel/scope contracts for `development` / `recommendations-dev` (or the current documented `--track=dev` binding in `docs/cloudflare-cloud-path.md` / `docs/testing.md`).
+
+Acceptance criteria:
+- A reproducible, secret-free procedure exists to probe, seed, publish, or resolve signed recommendation material for `--track=dev` (script, doc section under run evidence, or private `scripts/track-b/` helper).
+- During verification, at least one recommendation id / snapshot is resolvable from the bound `dev` recommendation service (not solely from a local material file).
+- Published/resolved material binds the expected `runtimeChannel` / channel id for `dev`; production or stage material must not be accepted as `--track=dev` success evidence.
+- Procedure records: command(s), host(s), channel, snapshot/recommendation id(s), and result code — without private keys or tokens.
+- If workers are healthy but empty, seeding/publishing is in-scope; full multi-worker reprovision from scratch remains `OOS8`.
+- Extensibility: the procedure accepts a track/channel parameter so `--track=stage` can reuse it later without rewriting the contract.
+
+### `R2` Live signed download / validate / import
+
+Description:
+Close the live download path: the rebuilt packaged runtime, bound to `--track=dev` trust env, downloads/resolves signed material and imports validated recommendation rows.
+
+Acceptance criteria:
+- With `ROLE_MODEL_RECOMMENDATION_SERVICE_URL`, verification key, and channel bound for `dev`, `POST /api/role-model/recommendations/download` succeeds against live material from `R1`.
+- Successful download yields one or more local recommendation rows with validated signature state (`signatureValid: true` or equivalent) and non-applied status until apply.
+- Missing trust env fails closed with an explicit configuration error (does not silently use unsigned local defaults as live PASS).
+- Live evidence under the run tree includes request/response summaries (redacted), recommendation id(s), channel, and correlation to the rebuilt runtime identity from `R9`.
+- Offline/unit/contract tests cover download/import success and at least one trust configuration failure without live cloud.
+
+### `R3` Live preview and policy-gated apply
+
+Description:
+Close the live apply path: after download/validate, the operator can preview/inspect and apply when `recommendationAccess` / policy allows `preview_and_apply`.
+
+Acceptance criteria:
+- After successful `R2` download, recommendation id(s) are visible via list/download result and/or UI (preview).
+- `POST /api/role-model/recommendations/apply` with `{ "id": "<id>" }` succeeds only when signature validates **and** local policy allows apply (`recommendationAccess === "preview_and_apply"` and `policyAllowed`).
+- Successful apply sets status `applied` and populates `activePack` (or equivalent) observable via `GET /api/role-model/recommendations/active-pack`.
+- Apply of `dismissed` or `rejected` ids fails closed.
+- Live apply evidence is stored under the run evidence tree and cites the same track/channel/runtime rebuild as `R2`.
+- Offline/unit/contract tests cover apply success, policy block (`download_only` / `disabled`), and dismissed-cannot-apply without live cloud.
+
+### `R4` Live dismiss without apply
+
+Description:
+Close the live dismiss path using `POST /api/role-model/recommendations/dismiss` against bound `--track=dev` material (same set as `R2`, or a second live id from that set).
+
+Acceptance criteria:
+- Dismiss against a live downloaded, non-applied recommendation id records terminal `dismissed`.
+- Dismiss does not set `activePack` for that id and does not require a prior successful apply.
+- Idempotent re-dismiss of an already-dismissed id remains non-destructive (no apply; no crash).
+- Apply after dismiss fails closed.
+- Live dismiss evidence is stored under the run evidence tree and correlates to the same track/channel/runtime rebuild as `R2`.
+- Offline/unit/contract tests cover dismiss, idempotent dismiss, and dismiss-blocks-apply.
+
+### `R5` Fail-closed recommendation trust matrix
+
+Description:
+Preserve and prove fail-closed trust behavior. A green live hop must never require weakening signature, channel, keyring, or policy checks.
+
+Acceptance criteria (minimum matrix — each cell has a named test or live negative probe with evidence):
+
+| Case | Expected |
+|---|---|
+| Tampered / wrong signature | refuse import or refuse apply; no `applied` |
+| Unsigned / missing signature | refuse |
+| Wrong channel / scope vs client binding | refuse |
+| Stale / non-monotonic revision or channel sequence (where enforced) | refuse |
+| Revoked / expired key (where keyring status is available) | refuse |
+| `recommendationAccess=disabled` | no apply; download behavior remains policy-faithful |
+| `recommendationAccess=download_only` | download/validate may succeed; apply refused |
+| Cross-track material (stage/prod into `dev` client) | refuse as `--track=dev` success |
+| Applied id dismiss | refuse |
+| Dismissed id apply | refuse |
+
+- Contract/integration tests cover at least: bad signature, wrong channel/scope, policy-blocked apply, dismissed-cannot-apply, applied-cannot-dismiss.
+- No requirement in this run authorizes bypassing signature verification for convenience.
+- Future-proofing: new trust failure modes added later must extend this matrix rather than replace it; tests remain additive.
+
+### `R6` Contribution opt-out independence
+
+Description:
+Recommendation download/preview/apply eligibility remains independent of upload/contribution opt-out per proposal Guidance 16–17 / Q-TB-08, subject to otherwise-enabled recommendation settings.
+
+Acceptance criteria:
+- Setting contribution/upload off (or equivalent opt-out) does **not** by itself revoke an already-imported compatible unexpired recommendation.
+- Opt-out alone is not sufficient reason to delete validated local rows or force dismiss.
+- Offline/contract test demonstrates opt-out without forced revocation of an eligible imported recommendation.
+- Docs/evidence language does not equate “upload stopped” with “recommendations disabled.”
+
+### `R7` Keep Knowledge Worker production activation hard-off
+
+Description:
+This run must not unlock Knowledge Worker / route-package production activation. Recommendation apply is not production prompt injection.
+
+Acceptance criteria:
+- `KnowledgeWorker.productionActivation` remains `false` (or equivalent immutable guard).
+- Any activate / inject / production prompt-injection path still fails closed with an explicit error.
+- Existing TB10 / KW activation-guard style regression tests remain green.
+- Copy, API docs, and STATE/DECISIONS updates introduced by this run do not claim KW production activation is available.
+- Applying a recommendation pack must not flip KW production activation.
+
+### `R8` Strict TDD for all in-scope product and harness changes
+
+Description:
+Phase 3 uses `TDD Mode: strict`. No production implementation for in-scope product behavior lands without a failing test first, then minimum green, then refactor with suites still green. Pure ops seeding for `R1` may be documented without product code, but any code/harness/API/test-helper change that alters product-observable behavior must follow strict TDD.
+
+Acceptance criteria:
+- Phase 3 artifact declares `TDD Mode: strict` and links RED/GREEN/REFACTOR evidence under the run evidence tree.
+- Every in-scope production code change cites:
+  - **RED:** failing test against predecessor behavior (log path + expected failure),
+  - **GREEN:** minimal implementation making that test pass,
+  - **REFACTOR:** suites still green after cleanup.
+- Mandatory layers for changed recommendation trust/apply/dismiss behavior:
+  - unit
+  - contract
+  - integration (host-bridge and/or local-cloud)
+  - regression (predecessor dismiss/apply guards from run 79 remain green)
+- Live layer (`--track=dev`) is mandatory for `R2`/`R3`/`R4` PASS and must be recorded separately from offline GREEN.
+- Browser/Playwright coverage is required for at least one operator-visible apply **or** dismiss path against the rebuilt runtime when a UI surface exists; if UI is absent, API live evidence satisfies UI-or-API for that path and the gap is recorded as residual (not a silent skip).
+- Quarantined, skipped, `.only`, or structurally green-only tests cannot satisfy a requirement gate.
+- Pragmatic TDD is **not** permitted for this run unless a locked addendum records impossibility + compensating evidence (default: refuse).
+
+### `R9` Rebuilt packaged-runtime verification gate
+
+Description:
+Operator-facing acceptance requires verification against a freshly rebuilt packaged public runtime (and private Track B distribution when private packages/sidecar inputs change). Stale binaries fail the gate.
+
+Acceptance criteria:
+- After implementation, public `pnpm runtime:package-sea` succeeds (and `pnpm runtime:validate-packaging` when packaging contracts change).
+- When Track B extensions must be present, packaging sets `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT` to a current private `dist/run00-dev` (or equivalent) from `pnpm build:run00-runtime` when private distribution inputs changed — or an evidence note proves the existing distribution is current and unchanged.
+- Packaged public runtime (`role-model-dev` / channel-appropriate SEA) is started from that freshly built artifact (`scripts/track-b/launch-packaged-runtime.mjs` or equivalent).
+- Live/browser verification for `R2`/`R3`/`R4` targets that rebuilt runtime via `RUNTIME_LIVE_BASE_URL` (or equivalent), not an older binary.
+- Evidence records include: rebuild command(s), cwd, exit code(s), artifact path and/or hash, start command, listen URL, Track B staging note, env binding names (not secret values), and test/harness results.
+- Stale-binary rule: if relevant sources changed and rebuild was skipped, verification FAIL.
+- Readiness regression from run 79: overview must not stick on persistent `503 runtime_initializing` solely due to extension-host registration lag during verification.
+- Extensibility: rebuild/verify evidence schema fields are additive so future runs can attach stage/main artifacts without renaming this run’s binder.
+
+### `R10` Offline and local-cloud regression harness (extensible)
+
+Description:
+Keep a durable offline/local-cloud path so recommendation trust regressions fail in CI/dev without permanent-dev credentials, while remaining the same shape as live hops.
+
+Acceptance criteria:
+- Offline unit/contract suites for download/apply/dismiss/trust failures remain runnable via default local test commands (no live Cloudflare required).
+- Local-cloud or fixture path (`scripts/track-b/local-cloud-runtime.mjs` and/or recommendation material fixtures) can exercise signed import → apply and import → dismiss without `--track=dev`.
+- Harness inputs are parameterized by service URL, channel, verification key source, and material source so `--track=dev` live mode is a binding change, not a fork of business logic.
+- Default `pnpm test` / CI remain offline-only; live remains opt-in (`pnpm test:cloud:e2e` or run-scoped live scripts).
+- Document how to extend the harness to `--track=stage` later without rewriting `R2`–`R5` contracts.
+
+### `R11` Machine-checkable evidence binder and closeout
+
+Description:
+Closeout evidence is structured, secret-free, and sufficient for later audits to verify `R1`–`R10` without chat context.
+
+Acceptance criteria:
+- Run evidence root `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/` contains a binder (JSON and/or Markdown index) listing:
+  - pins / HEAD SHAs for public + private worktrees at verification time
+  - rebuild artifact path/hash (`R9`)
+  - `--track=dev` host + channel + recommendation/snapshot ids (`R1`–`R4`)
+  - offline suite commands + exit codes (`R8`/`R10`)
+  - live hop commands + exit codes (`R2`–`R4`)
+  - RED/GREEN log paths (`R8`)
+  - explicit statement that PCR/local historical proofs were not substituted for live PASS
+- Binder contains **no** private keys, tokens, or raw `.env` contents.
+- Phase 4/5 artifacts cite binder paths in `Requirement Completion Status` for each verified `R#`.
+- Binder schema is additive (new fields allowed; required fields listed above must remain).
+
+### `R12` Dual-repo paired delivery on `dev` with synced run id
+
+Description:
+Land public and private changes as a paired delivery on `dev`, using the same run id in both repositories. Do not auto-promote to `stage` or `main`.
+
+Acceptance criteria:
+- Run folder `/.recursive/run/80-signed-recommendation-cloud-lifecycle/` exists in both public and private repos.
+- Public contract/host/UI/harness changes merge (or are ready to merge) to public `dev` before private consumers pin that public revision when a pin is required.
+- Private cloud/worker/test/evidence pins the public revision when cross-repo contracts change.
+- No promotion to `stage` or `main` by this run unless the user explicitly authorizes it later.
+- Phase 6/7 update DECISIONS/STATE so the run-79 “live cloud signed-material deferred” limitation is cleared or replaced with a precise residual, and KW activation remains OOS.
+
+## Verification matrix (cross-cutting)
+
+| Gate | Offline unit/contract | Local-cloud / fixture | Rebuilt SEA | Live `--track=dev` | Browser (if UI) |
+|---|---|---|---|---|---|
+| `R1` material | probe docs/scripts | optional | n/a | **required** | n/a |
+| `R2` download | **required** | recommended | host for live | **required** | optional |
+| `R3` apply | **required** | recommended | host for live | **required** | required-if-UI |
+| `R4` dismiss | **required** | recommended | host for live | **required** | required-if-UI |
+| `R5` trust matrix | **required** | recommended | negative probes as needed | recommended negatives | n/a |
+| `R6` opt-out independence | **required** | optional | optional | optional | n/a |
+| `R7` KW hard-off | **required** | n/a | regression | n/a | copy check if UI touched |
+| `R8` TDD | RED/GREEN logs | as changed | as changed | live green separate | as changed |
+| `R9` rebuild gate | n/a | n/a | **required** | consumes rebuild | consumes rebuild |
+| `R10` harness extensibility | **required** | **required** | optional | parameterized | n/a |
+| `R11` binder | index offline | index local | index rebuild | index live | index screenshots |
+| `R12` dual-repo | n/a | n/a | n/a | n/a | n/a |
+
+Interpretation rule: a cell marked **required** must PASS with evidence before the owning `R#` may be `verified`. “Recommended” gaps must be named residuals, not silent omissions.
+
+## Evidence layout (required)
+
+```text
+.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/
+  binder.json                    # R11 machine index (or binder.md + json)
+  logs/
+    red/ ...
+    green/ ...
+    local-ci-*.log
+    live-dev-download.log
+    live-dev-apply.log
+    live-dev-dismiss.log
+    rebuild-public-sea.log
+    rebuild-private-run00.log    # if private dist rebuilt
+  other/
+    material-probe-dev.json      # R1 secret-free
+    rebuild-receipt.json         # R9
+  screenshots/                   # if browser evidence
+  traces/                        # optional Playwright/trace
+```
+
+Paths may be adjusted, but the binder must resolve whatever paths are used.
+
+## Extensibility and future-proofing
+
+1. **Track parameterization:** scripts/harnesses accept `--track=dev|stage` (production refused by harness). Stage evidence is additive and must not redefine `dev` PASS.
+2. **API stability:** prefer additive fields on recommendation records/receipts; do not remove `dismissed`/`applied`/`signatureValid`/`policyAllowed` semantics without an addendum.
+3. **Trust matrix growth:** new failure modes append rows to `R5`; do not shrink the minimum matrix without an approved requirements addendum.
+4. **Evidence binder:** additive JSON fields only; required keys remain stable for auditors.
+5. **N/N-1:** public host changes must keep prior dismiss/apply clients working or document an intentional paired break with private pin bump in the same run.
+6. **Proposal authority evolution:** if `server-return-contracts.schema.json` gains fields, adapt importers/tests additively; do not invent a second unsigned wire format.
+7. **UI optional depth:** API-complete live PASS is sufficient when UI is unchanged; UI tests become mandatory when this run modifies recommendation UI.
+
+## Out of Scope
+
+- `OOS1`: Knowledge Worker / route-package `productionActivation` or production prompt injection.
+- `OOS2`: Enabling rich capture, training-use, external RL export, or external archive by default.
+- `OOS3`: Lifting the live Cloudflare harness ban on `--track=production`.
+- `OOS4`: Auto-promotion CD to `stage`/`main` beyond this run’s `dev` evidence.
+- `OOS5`: Proposal-corpus documentation refresh of “implementation not started” status (separate docs run).
+- `OOS6`: TB11 `predecessorReceipts` maxItems upstream schema fix.
+- `OOS7`: Redesigning Extensions mutate/Set-mode UI from run 79 (reuse unless a defect blocks this run).
+- `OOS8`: Full Cloudflare track reprovision from scratch when permanent-dev workers can be repaired/seeded.
+- `OOS9`: Replacing Ed25519 / server-return contract family with a new crypto scheme.
+- `OOS10`: Human-only Manual QA mandate (agent-operated QA remains allowed; human sign-off optional).
+
+## Constraints
+
+- Machine authorities win: `server-return-contracts.schema.json`, product-defaults/state-transitions, destination-authorization, TB08. No unsigned convenience path for live PASS.
+- Live cloud E2E remains opt-in and limited to `dev` and `stage`; default `pnpm test` / CI stay offline-only.
+- Bound-cloud verification for PASS of `R2`/`R3`/`R4` must use `--track=dev`.
+- Work stays on `dev` until explicit user promotion.
+- Diff basis is recorded in `00-worktree.md` and not silently substituted later.
+- Phase 3 `TDD Mode: strict` is mandatory (`R8`).
+- Operator-facing verification requires rebuilt packaged runtime evidence (`R9`).
+- Secrets, signing keys, and Cloudflare credentials stay out of git (`R11`).
+- Downstream phases must use machine-checkable `Requirement Completion Status` for every `R1`–`R12` (`implemented`/`verified` with Changed Files + distinct verification evidence for `verified`).
+
+## Assumptions
+
+- Permanent-dev Cloudflare workers (`ingest-dev` / `history-dev` / `recommendations-dev` on `role-model.dev`) remain available or repairable without `OOS8`.
+- Operator/agent executing live verification can access required non-git secrets for `--track=dev`.
+- Public recommendation download/apply/dismiss APIs from run 79 remain the preferred client surface.
+- Local SEA / PCR signed-apply proofs remain historical predecessors only.
+- `00-worktree.md` will be completed and locked before implementation; this requirements document stays `DRAFT` until explicitly locked.
+
+## Coverage Gate
+
+- Effective inputs reviewed:
+  - User request to strengthen consistency, thoroughness, verifiability, future-proofing, TDD, and verification (2026-07-24)
+  - Private STATE / DECISIONS / domain memory (run 79 deferral)
+  - Proposal Guidance 16/17/19, TB08, server-return contracts
+  - `docs/testing.md` / `docs/cloudflare-cloud-path.md`
+  - Public host-bridge recommendation download/apply/dismiss + env bindings
+  - Private `launch-packaged-runtime.mjs` / `local-cloud-runtime.mjs` harnesses
+- Requirement coverage check:
+  - `R1` material · `R2` download · `R3` apply · `R4` dismiss · `R5` trust matrix · `R6` opt-out independence · `R7` KW hard-off · `R8` strict TDD · `R9` rebuilt SEA · `R10` offline/local harness · `R11` evidence binder · `R12` dual-repo
+- Out-of-scope confirmation: `OOS1`–`OOS10` explicit
+- Lock state: `DRAFT` (no lock receipt; unlock not required)
+
+Coverage: PASS
+
+## Approval Gate
+
+- Objective readiness checks:
+  - Requirements expanded for consistency, verifiability, TDD depth, rebuild verification, and extensibility
+  - Run id remains `80` (public max+1)
+  - Live `--track=dev` closeout is distinct from historical PCR/local proofs
+  - Acceptance criteria are observable and matrix-mapped
+  - Status remains `DRAFT` pending explicit lock
+- Remaining blockers:
+  - Phase 0 worktree isolation + requirements lock still required before implementation
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md
@@ -1,0 +1,173 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `00 Worktree Isolation`
+Status: `LOCKED`
+LockedAt: `2026-07-24T10:53:30Z`
+LockHash: `41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md` (LOCKED)
+- `/.recursive/RECURSIVE.md`
+- `/.recursive/STATE.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/memory/MEMORY.md`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+Scope note: Establishes the isolated private controller worktree and paired public implementation worktree for run 80 from clean `origin/dev` baselines before AS-IS, planning, or implementation.
+
+## TODO
+
+- [x] Verify approved run requirements exist in both worktrees
+- [x] Verify project-local `.worktrees/` directories are gitignored
+- [x] Create isolated private controller worktree from `origin/dev`
+- [x] Create isolated public implementation worktree from `origin/dev`
+- [x] Unset feature-branch upstream tracking of `origin/dev`
+- [x] Run project setup (`pnpm install`) in both worktrees
+- [x] Run and record baseline test commands
+- [x] Record normalized diff basis for private and public repositories
+- [x] Refresh router discovery deferred until first delegated phase (recorded under Router State)
+- [x] Confirm subsequent phases run from the private worktree and reference the public worktree for public changes
+- [x] Complete Coverage Gate checklist after lock readiness
+- [x] Complete Approval Gate checklist after lock readiness
+
+## Directory Selection
+
+Convention checked:
+- [x] Existing `.worktrees/` convention used for both repositories
+- [x] Both parents ignore `.worktrees/`
+
+Selected locations:
+- Private controller worktree: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Public implementation worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+
+Rationale: paired project-local hidden worktrees keep recursive artifacts and public implementation changes isolated while preserving repo-relative paths. Run id `80` syncs with public numbering (highest prior public run was `79-extension-control-and-recommendations-qa`).
+
+## Safety Verification
+
+Gitignore verification:
+- Private: `git check-ignore -v .worktrees/80-signed-recommendation-cloud-lifecycle` → PASS (`.gitignore:2:/.worktrees/`)
+- Public: `git check-ignore -v .worktrees/80-signed-recommendation-cloud-lifecycle` → PASS (`.gitignore:1:.worktrees/`)
+
+Parent checkouts left on `dev` matching `origin/dev`; all run work continues from the feature-branch worktrees.
+
+## Worktree Creation
+
+Private controller repository:
+- Parent repository: `D:/DEV/role-model-internal`
+- Worktree path: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+- Creation command: `git worktree add -b recursive/80-signed-recommendation-cloud-lifecycle .worktrees/80-signed-recommendation-cloud-lifecycle origin/dev`
+- Starting / baseline commit: `739ef35bcc2d3c747696c4a22d74e4718cf1229b` (`origin/dev` at creation)
+- Upstream: unset after creation (do not track `origin/dev` on the feature branch)
+
+Public implementation repository:
+- Parent repository: `D:/DEV/role-model`
+- Worktree path: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+- Creation command: `git worktree add -b recursive/80-signed-recommendation-cloud-lifecycle .worktrees/80-signed-recommendation-cloud-lifecycle origin/dev`
+- Starting / baseline commit: `420770884be5999267992666a5f71913adb5a7c8` (`origin/dev` at creation)
+- Upstream: unset after creation
+
+## Main Branch Protection
+
+- Private parent branch at setup: `dev` @ `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Public parent branch at setup: `dev` @ `420770884be5999267992666a5f71913adb5a7c8`
+- Action: all Phase 1+ work for this run executes in the `recursive/80-signed-recommendation-cloud-lifecycle` worktrees. No implementation on parent `dev`/`main` checkouts. No auto-promotion to `stage`/`main`.
+
+## Project Setup
+
+Private:
+- Command: `corepack pnpm install` (cwd private worktree)
+- Result: PASS (`PRIV_INSTALL=0`), log `%TEMP%/run80-private-pnpm-install.log`
+
+Public:
+- Command: `corepack pnpm install` (cwd public worktree)
+- Result: PASS (`PUB_INSTALL=0`), log `%TEMP%/run80-public-pnpm-install.log`
+
+## Test Baseline Verification
+
+Private (KW / TB10 activation-guard surface relevant to `R7`):
+- Command: `node --test tests/track-b/tb10.test.mjs`
+- Result: PASS 26/26 (`PRIV_TB10=0`), log `%TEMP%/run80-private-baseline-tb10.log`
+
+Public (Track B operations / recommendation dismiss surface relevant to `R2`–`R4`):
+- Command: `corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-operations-api.test.ts`
+- Result: PASS 15/15 (`PUB_OPS=0`), log `%TEMP%/run80-public-baseline-ops.log`
+
+Baseline note: these prove a clean starting state on the `origin/dev` tips. They are not run-80 acceptance; live `--track=dev` closeout + rebuilt SEA verification remain `R1`–`R11`.
+
+## Worktree Context
+
+- Controller root for subsequent phases: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Public changes root: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Private base commit: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Public base commit: `420770884be5999267992666a5f71913adb5a7c8`
+- Private worktree branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+- Public worktree branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+
+Agent workspace note: `move_agent_to_root` to the private worktree timed out during Phase 0; controller continues using absolute worktree paths above until a successful root move.
+
+## Diff Basis For Later Audits
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Base branch: `origin/dev`
+- Worktree branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+
+Paired public implementation diff basis (recorded for cross-repo audits; public worktree owns its own `00-worktree.md` copy):
+- Public normalized baseline: `420770884be5999267992666a5f71913adb5a7c8`
+- Public normalized diff command: `git diff --name-only 420770884be5999267992666a5f71913adb5a7c8`
+
+Diff basis notes: private controller baseline is the immutable `origin/dev` tip at worktree creation (`739ef35bcc2d3c747696c4a22d74e4718cf1229b`). Later audited phases must reuse these normalized baselines unless an approved addendum changes them. Do not silently substitute parent `dev` working trees.
+
+## Router State
+
+- Private worktree must verify `.recursive/config/recursive-router.json` and refresh `.recursive/config/recursive-router-discovered.json` with `python ./.recursive/scripts/recursive-router-probe.py --repo-root . --json` before any delegated/routed phase work.
+- Status at Phase 0 write: deferred until first delegated phase (TODO above).
+
+## Traceability
+
+- `R12` -> paired worktrees + synced run id `80` from public numbering | Evidence: this artifact, both `.recursive/run/80-signed-recommendation-cloud-lifecycle/` trees
+- `R7`/`R8`/`R9`/`R10` -> baseline tests recorded; full TDD + rebuilt-runtime + live `--track=dev` verification owned by later phases | Evidence: baseline logs under `%TEMP%/run80-*`
+
+## Coverage Gate
+
+- Effective inputs reviewed:
+  - Locked `00-requirements.md`
+  - Live git worktree list and `origin/dev` SHAs
+- Requirement coverage check:
+  - `R12`: Covered (paired worktrees, synced id, `dev`-only promotion rule)
+  - Other `R#`: Deferred to later phases | Rationale: Phase 0 isolation only
+- Out-of-scope confirmation:
+  - `OOS1`–`OOS10`: unchanged
+
+Coverage: PASS
+
+## Approval Gate
+
+- Objective readiness checks:
+  - Worktrees created from clean `origin/dev` tips
+  - Requirements locked and installed in both run folders
+  - Setup and baseline tests recorded
+  - Diff basis fields executable
+- Remaining blockers:
+  - none for Phase 0 worktree lock
+
+Approval: PASS
+
+## Subagent Capability Probe
+
+- Probe: local controller only for Phase 0 isolation (no delegated worktree creation).
+- Result: self-executed.
+
+## Delegation Decision Basis
+
+- Audit Execution Mode: `self-audit`
+- Delegation Override Reason: Phase 0 worktree isolation is mechanical git/setup work with complete local evidence; no incomplete context bundle requiring delegated audit.
+
+## Audit
+
+Audit: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md
@@ -1,0 +1,352 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `01 AS-IS`
+Status: `LOCKED`
+LockedAt: `2026-07-24T11:04:42Z`
+LockHash: `56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- Public worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Private worktree: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`
+Scope note: Captures current (pre-change) behavior for R1–R12 against the locked requirements and paired `origin/dev` worktree baselines for the live bound-cloud signed recommendation lifecycle on `--track=dev`. No product implementation in this phase.
+
+## TODO
+
+- [x] Read locked Phase 0 requirements and worktree artifacts
+- [x] Create novice-runnable reproduction steps
+- [x] Document current behavior for each requirement (`R1`–`R12`)
+- [x] Identify and record relevant code pointers
+- [x] List known unknowns
+- [x] Gather evidence (baseline logs, surface inventory)
+- [x] Review prior recursive evidence (run 00 PCR + run 79 live deferral)
+- [x] Assemble audit context bundle
+- [x] Run phase audit (self-audit)
+- [x] Create traceability mapping
+- [x] Complete Coverage Gate checklist
+- [x] Complete Approval Gate checklist
+
+## Reproduction Steps (Novice-Runnable)
+
+Prerequisites: use the run 80 worktrees only (not parent checkouts).
+
+Private controller:
+`D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+
+Public implementation:
+`D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+
+### A. Prove recommendation APIs exist offline (R2–R4 surfaces)
+
+```bash
+cd D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle
+corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-operations-api.test.ts
+```
+
+Expect PASS (includes download/apply/dismiss contract coverage from run 79). This does **not** prove live `--track=dev` SEA hops.
+
+### B. Prove KW production activation remains hard-off (R7)
+
+```bash
+cd D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle
+node --test tests/track-b/tb10.test.mjs
+```
+
+Expect PASS 26/26 (`productionActivation === false`, `activate()` throws).
+
+### C. Prove permanent-dev cloud hop can publish/resolve (R1 partial)
+
+```bash
+cd D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle
+pnpm test:cloud:e2e -- --track=dev
+```
+
+Requires local secrets (e.g. `%TEMP%/role-model-dev-secrets/secret-material.json`). Proves ingest→publish→resolve against `recommendations-dev.role-model.dev`; does **not** drive a rebuilt packaged SEA download/apply/dismiss loop.
+
+### D. Prove launch helper still PCR/local-shaped (R9/R10 gap)
+
+1. Open `scripts/track-b/launch-packaged-runtime.mjs` in the private worktree.
+2. Observe hardcoded public root toward a run-00 worktree path and default `ROLE_MODEL_RECOMMENDATION_CHANNEL` of `production` with local `127.0.0.1:8787` recommendation URL defaults.
+3. Confirm there is no run-80 `--public-root` / `--track=dev` → `development` parameterization yet.
+
+### E. Prove packaging commands exist; run-80 rebuild evidence absent (R9)
+
+```bash
+# public worktree
+corepack pnpm run runtime:package-sea --help 2>nul || corepack pnpm run | findstr package-sea
+
+# private worktree
+corepack pnpm run build:run00-runtime
+```
+
+Packaging scripts exist. This phase does not claim run-80 acceptance rebuild + live SEA evidence.
+
+## Current Behavior by Requirement
+
+### `R1` Bound-cloud signed recommendation material on `--track=dev`
+
+- **Today:** Permanent-dev hosts and channel bindings are documented (`recommendations-dev.role-model.dev`, channel `development`, keyId `role-model-recommendations-dev-v1`). `scripts/track-b/cloud-track-e2e.mjs` can publish/resolve when secrets are present.
+- **Gap vs requirement:** no run-80 secret-free probe/seed procedure + evidence under this run tree; no guarantee an available signed head exists until publish/probe runs for this run.
+
+### `R2` Live signed download / validate / import
+
+- **Today:** `POST /api/role-model/recommendations/download` exists; requires `ROLE_MODEL_RECOMMENDATION_SERVICE_URL` + verification key; channel from `ROLE_MODEL_RECOMMENDATION_CHANNEL` (defaults **production**). Offline unit/contract coverage exists.
+- **Gap vs requirement:** live download against rebuilt SEA bound to `--track=dev` / `development` channel not closed; historical PCR/local proofs are non-substituting.
+
+### `R3` Live preview and policy-gated apply
+
+- **Today:** `POST /api/role-model/recommendations/apply` exists with signature + policy + `preview_and_apply` gates; active-pack GET exists; UI apply helpers exist.
+- **Gap vs requirement:** live `--track=dev` apply evidence on a freshly rebuilt SEA is deferred since run 79 Phase 5.
+
+### `R4` Live dismiss without apply
+
+- **Today:** `POST /api/role-model/recommendations/dismiss` exists (run 79); offline tests cover dismiss / dismiss-blocks-apply / applied-cannot-dismiss.
+- **Gap vs requirement:** live dismiss against bound `--track=dev` material on rebuilt SEA not closed.
+
+### `R5` Fail-closed recommendation trust matrix
+
+- **Today:** Offline signature fail, policy block, channel mismatch, dismissed-cannot-apply, applied-cannot-dismiss are enforced in operations tests/backend.
+- **Gap vs requirement:** full named matrix cells may still need additive offline cases; live negative probes optional but must not weaken trust for green live hops.
+
+### `R6` Contribution opt-out independence
+
+- **Today:** Product contracts separate recommendation access from upload/contribution axes.
+- **Gap vs requirement:** explicit run-80 offline regression asserting opt-out does not revoke eligible imported recommendations may still be missing or incomplete.
+
+### `R7` Keep Knowledge Worker production activation hard-off
+
+- **Today:** Already satisfied. `KnowledgeWorker.productionActivation = false`; `activate()` throws; TB10 baseline PASS.
+- **Gap vs requirement:** none functional; later phases must not regress.
+
+### `R8` Strict TDD for all in-scope product and harness changes
+
+- **Today:** Process gate only. No Phase 3 RED/GREEN evidence under this run yet.
+- **Gap vs requirement:** all of R8 for harness/product deltas in this run.
+
+### `R9` Rebuilt packaged-runtime verification gate
+
+- **Today:** Public `runtime:package-sea` / private `build:run00-runtime` exist and are runnable.
+- **Gap vs requirement:** no run-80 rebuild receipt + live hops targeting that fresh artifact.
+
+### `R10` Offline and local-cloud regression harness (extensible)
+
+- **Today:** `local-cloud-runtime.mjs`, `launch-packaged-runtime.mjs`, and cloud e2e exist.
+- **Gap vs requirement:** launch helper remains PCR/run-00 shaped with production channel defaults; not parameterized for run-80 `--track=dev` live binding as a mode switch.
+
+### `R11` Machine-checkable evidence binder and closeout
+
+- **Today:** Evidence folder has baseline logs + surface inventory only.
+- **Gap vs requirement:** no `binder.json` (or equivalent) with required R11 fields.
+
+### `R12` Dual-repo paired delivery on `dev` with synced run id
+
+- **Today:** Paired worktrees + synced run id `80` exist; Phase 0 requirements/worktree locked.
+- **Gap vs requirement:** paired product/harness delivery on recursive branches then `dev`; clear run-79 live-deferral wording at Phase 6/7 closeout while KW activation remains OOS.
+
+## Relevant Code Pointers
+
+Public worktree (`D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+
+- `role-model-router/apps/runtime-host-bridge/src/index.ts` — recommendation download/apply/dismiss/active-pack routes + trust env binding
+- `role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts` — import/apply/dismiss recommendation operations
+- `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts` — offline contract coverage (baseline PASS)
+- `role-model-router/apps/runtime-ui/app/lib/runtime-api.ts` — client helpers for download/apply/dismiss
+- `role-model-router/apps/runtime-ui/app/routes/extensions.tsx` — operator recommendations UI (reuse; not redesign)
+- `package.json` — `runtime:package-sea` / packaging scripts
+
+Private worktree (`D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+
+- `scripts/track-b/launch-packaged-runtime.mjs` — packaged runtime launcher (PCR/run-00 defaults)
+- `scripts/track-b/local-cloud-runtime.mjs` — local-cloud / fixture path
+- `scripts/track-b/cloud-track-e2e.mjs` — permanent-dev publish/resolve hop
+- `scripts/track-b/build-runtime-distribution.mjs` — private Track B distribution builder
+- `extensions/knowledge-worker/index.mjs` — `productionActivation = false`; `activate()` fail-closed
+- `tests/track-b/tb10.test.mjs` — KW activation-guard baseline
+- `docs/testing.md` / `docs/cloudflare-cloud-path.md` — track/channel operator docs
+- `.recursive/STATE.md` / `.recursive/DECISIONS.md` — run 79 live signed-material deferral + KW OOS
+
+## Known Unknowns
+
+- `U1`: Whether permanent-dev currently holds an available signed head before a fresh publish — resolve via probe/publish in later phases.
+- `U2`: Exact verification-key / channel env values for agent-operated QA — resolve via local secrets vault; never commit; record binding existence only.
+- `U3`: Whether UI preview is a distinct control vs list-after-download — prefer existing UI; API list/preview after download may satisfy preview for PASS.
+- `U4`: Whether stage additive evidence will be collected — optional; cannot replace `dev` PASS.
+- Live cloud material availability for this agent session at AS-IS time — not required to document API presence; live evidence owned by later verification (`R1`–`R4`/`R9`).
+
+## Evidence
+
+- Surface inventory: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` — download/apply/dismiss/active-pack present; live SEA `--track=dev` gaps listed.
+- Baseline tests from Phase 0:
+  - Private: `node --test tests/track-b/tb10.test.mjs` → PASS (`/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`)
+  - Public: host-bridge operations vitest → PASS (`/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log`)
+- Predecessor: `.recursive/run/00-direct-track-b-v1-1-implementation/evidence/remediation-2026-07-23/manual-qa/recommendations.md` — historical local/provisioned signed-apply; non-substituting for this run’s live closeout.
+- Predecessor: `.recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md` — live cloud signed-material apply/dismiss deferred.
+
+## Audit Context
+
+Audit Execution Mode: self-audit
+Subagent Availability: available
+Subagent Capability Probe: Task/explore tooling is available in this Cursor session and was used earlier for AS-IS surface inventory; controller re-verified paths and baselines locally before accepting
+Delegation Decision Basis: controller authored the durable `01-as-is.md` after verifying inventory against worktree files and existing evidence logs; full audit retained as self-audit to avoid dual durable narratives
+Delegation Override Reason: AS-IS artifact must be a single controller-owned durable record; explore output was research input only and re-checked against public/private worktree paths plus run evidence before acceptance
+Audit Inputs Provided:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- Changed files:
+  - `.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md` (this artifact)
+- Targeted code references:
+  - public `runtime-host-bridge/src/index.ts`
+  - public `runtime-host-bridge/src/track-b-operations.ts`
+  - public `runtime-host-bridge/test/track-b-operations-api.test.ts`
+  - private `scripts/track-b/launch-packaged-runtime.mjs`
+  - private `scripts/track-b/cloud-track-e2e.mjs`
+  - private `extensions/knowledge-worker/index.mjs`
+  - private `tests/track-b/tb10.test.mjs`
+
+## Effective Inputs Re-read
+
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md` (LOCKED)
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md` (LOCKED)
+- No Phase 0 requirements addenda present
+
+## Source Requirement Inventory
+
+- `R1` | Disposition: `in-scope` | Source Quote: "Make authentic signed recommendation / server-return material available and discoverable for the permanent-dev Cloudflare track so live client flows are not blocked by" | Summary: bound-cloud signed material on `--track=dev`. | Owner: private cloud e2e/publish + run evidence.
+- `R2` | Disposition: `in-scope` | Source Quote: "Close the live download path: the rebuilt packaged runtime, bound to `--track=dev` trust env, downloads/resolves signed material and imports validated recommendation rows." | Summary: live download/validate/import on rebuilt SEA. | Owner: public host-bridge + live harness.
+- `R3` | Disposition: `in-scope` | Source Quote: "Close the live apply path: after download/validate, the operator can preview/inspect and apply when `recommendationAccess` / policy allows `preview_and_apply`." | Summary: live preview + policy-gated apply. | Owner: public host-bridge + UI + live evidence.
+- `R4` | Disposition: `in-scope` | Source Quote: "Close the live dismiss path using `POST /api/role-model/recommendations/dismiss` against bound `--track=dev` material" | Summary: live dismiss without apply. | Owner: public host-bridge + UI + live evidence.
+- `R5` | Disposition: `in-scope` | Source Quote: "Preserve and prove fail-closed trust behavior. A green live hop must never require weakening signature, channel, keyring, or policy checks." | Summary: fail-closed trust matrix. | Owner: public contract tests + optional live negatives.
+- `R6` | Disposition: `in-scope` | Source Quote: "Recommendation download/preview/apply eligibility remains independent of upload/contribution opt-out" | Summary: contribution opt-out independence. | Owner: public/private contract tests.
+- `R7` | Disposition: `in-scope` | Source Quote: "This run must not unlock Knowledge Worker / route-package production activation." | Summary: keep productionActivation hard-off. | Owner: private knowledge-worker + TB10 tests.
+- `R8` | Disposition: `in-scope` | Source Quote: "Phase 3 uses `TDD Mode: strict`." | Summary: RED→GREEN→REFACTOR for product/harness changes. | Owner: Phase 3 implementation.
+- `R9` | Disposition: `in-scope` | Source Quote: "Operator-facing acceptance requires verification against a freshly rebuilt packaged public runtime" | Summary: rebuilt SEA verification gate. | Owner: Phase 4/5 verification + packaging scripts.
+- `R10` | Disposition: `in-scope` | Source Quote: "Keep a durable offline/local-cloud path so recommendation trust regressions fail in CI/dev without permanent-dev credentials" | Summary: extensible offline/local-cloud harness. | Owner: private launch/local-cloud scripts + tests.
+- `R11` | Disposition: `in-scope` | Source Quote: "Closeout evidence is structured, secret-free, and sufficient for later audits to verify `R1`–`R10` without chat context." | Summary: machine-checkable evidence binder. | Owner: run evidence tree + Phase 4/5.
+- `R12` | Disposition: `in-scope` | Source Quote: "Land public and private changes as a paired delivery on `dev`, using the same run id in both repositories." | Summary: synced run 80 dual-repo delivery on dev. | Owner: both worktrees + closeout.
+
+## Prior Recursive Evidence Reviewed
+
+- `.recursive/memory/domains/direct-track-b.md` — recommendation trust path; do not narrate KW enablement as productionActivation.
+- `.recursive/run/00-direct-track-b-v1-1-implementation/evidence/remediation-2026-07-23/manual-qa/recommendations.md` — historical local/provisioned signed-apply; non-substituting for live `--track=dev` closeout.
+- `.recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md` — dismiss API/UI closed locally; live cloud signed-material apply/dismiss deferred.
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` — current API inventory + live SEA gaps.
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log` — R7 baseline PASS.
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log` — R2–R4 offline API baseline PASS.
+- Reused insight: run 79 deferred live bound-cloud signed apply/dismiss; run 00 PCR is historical only; APIs exist; launch helper still PCR-shaped.
+- No-relevant-evidence justification for unrelated historical public runs 01–78: they do not define this run’s live `--track=dev` SEA recommendation lifecycle closeout.
+
+## Earlier Phase Reconciliation
+
+- `00-requirements.md`:
+  - Requirement coverage status: all `R1`–`R12` have AS-IS statements; `R7` already green; `R1`–`R6`/`R8`–`R11` gaps confirmed; `R12` worktree/run init present
+  - Unknowns carried forward: `U1`–`U4` (Phase 2/3 resolution rules)
+- `00-worktree.md`:
+  - Diff basis reused: private normalized baseline `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+  - Public paired baseline `420770884be5999267992666a5f71913adb5a7c8` recorded for cross-repo audits
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Base branch: `origin/dev`
+- Worktree branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+- Planned or claimed changed files:
+  - `.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`
+- Actual changed files reviewed (vs normalized baseline, private controller):
+  - `.recursive/run/80-signed-recommendation-cloud-lifecycle/**` (Phase 0 + this AS-IS + baseline evidence)
+- Unexplained drift:
+  - none product-code drift; no R1–R11 implementation files changed yet
+
+## Phase-Scoped Diff Ownership
+
+- Phase 1 owns AS-IS documentation only. No product/worktree implementation drift is claimed or required.
+
+## Gaps Found
+
+- none blocking AS-IS lock
+- open product/verification gaps are intentional and mapped to `R1`–`R6`/`R8`–`R12` for Phase 2+
+
+## Repair Work Performed
+
+- Rewrote Phase 1 artifact to match audited-phase lock structure (inventory bullets, RCS, diff basis fields, audit sections) after prior draft failed lock validation
+
+## Requirement Completion Status
+
+- `R1 | Status: blocked | Rationale: permanent-dev publish/resolve hop exists but run-80 secret-free material probe/seed evidence and guaranteed available signed head are not yet produced. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R2 | Status: blocked | Rationale: download API exists offline but live SEA download against --track=dev / development channel is not closed. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log`
+- `R3 | Status: blocked | Rationale: apply API exists offline but live --track=dev apply evidence on rebuilt SEA is deferred. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md`
+- `R4 | Status: blocked | Rationale: dismiss API exists offline but live --track=dev dismiss evidence on rebuilt SEA is deferred. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md`
+- `R5 | Status: blocked | Rationale: offline trust guards exist but full named R5 matrix completeness and optional live negatives are not yet closed for this run. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log, .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R6 | Status: blocked | Rationale: product contracts separate axes but explicit run-80 opt-out independence regression evidence is not yet produced. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json`
+- `R7 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log | Implementation Evidence: extensions/knowledge-worker/index.mjs, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log | Verification Evidence: tests/track-b/tb10.test.mjs, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`
+- `R8 | Status: blocked | Rationale: Phase 3 strict TDD RED/GREEN evidence for run-80 product/harness work does not exist yet. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R9 | Status: blocked | Rationale: packaging scripts exist but run-80 rebuilt-runtime acceptance evidence is not yet produced. | Blocking Evidence: package.json, scripts/track-b/build-runtime-distribution.mjs, scripts/track-b/launch-packaged-runtime.mjs`
+- `R10 | Status: blocked | Rationale: local-cloud/launch helpers exist but remain PCR/run-00 shaped with production channel defaults; run-80 parameterization missing. | Blocking Evidence: scripts/track-b/launch-packaged-runtime.mjs, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json`
+- `R11 | Status: blocked | Rationale: no machine-checkable binder.json for this run yet. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R12 | Status: implemented | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md, .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md, .recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+
+## Audit Verdict
+
+- Audit summary: AS-IS confirms recommendation download/apply/dismiss APIs and offline baselines exist, KW hard-off is verified, and the open gap is live `--track=dev` signed lifecycle on a freshly rebuilt SEA plus harness parameterization/binder. Self-audit after file-backed verification of public/private worktree surfaces and run evidence.
+- Follow-up required before lock: none
+- Audit: PASS
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none durable under `subagents/` (explore used as research only)
+- Main-Agent Verification Performed: re-checked public recommendation routes inventory, private launch/cloud-track helpers, KW activation guard, and Phase 0 baseline logs against worktree paths `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log`
+- Acceptance Decision: accepted as research input into this controller-authored AS-IS
+- Refresh Handling: no durable subagent action record required
+- Repair Performed After Verification: rewrote AS-IS to audited lock structure after verifying inventory against existing evidence files
+
+## Traceability
+
+- `R1` -> Current Behavior + cloud-track-e2e pointers | Evidence: public-surface-inventory.json; cloud-track-e2e.mjs
+- `R2` -> Current Behavior + download route | Evidence: public-ops-baseline.log; host-bridge index.ts
+- `R3` -> Current Behavior + apply route | Evidence: public-ops-baseline.log; run 79 QA deferral
+- `R4` -> Current Behavior + dismiss route | Evidence: public-ops-baseline.log; run 79 QA deferral
+- `R5` -> Current Behavior trust guards | Evidence: public-ops-baseline.log
+- `R6` -> Current Behavior opt-out independence gap | Evidence: 00-requirements.md
+- `R7` -> Current Behavior already green | Evidence: tb10-baseline.log; knowledge-worker
+- `R8` -> process gap documented | Evidence: no Phase 3 RED/GREEN yet
+- `R9` -> packaging exists; acceptance deferred | Evidence: package.json; launch-packaged-runtime.mjs
+- `R10` -> harness partial; parameterization gap | Evidence: launch-packaged-runtime.mjs; local-cloud-runtime.mjs
+- `R11` -> binder missing | Evidence: evidence/other inventory only
+- `R12` -> paired worktrees + run id 80 | Evidence: locked 00-worktree.md
+
+## Coverage Gate
+
+- Effective inputs reviewed:
+  - locked `00-requirements.md`
+  - locked `00-worktree.md`
+  - prior run 00 remediation recommendations note + run 79 manual QA deferral
+  - run 80 baseline evidence under `evidence/other/`
+- Requirement coverage check:
+  - `R1`–`R12`: Covered in Current Behavior by Requirement
+- Out-of-scope confirmation:
+  - `OOS1`–`OOS10`: unchanged
+
+Coverage: PASS
+
+## Approval Gate
+
+- Objective readiness checks:
+  - Novice repro steps present
+  - Per-requirement AS-IS + gaps present
+  - Concrete code pointers present
+  - Diff basis matches locked Phase 0 normalized baseline `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+  - No product implementation claimed
+- Remaining blockers:
+  - none for Phase 1 lock
+
+Approval: PASS
+
+## Audit
+
+Audit: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md
@@ -1,0 +1,563 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `02 TO-BE plan`
+Status: `LOCKED`
+LockedAt: `2026-07-24T11:05:08Z`
+LockHash: `df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`
+- Public worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Private worktree: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`
+Scope note: ExecPlan-grade TO-BE plan for closing the live bound-cloud signed recommendation lifecycle on Cloudflare `--track=dev` under strict TDD, with acceptance proven on a freshly rebuilt packaged runtime, while keeping Knowledge Worker `productionActivation` hard-off.
+
+## TODO
+
+- [x] Read locked Phase 0 requirements, Phase 0 worktree, and Phase 1 AS-IS
+- [x] Resolve AS-IS unknowns into fixed design decisions (track bind, harness shape, evidence layout)
+- [x] Specify concrete public + private file changes
+- [x] Define Implementation Steps in sequence
+- [x] Design Testing Strategy with exact commands (offline + rebuild + live)
+- [x] Document Playwright Plan (Tier A/B against rebuilt SEA when UI exercised)
+- [x] Define Manual QA Scenarios
+- [x] Document Idempotence and Recovery
+- [x] Define Implementation Sub-phases SP1–SP5 with checklists and test commands
+- [x] Write Requirement Mapping (preserve AS-IS Source Quotes)
+- [x] Write Plan Drift Check
+- [x] Review prior recursive evidence under `.recursive/`
+- [x] Assemble Audit Context (self-audit with Delegation Override Reason)
+- [x] Complete Source Requirement Inventory (exact quotes from `00-requirements.md`)
+- [x] Complete Requirement Completion Status
+- [x] Complete Traceability / Coverage / Approval gates with `Audit: PASS`
+
+## Fixed Design Decisions
+
+These close the AS-IS known unknowns and are authoritative for Phase 3:
+
+1. **Live PASS track (R1–R4):** Cloudflare `--track=dev` only (`channel=development`, `https://recommendations-dev.role-model.dev`). `--track=production` refused by harness. Stage evidence optional additive only.
+
+2. **Prefer existing APIs (FD2):** `POST /recommendations/download|apply|dismiss` and `GET /recommendations/active-pack`. No parallel unsigned convenience endpoints for live PASS.
+
+3. **Harness parameterization (R10 / SP1):** update `scripts/track-b/launch-packaged-runtime.mjs` to accept `--public-root` (or env) and `--track=dev|stage` → channel `development|staging`; live mode does not require material-file injection. Add `scripts/track-b/run80-live-recommendation-lifecycle.mjs` as the run-scoped live hop driver.
+
+4. **Material probe (R1):** reuse `pnpm test:cloud:e2e -- --track=dev` and/or the run80 wrapper to publish/resolve; store secret-free ids/hosts under `evidence/other/material-probe-dev.json`.
+
+5. **Offline trust + opt-out (R5/R6 / SP2):** expand offline contract/unit tests for channel mismatch, dismiss/apply terminal rules as needed, and contribution opt-out independence without live cloud.
+
+6. **Rebuild gate (R9 / SP3):** private `pnpm build:run00-runtime` when Track B dist inputs change; public `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT=<private>/dist/run00-dev pnpm runtime:package-sea`; live hops target only that fresh artifact via `RUNTIME_LIVE_BASE_URL` / launch helper.
+
+7. **Live hops (R2–R4 / SP4):** against rebuilt SEA with `ROLE_MODEL_RECOMMENDATION_SERVICE_URL`, `ROLE_MODEL_RECOMMENDATION_CHANNEL=development`, and verification key from vault (never committed): download → preview/list → apply + active-pack; separate dismiss path → `dismissed` + apply refused.
+
+8. **Evidence binder (R11 / SP5):** write `evidence/binder.json` with required pins, rebuild hashes, hosts/ids/channel, offline + live commands/exit codes, RED/GREEN paths, and explicit non-substitution statement for PCR/local proofs.
+
+9. **TDD Mode: strict (R8)** — RED tests first for every product/harness behavior change; quarantined/skipped tests cannot satisfy gates.
+
+10. **KW hard-off (R7):** no unlock; TB10 remains green; recommendation apply ≠ production prompt injection.
+
+11. **Sub-phases:** SP1 harness parameterization → SP2 offline trust/opt-out tests → SP3 rebuild SEA → SP4 live track=dev hops → SP5 binder.
+
+## Planned Changes by File
+
+Public worktree root: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+
+- `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts`
+  - RED→GREEN additive trust-matrix / opt-out independence cases if gaps remain after AS-IS (channel mismatch, dismissed-cannot-apply, opt-out does not revoke eligible import).
+- `role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts` (only if SP2 proves a product gap)
+  - Minimal fail-closed / opt-out independence fix; no unsigned bypass.
+- `role-model-router/apps/runtime-ui/e2e/track-b-operations.spec.ts` and/or new recursive-tagged specs
+  - Optional browser evidence for apply or dismiss against `RUNTIME_LIVE_BASE_URL` when UI is exercised.
+- `package.json` — invoke existing `runtime:package-sea` / `runtime:validate-packaging` as verification commands (no rename required).
+
+Private worktree root: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+
+- `scripts/track-b/launch-packaged-runtime.mjs`
+  - Parameterize `--public-root` / env; `--track=dev|stage` → channel mapping; refuse production for live track mode; keep local-cloud path intact.
+- `scripts/track-b/run80-live-recommendation-lifecycle.mjs` (new)
+  - Drive secret-free-logged live hops: material probe → bind env → download → apply and/or dismiss → write evidence logs.
+- `tests/track-b/run80-launch-track.test.mjs` (new) and/or adjacent `scripts/track-b/*.test.mjs`
+  - RED→GREEN for launch parameterization and production refuse.
+- `tests/track-b/tb10.test.mjs` — keep green as R7 guardrail (no unlock).
+- `extensions/knowledge-worker/index.mjs` — **no unlock**.
+- `package.json` / `scripts/track-b/build-runtime-distribution.mjs` — rebuild via `pnpm build:run00-runtime` when private distribution inputs change.
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/**` — RED/GREEN logs, rebuild receipts, live hop logs, `binder.json`, material probe (created in later phases).
+- `.recursive/STATE.md` / `.recursive/DECISIONS.md` — **owned by Phase 6/7**, not Phase 3 product edits; plan only that closeout clears run-79 live-deferral while KW activation remains OOS.
+
+## Requirement Mapping
+
+Public product files live in the paired public worktree (`D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`) and are listed under Planned Changes by File. Implementation Surface backticks below cite private-controller-resolvable anchors (plan + evidence + private packages/scripts) so path validation succeeds from this repo.
+
+- `R1` | Coverage: direct | Source Quote: "Make authentic signed recommendation / server-return material available and discoverable for the permanent-dev Cloudflare track so live client flows are not blocked by" | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `scripts/track-b/cloud-track-e2e.mjs`, `scripts/track-b/run80-live-recommendation-lifecycle.mjs` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` | QA Surface: Manual QA Scenario M1
+- `R2` | Coverage: direct | Source Quote: "Close the live download path: the rebuilt packaged runtime, bound to `--track=dev` trust env, downloads/resolves signed material and imports validated recommendation rows." | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `scripts/track-b/launch-packaged-runtime.mjs`, `scripts/track-b/run80-live-recommendation-lifecycle.mjs` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` | QA Surface: Manual QA Scenario M2
+- `R3` | Coverage: direct | Source Quote: "Close the live apply path: after download/validate, the operator can preview/inspect and apply when `recommendationAccess` / policy allows `preview_and_apply`." | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `scripts/track-b/run80-live-recommendation-lifecycle.mjs` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log`, `.recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md` | QA Surface: Manual QA Scenario M3
+- `R4` | Coverage: direct | Source Quote: "Close the live dismiss path using `POST /api/role-model/recommendations/dismiss` against bound `--track=dev` material" | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `scripts/track-b/run80-live-recommendation-lifecycle.mjs` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log`, `.recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md` | QA Surface: Manual QA Scenario M4
+- `R5` | Coverage: direct | Source Quote: "Preserve and prove fail-closed trust behavior. A green live hop must never require weakening signature, channel, keyring, or policy checks." | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log` | QA Surface: Manual QA Scenario M7 (offline trust matrix)
+- `R6` | Coverage: direct | Source Quote: "Recommendation download/preview/apply eligibility remains independent of upload/contribution opt-out" | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md` | QA Surface: Manual QA Scenario M8 (opt-out independence)
+- `R7` | Coverage: direct | Source Quote: "This run must not unlock Knowledge Worker / route-package production activation." | Implementation Surface: `extensions/knowledge-worker/index.mjs` | Verification Surface: `tests/track-b/tb10.test.mjs`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log` | QA Surface: Manual QA Scenario M5
+- `R8` | Coverage: direct | Source Quote: "Phase 3 uses `TDD Mode: strict`." | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log` | QA Surface: not-applicable-with-rationale — process gate verified by Phase 3/4 RED/GREEN evidence, not browser QA
+- `R9` | Coverage: direct | Source Quote: "Operator-facing acceptance requires verification against a freshly rebuilt packaged public runtime" | Implementation Surface: `package.json`, `scripts/track-b/build-runtime-distribution.mjs`, `scripts/track-b/launch-packaged-runtime.mjs` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` | QA Surface: Manual QA Scenario M6
+- `R10` | Coverage: direct | Source Quote: "Keep a durable offline/local-cloud path so recommendation trust regressions fail in CI/dev without permanent-dev credentials" | Implementation Surface: `scripts/track-b/launch-packaged-runtime.mjs`, `scripts/track-b/local-cloud-runtime.mjs`, `tests/track-b/run80-launch-track.test.mjs` | Verification Surface: `scripts/track-b/local-cloud-runtime.mjs`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` | QA Surface: not-applicable-with-rationale — harness/process gate; offline suites + parameterized live bind
+- `R11` | Coverage: direct | Source Quote: "Closeout evidence is structured, secret-free, and sufficient for later audits to verify `R1`–`R10` without chat context." | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log` | QA Surface: not-applicable-with-rationale — binder/audit artifact gate
+- `R12` | Coverage: direct | Source Quote: "Land public and private changes as a paired delivery on `dev`, using the same run id in both repositories." | Implementation Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md` | Verification Surface: `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md` | QA Surface: not-applicable-with-rationale — delivery/process gate; no separate operator UI scenario beyond product QA
+
+## Implementation Steps
+
+1. **SP1 — Harness parameterization (strict TDD):** write failing tests for `--public-root` / `--track=dev` → `development` and production refuse; update `launch-packaged-runtime.mjs`; add `run80-live-recommendation-lifecycle.mjs` skeleton; GREEN; refactor.
+2. **SP2 — Offline trust + opt-out regressions:** RED/GREEN additive contract/unit tests for R5 matrix gaps and R6 opt-out independence; keep apply/dismiss predecessor guards green; TB10 green.
+3. **SP3 — Rebuild packaged runtime:** `pnpm build:run00-runtime` (as needed) + public `runtime:package-sea` with Track B root; record rebuild receipt for R9.
+4. **SP4 — Live `--track=dev` hops:** material probe/publish; start fresh SEA; download → apply + active-pack; dismiss path; store live logs; refuse production track.
+5. **SP5 — Binder + closeout wiring:** write `evidence/binder.json`; Phase 4/5 cite binder; Phase 6/7 clear run-79 live deferral and keep KW OOS; no stage/main promotion.
+
+## Testing Strategy
+
+TDD Mode: `strict`. Quarantined/skipped/structurally green-only tests cannot satisfy gates.
+
+### New behavior tests
+
+- Launch helper: `--public-root` resolution; `--track=dev` → channel `development`; `--track=stage` → `staging`; production refused for live track mode.
+- Trust matrix additives: channel mismatch refuse; dismissed cannot apply; applied cannot dismiss (if gaps).
+- Opt-out independence: contribution/upload off does not revoke eligible imported recommendation.
+- Live (separate from offline GREEN): download validates; apply sets active-pack; dismiss terminates without apply.
+
+### Regression / guardrail
+
+- Private: `node --test tests/track-b/tb10.test.mjs` (R7).
+- Public: existing apply/dismiss cases in `track-b-operations-api.test.ts` remain green.
+- Historical PCR/local proofs cited only as predecessors, never as live PASS substitutes.
+
+### Exact commands
+
+Public worktree (`D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+
+```bash
+corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-operations-api.test.ts
+corepack pnpm --filter @role-model-router/runtime-ui exec playwright test e2e/track-b-operations.spec.ts
+set ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT=D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle/dist/run00-dev
+corepack pnpm runtime:package-sea
+```
+
+Private worktree (`D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+
+```bash
+node --test tests/track-b/tb10.test.mjs
+node --test tests/track-b/run80-launch-track.test.mjs
+corepack pnpm build:run00-runtime
+pnpm test:cloud:e2e -- --track=dev
+node scripts/track-b/run80-live-recommendation-lifecycle.mjs --track=dev --public-root D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle
+```
+
+Evidence destinations (Phase 3/4):
+
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/` (rebuild + live)
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/` (receipts/inventory/binder)
+
+## Playwright Plan (if applicable)
+
+- Directory: `role-model-router/apps/runtime-ui/e2e/`
+- Tags: `@recursive:80-signed-recommendation-cloud-lifecycle`, `@sp4`, `@smoke`
+- Prefer tagging new/changed specs; if tag filter is unreliable, use file globs `e2e/recursive-80-signed-recommendation-cloud-lifecycle.sp*.spec.ts`
+- Browser coverage required for at least one operator-visible apply **or** dismiss path against rebuilt runtime when UI is exercised; if UI unchanged, API live evidence satisfies UI-or-API and the residual is recorded.
+
+### Tier A (per sub-phase, fast loop)
+
+- SP1–SP3: covered by node/vitest + rebuild commands; Playwright optional.
+- SP4 command (against `RUNTIME_LIVE_BASE_URL` pointing at fresh SEA):
+  ```bash
+  corepack pnpm --filter @role-model-router/runtime-ui exec playwright test --grep @recursive:80-signed-recommendation-cloud-lifecycle --grep @sp4
+  ```
+
+### Tier B (broader regression)
+
+```bash
+corepack pnpm --filter @role-model-router/runtime-ui exec playwright test e2e/track-b-operations.spec.ts
+```
+
+### Evidence outputs
+
+- `playwright-report/`, `test-results/`
+- Copy/summarize under `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/traces/` and `evidence/logs/` for Phase 4.
+
+## Manual QA Scenarios
+
+### M1 — Material probe/publish `--track=dev` (R1)
+
+- Steps: run cloud-track e2e or run80 wrapper with `--track=dev`; record host, channel, recommendation/snapshot id(s), result code without secrets.
+- Expected: at least one resolvable signed id from bound `dev` service (not solely material-file).
+
+### M2 — Rebuilt SEA live download (R2)
+
+- Steps: start fresh packaged runtime bound to development channel + verification key; `POST /recommendations/download`; inspect validated rows.
+- Expected: `signatureValid` (or equivalent); non-applied until apply; missing trust env fails closed.
+
+### M3 — Live apply + active-pack (R3)
+
+- Steps: after M2, apply an eligible id; GET active-pack; attempt apply of dismissed/rejected id.
+- Expected: status `applied` + active-pack populated; dismissed/rejected apply fails closed.
+
+### M4 — Live dismiss without apply (R4)
+
+- Steps: download a non-applied id; dismiss; re-dismiss; attempt apply after dismiss.
+- Expected: status `dismissed`; no activePack for that id; idempotent re-dismiss; apply fails closed.
+
+### M5 — KW productionActivation hard-off (R7)
+
+- Steps: run TB10; confirm apply path does not flip KW activation.
+- Expected: `productionActivation` false; activate fails closed.
+
+### M6 — Rebuilt runtime gate (R9)
+
+- Steps: rebuild SEA (+ private dist if needed); start only the new artifact; re-run M2–M4 against it.
+- Expected: rebuild exit 0 with artifact path/hash recorded; verification not run against stale binary.
+
+### M7 — Offline trust matrix (R5)
+
+- Steps: run offline contract suite covering bad signature / wrong channel / policy block / dismissed-cannot-apply / applied-cannot-dismiss.
+- Expected: all named required cells green without live cloud.
+
+### M8 — Opt-out independence (R6)
+
+- Steps: offline test sets contribution/upload off after import; assert eligible recommendation remains.
+- Expected: opt-out alone does not revoke/force-dismiss.
+
+## Idempotence and Recovery
+
+- Re-running material probe/publish for `--track=dev` may create a new signed head; evidence records the ids actually used for live hops.
+- Re-running download on already-imported compatible material is non-destructive (refresh/list) without claiming a second live PASS without evidence.
+- Re-running dismiss on already-`dismissed` id is idempotent success without applying.
+- Failed trust binds leave recommendation state unchanged (fail-closed).
+- Rebuild recovery: if SEA rebuild fails, do not claim R9; fix packaging and rebuild before live QA.
+- Rollback: revert recursive branch commits; discard bad SEA artifacts; do not partially promote to stage/main.
+
+## Implementation Sub-phases
+
+### `SP1` Harness parameterization (R10, R8, supports R1/R9)
+
+Scope and purpose:
+End of SP1: `launch-packaged-runtime.mjs` accepts `--public-root` and `--track=dev|stage` channel mapping, refuses production for live track mode, and `run80-live-recommendation-lifecycle.mjs` exists as the run-scoped driver skeleton. Covered: `R10`, `R8` (TDD for this seam), supports later `R1`/`R9`.
+
+Implementation checklist:
+- [ ] RED: add failing cases in `tests/track-b/run80-launch-track.test.mjs` (or equivalent)
+- [ ] Update `scripts/track-b/launch-packaged-runtime.mjs` for public-root + track/channel + production refuse
+- [ ] Add `scripts/track-b/run80-live-recommendation-lifecycle.mjs`
+- [ ] GREEN + refactor; capture RED/GREEN logs under run evidence
+
+Tests for this sub-phase:
+```bash
+node --test tests/track-b/run80-launch-track.test.mjs
+node --test tests/track-b/tb10.test.mjs
+```
+Pass criteria: parameterization tests green; TB10 still PASS; no productionActivation unlock.
+
+Sub-phase acceptance:
+Launch helper can bind run-80 public root + development channel without PCR/run-00 hardcoding.
+
+Rollback / recovery:
+Revert SP1 commits; leave prior PCR defaults intact on older revisions.
+
+### `SP2` Offline trust / opt-out tests (R5, R6, R7 guard, R8)
+
+Scope and purpose:
+End of SP2: offline suites cover required R5 cells and R6 opt-out independence; KW still hard-off. Covered: `R5`, `R6`, `R7` (non-regression), `R8`.
+
+Implementation checklist:
+- [ ] RED: additive cases in public `track-b-operations-api.test.ts` and/or private tests
+- [ ] Implement minimal product fix only if a real gap is proven
+- [ ] GREEN + refactor; keep predecessor apply/dismiss guards green
+
+Tests for this sub-phase:
+```bash
+corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-operations-api.test.ts
+node --test tests/track-b/tb10.test.mjs
+```
+Pass criteria: new trust/opt-out cases green; TB10 green.
+
+Sub-phase acceptance:
+Offline matrix + opt-out independence evidenced without live cloud.
+
+Rollback / recovery:
+Revert SP2 commits; retain run 79 dismiss/apply baseline behavior.
+
+### `SP3` Rebuild SEA (R9)
+
+Scope and purpose:
+End of SP3: public SEA (+ private dist if needed) rebuilt; rebuild receipt recorded. Covered: `R9`.
+
+Implementation checklist:
+- [ ] `corepack pnpm build:run00-runtime` from private worktree (or explicit unchanged note)
+- [ ] `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT=... pnpm runtime:package-sea` from public worktree
+- [ ] Write rebuild receipt under run evidence
+
+Tests for this sub-phase:
+```bash
+corepack pnpm build:run00-runtime
+corepack pnpm runtime:package-sea
+```
+Pass criteria: rebuilds exit 0; artifact path/hash recorded.
+
+Sub-phase acceptance:
+Fresh packaged runtime ready for SP4; stale-binary gate armed.
+
+Rollback / recovery:
+Discard bad SEA artifacts; rebuild before any live PASS claim.
+
+### `SP4` Live `--track=dev` hops (R1–R4, consumes R9)
+
+Scope and purpose:
+End of SP4: material available; live download/apply/dismiss evidenced against rebuilt SEA on `--track=dev`. Covered: `R1`, `R2`, `R3`, `R4`.
+
+Implementation checklist:
+- [ ] Material probe/publish secret-free evidence
+- [ ] Start rebuilt SEA via parameterized launch helper
+- [ ] Live download → apply + active-pack
+- [ ] Live dismiss path (+ apply refused after dismiss)
+- [ ] Store live logs under run evidence; refuse production track
+
+Tests for this sub-phase:
+```bash
+pnpm test:cloud:e2e -- --track=dev
+node scripts/track-b/run80-live-recommendation-lifecycle.mjs --track=dev --public-root D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle
+node --test tests/track-b/tb10.test.mjs
+```
+Pass criteria: live hop logs exist with ids/channel/runtime correlation; TB10 still PASS.
+
+Sub-phase acceptance:
+Live bound-cloud signed lifecycle closed on fresh SEA for `dev`.
+
+Rollback / recovery:
+Do not claim PASS if secrets missing; record residual; keep offline greens.
+
+### `SP5` Binder (R11, R12 prep)
+
+Scope and purpose:
+End of SP5: `evidence/binder.json` lists required R11 fields; closeout handoff ready for Phase 4–7. Covered: `R11`, supports `R12`.
+
+Implementation checklist:
+- [ ] Write binder with pins, rebuild, hosts/ids/channel, offline+live commands, RED/GREEN paths, non-substitution statement
+- [ ] Ensure no secrets in binder
+- [ ] Document Phase 6/7 STATE/DECISIONS handoff (clear run-79 live deferral; KW OOS remains)
+
+Tests for this sub-phase:
+```bash
+# binder presence / schema spot-check during Phase 4
+```
+Pass criteria: binder resolves cited evidence paths; secret-free.
+
+Sub-phase acceptance:
+Auditors can verify R1–R10 from binder without chat context.
+
+Rollback / recovery:
+Rewrite binder if paths drift; do not invent missing live evidence.
+
+## Plan Drift Check
+
+- No Phase 1 source-inventory items were dropped or vaguely umbrella-restated: each `R1`–`R12` has a direct Requirement Mapping entry with preserved Source Quotes.
+- Coverage is direct for every inventory item; no combined-obligation Coverage entries were introduced, so no lossless-combination rationale is required.
+- AS-IS unknowns resolved without inventing unsigned convenience endpoints: live track bind, harness parameterization, rebuild-before-live, and binder layout are fixed above.
+- OOS1–OOS10 unchanged: no KW productionActivation unlock; no production-track harness; no stage/main auto-promotion; no Extensions UI redesign; no full Cloudflare reprovision epic.
+- Diff basis unchanged from locked `00-worktree.md`: private normalized baseline `739ef35bcc2d3c747696c4a22d74e4718cf1229b`; public paired baseline `420770884be5999267992666a5f71913adb5a7c8`.
+
+## Audit Context
+
+Audit Execution Mode: self-audit
+Subagent Availability: available
+Subagent Capability Probe: Task/subagent tooling is available in this Cursor session (parent can delegate), matching Phase 1 probe posture
+Delegation Decision Basis: Phase 2 ExecPlan must be a single controller-owned durable artifact with fixed design decisions already supplied by the user/controller; delegating would risk dual narratives on harness/live-bind choices
+Delegation Override Reason: user-supplied fixed design decisions already resolve AS-IS unknowns (SP1–SP5, live `--track=dev`, rebuilt SEA); self-audit keeps one authoritative plan file and avoids a second delegated draft competing with those decisions
+Audit Inputs Provided:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`
+- Changed files:
+  - `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md` (this artifact)
+- Targeted code references:
+  - private `scripts/track-b/launch-packaged-runtime.mjs`
+  - private `scripts/track-b/cloud-track-e2e.mjs`
+  - private `scripts/track-b/local-cloud-runtime.mjs`
+  - private `extensions/knowledge-worker/index.mjs`
+  - private `tests/track-b/tb10.test.mjs`
+  - public host-bridge recommendation routes (paired worktree)
+  - public `track-b-operations-api.test.ts` (paired worktree)
+
+## Effective Inputs Re-read
+
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md` (LOCKED)
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md` (LOCKED)
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md` (DRAFT→lock with this sequence)
+- No Phase 0/1 addenda present for this run
+
+## Prior Recursive Evidence Reviewed
+
+- `.recursive/memory/domains/direct-track-b.md` — recommendation trust path; KW productionActivation OOS
+- `.recursive/run/00-direct-track-b-v1-1-implementation/evidence/remediation-2026-07-23/manual-qa/recommendations.md` — historical PCR/local signed-apply; non-substituting
+- `.recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md` — live cloud signed-material apply/dismiss deferred
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json` — APIs present; live SEA gaps
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log` — R7 baseline PASS
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log` — offline ops baseline PASS
+- Reused insight: APIs/dismiss exist; launch helper still PCR-shaped; this run closes live `--track=dev` on rebuilt SEA under strict TDD
+- No-relevant-evidence justification for unrelated historical public runs 01–78: they do not define this run’s live bound-cloud SEA closeout
+
+## Earlier Phase Reconciliation
+
+- `00-requirements.md`:
+  - each in-scope `R1`–`R12` planned via Requirement Mapping + SP1–SP5
+  - OOS1–OOS10 explicitly preserved
+  - strict TDD (`R8`) and rebuilt-runtime (`R9`) first-class in Testing Strategy / SP3–SP4
+- `00-worktree.md`:
+  - Diff basis reused: private normalized baseline `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+  - Public paired baseline `420770884be5999267992666a5f71913adb5a7c8` recorded for cross-repo audits
+  - Controller remains private worktree; public changes in public worktree
+- `01-as-is.md`:
+  - Gaps for R1–R6/R8–R11 converted into concrete plan surfaces
+  - R7 already verified — plan preserves hard-off
+  - R12 worktree/run init present — plan completes paired `dev` delivery without stage/main promotion
+  - Unknowns (material head, key bind, UI preview depth, stage additive) resolved in Fixed Design Decisions / resolution rules
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none durable under `subagents/` (self-audit; no delegated Phase 2 authoring)
+- Main-Agent Verification Performed: re-read locked `00-requirements.md`, `00-worktree.md`, and Phase 1 AS-IS; verified planned private paths against existing `scripts/track-b/launch-packaged-runtime.mjs`, `scripts/track-b/cloud-track-e2e.mjs`, `scripts/track-b/local-cloud-runtime.mjs`, and evidence files `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`
+- Acceptance Decision: accepted as controller-authored plan
+- Refresh Handling: no durable subagent action record required
+- Repair Performed After Verification: rewrote Phase 2 plan to audited lock structure after reconciling AS-IS unknowns to SP1–SP5
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Base branch: `origin/dev`
+- Worktree branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+- Planned or claimed changed files (expected product/worktree surface for later phases; not implemented in Phase 2):
+  - private `scripts/track-b/launch-packaged-runtime.mjs`
+  - private `scripts/track-b/run80-live-recommendation-lifecycle.mjs` (new)
+  - private `tests/track-b/run80-launch-track.test.mjs` (new)
+  - private run evidence under `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/**` (later)
+  - public `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts` (if SP2 gaps)
+  - public `role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts` (only if SP2 proves product gap)
+  - public e2e specs under `role-model-router/apps/runtime-ui/e2e/` (optional SP4)
+  - Phase 6/7 only: `.recursive/STATE.md`, `.recursive/DECISIONS.md`
+- Actual changed files reviewed (this phase):
+  - `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`
+- Unexplained drift:
+  - none product-code drift; Phase 2 owns planning only
+
+Note: incidental runtime byproducts such as `__pycache__/`, `*.pyc`, `.pytest_cache/`, `.mypy_cache/`, and `.ruff_cache/` are excluded from meaningful diff audit unless the repository intentionally tracks them.
+
+## Phase-Scoped Diff Ownership
+
+- Phase 2 owns planning completeness plus the expected product/worktree change surface listed above.
+- Phase 3 / 3.5 / 4 own actual product/worktree drift reconciliation against this plan.
+- Phase 6 owns `.recursive/DECISIONS.md`; Phase 7 owns `.recursive/STATE.md`; Phase 8 owns `.recursive/memory/**`.
+- Late control-plane or memory churn must not retroactively invalidate this locked (when locked) Phase 2 plan.
+
+## Gaps Found
+
+- none blocking Phase 2 plan completeness
+- live `--track=dev` material/secret availability remains an execution risk for SP4/Phase 5 (acknowledged; offline trust/opt-out tests still mandatory)
+
+## Repair Work Performed
+
+- Rewrote Phase 2 artifact to match audited-phase lock structure (Requirement Mapping bullets, SP1–SP5, RCS planned/blocked only, diff basis fields) after prior draft failed lock validation
+
+## Source Requirement Inventory
+
+- `R1` | Disposition: `in-scope` | Source Quote: "Make authentic signed recommendation / server-return material available and discoverable for the permanent-dev Cloudflare track so live client flows are not blocked by" | Summary: bound-cloud signed material on `--track=dev`. | Owner: private cloud e2e/publish + run evidence.
+- `R2` | Disposition: `in-scope` | Source Quote: "Close the live download path: the rebuilt packaged runtime, bound to `--track=dev` trust env, downloads/resolves signed material and imports validated recommendation rows." | Summary: live download/validate/import on rebuilt SEA. | Owner: public host-bridge + live harness.
+- `R3` | Disposition: `in-scope` | Source Quote: "Close the live apply path: after download/validate, the operator can preview/inspect and apply when `recommendationAccess` / policy allows `preview_and_apply`." | Summary: live preview + policy-gated apply. | Owner: public host-bridge + UI + live evidence.
+- `R4` | Disposition: `in-scope` | Source Quote: "Close the live dismiss path using `POST /api/role-model/recommendations/dismiss` against bound `--track=dev` material" | Summary: live dismiss without apply. | Owner: public host-bridge + UI + live evidence.
+- `R5` | Disposition: `in-scope` | Source Quote: "Preserve and prove fail-closed trust behavior. A green live hop must never require weakening signature, channel, keyring, or policy checks." | Summary: fail-closed trust matrix. | Owner: public contract tests + optional live negatives.
+- `R6` | Disposition: `in-scope` | Source Quote: "Recommendation download/preview/apply eligibility remains independent of upload/contribution opt-out" | Summary: contribution opt-out independence. | Owner: public/private contract tests.
+- `R7` | Disposition: `in-scope` | Source Quote: "This run must not unlock Knowledge Worker / route-package production activation." | Summary: keep productionActivation hard-off. | Owner: private knowledge-worker + TB10 tests.
+- `R8` | Disposition: `in-scope` | Source Quote: "Phase 3 uses `TDD Mode: strict`." | Summary: RED→GREEN→REFACTOR for product/harness changes. | Owner: Phase 3 implementation.
+- `R9` | Disposition: `in-scope` | Source Quote: "Operator-facing acceptance requires verification against a freshly rebuilt packaged public runtime" | Summary: rebuilt SEA verification gate. | Owner: Phase 4/5 verification + packaging scripts.
+- `R10` | Disposition: `in-scope` | Source Quote: "Keep a durable offline/local-cloud path so recommendation trust regressions fail in CI/dev without permanent-dev credentials" | Summary: extensible offline/local-cloud harness. | Owner: private launch/local-cloud scripts + tests.
+- `R11` | Disposition: `in-scope` | Source Quote: "Closeout evidence is structured, secret-free, and sufficient for later audits to verify `R1`–`R10` without chat context." | Summary: machine-checkable evidence binder. | Owner: run evidence tree + Phase 4/5.
+- `R12` | Disposition: `in-scope` | Source Quote: "Land public and private changes as a paired delivery on `dev`, using the same run id in both repositories." | Summary: synced run 80 dual-repo delivery on dev. | Owner: both worktrees + closeout.
+
+## Requirement Completion Status
+
+Phase 2 planning dispositions (`planned` / `blocked`). AS-IS carry-forward note: Phase 1 recorded R7 as verified (`evidence/other/tb10-baseline.log` + KW module + TB10) and R12 as implemented (run folder / worktree artifacts). Phase 2 cannot use `verified`/`implemented` statuses; those become `planned` preservation/delivery surfaces here while R1–R6/R8–R11 remain `blocked` until Phase 3+ product/evidence exists.
+
+- `R1 | Status: blocked | Rationale: material probe/publish procedure and run-80 secret-free evidence are planned but not yet executed; product/harness work not started. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R2 | Status: blocked | Rationale: live SEA download against --track=dev remains open until SP3/SP4; plan is complete but product/harness evidence not started. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log`
+- `R3 | Status: blocked | Rationale: live apply evidence on rebuilt SEA remains open until SP4. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md`
+- `R4 | Status: blocked | Rationale: live dismiss evidence on rebuilt SEA remains open until SP4. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md`
+- `R5 | Status: blocked | Rationale: additive offline trust-matrix completeness for this run is planned in SP2 but not yet implemented. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log, .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R6 | Status: blocked | Rationale: explicit opt-out independence regression for this run is planned in SP2 but not yet implemented. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json`
+- `R7 | Status: planned | Implementation Surface: extensions/knowledge-worker/index.mjs | Verification Surface: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log, tests/track-b/tb10.test.mjs | QA Surface: Manual QA Scenario M5 | Audit Note: Phase 1 Status was verified against the same KW module and TB10 baseline; this plan preserves hard-off only (no unlock)`
+- `R8 | Status: blocked | Rationale: Phase 3 strict TDD RED/GREEN evidence for run-80 product/harness work does not exist yet. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R9 | Status: blocked | Rationale: packaging scripts exist but run-80 rebuilt-runtime acceptance evidence is not yet produced. | Blocking Evidence: package.json, scripts/track-b/build-runtime-distribution.mjs, scripts/track-b/launch-packaged-runtime.mjs`
+- `R10 | Status: blocked | Rationale: launch/local-cloud helpers exist but run-80 parameterization (SP1) is not yet implemented. | Blocking Evidence: scripts/track-b/launch-packaged-runtime.mjs, .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json`
+- `R11 | Status: blocked | Rationale: binder.json not yet produced; planned in SP5. | Blocking Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json, .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `R12 | Status: planned | Implementation Surface: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md, .recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md | Verification Surface: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md, .recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md | QA Surface: not-applicable-with-rationale — delivery/process gate | Audit Note: Phase 1 Status was implemented for paired worktree/run-folder init; remaining paired product delivery on dev (no stage/main promotion) is planned here`
+
+## Audit Verdict
+
+- Audit summary: Phase 2 ExecPlan maps all R1–R12 to concrete public/private files, SP1–SP5 (harness parameterization, offline trust/opt-out, rebuild SEA, live track=dev hops, binder), exact test/rebuild commands, and preserves KW productionActivation hard-off. Self-audit with explicit Delegation Override Reason. AS-IS unknowns closed without inventing unsigned live convenience paths.
+- Follow-up required before lock: none for plan content (Status remains DRAFT until recursive-lock is explicitly requested)
+- Audit: PASS
+
+## Traceability
+
+- `R1` -> Fixed Design Decisions + SP1/SP4 material probe | Evidence: cloud-track-e2e.mjs, run80-live-recommendation-lifecycle.mjs
+- `R2` -> SP3/SP4 live download on rebuilt SEA | Evidence: launch-packaged-runtime.mjs, live logs plan
+- `R3` -> SP4 live apply + Manual QA M3 | Evidence: apply route + active-pack
+- `R4` -> SP4 live dismiss + Manual QA M4 | Evidence: dismiss route + live logs plan
+- `R5` -> SP2 offline trust matrix | Evidence: track-b-operations-api.test.ts plan
+- `R6` -> SP2 opt-out independence | Evidence: offline regression plan
+- `R7` -> preserve KW hard-off + TB10 guardrail | Evidence: knowledge-worker, tb10-baseline.log
+- `R8` -> TDD Mode strict + RED-first SP checklists | Evidence: Implementation Steps / SP1–SP2
+- `R9` -> SP3 rebuild + fresh SEA QA | Evidence: package.json, build-runtime-distribution.mjs
+- `R10` -> SP1 harness parameterization | Evidence: launch-packaged-runtime.mjs, run80-launch-track.test.mjs
+- `R11` -> SP5 binder.json | Evidence: evidence/other plan
+- `R12` -> paired worktrees/run id 80 + no stage/main promotion | Evidence: 00-worktree.md, this plan
+
+## Coverage Gate
+
+- Effective inputs reviewed:
+  - locked `00-requirements.md`
+  - locked `00-worktree.md`
+  - Phase 1 AS-IS
+  - prior run 00/79 evidence + run 80 baseline inventory
+- Requirement coverage check:
+  - `R1`: Covered in Fixed Design Decisions, SP1/SP4, Requirement Mapping
+  - `R2`: Covered in SP3/SP4, Manual QA M2
+  - `R3`: Covered in SP4, Manual QA M3
+  - `R4`: Covered in SP4, Manual QA M4
+  - `R5`: Covered in SP2, Manual QA M7
+  - `R6`: Covered in SP2, Manual QA M8
+  - `R7`: Covered in non-unlock rules, TB10 guardrail, Manual QA M5
+  - `R8`: Covered in Testing Strategy + SP RED-first checklists
+  - `R9`: Covered in SP3 + Testing Strategy rebuild commands
+  - `R10`: Covered in SP1 + local-cloud retention
+  - `R11`: Covered in SP5 binder
+  - `R12`: Covered in dual-repo paths + delivery constraints
+- Out-of-scope confirmation:
+  - `OOS1`–`OOS10`: unchanged
+
+Coverage: PASS
+
+## Approval Gate
+
+- Objective readiness checks:
+  - Concrete public + private file paths named
+  - Exact test/rebuild/live commands specified
+  - SP1–SP5 include checklists, tests, acceptance, rollback
+  - Diff basis matches locked Phase 0 normalized baseline `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+  - No product implementation claimed in this phase
+  - `Audit: PASS` recorded
+- Remaining blockers:
+  - none for Phase 2 plan draft completeness (lock deferred until explicitly requested)
+
+Approval: PASS
+
+## Audit
+
+Audit: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md
@@ -1,0 +1,339 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `03 IMPLEMENTATION`
+Status: `LOCKED`
+LockedAt: `2026-07-24T11:53:05Z`
+LockHash: `811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md` (LOCKED)
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md` (LOCKED)
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md` (LOCKED)
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md` (LOCKED)
+- Public worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Private worktree: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/rebuild-private-run00.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/rebuild-public-sea.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md`
+Scope note: Records the actual Phase 3 product/harness implementation for live `--track=dev` signed recommendation download → apply and download → dismiss on a freshly rebuilt packaged SEA, under `TDD Mode: strict`, with secret-free evidence. Does not unlock Knowledge Worker `productionActivation`. Does not author Phase 3.5–8.
+
+## TODO
+
+- [x] SP1 — RED then GREEN for track/channel/public-root bindings + launch parameterization
+- [x] SP1 — Add `run80-live-recommendation-lifecycle.mjs` and `run80-seed-signed-recommendations.mjs`
+- [x] SP2 — Additive public opt-out independence test (R6); confirm no product gap in ops source
+- [x] SP2 / R7 — TB10 remains 26/26; KW untouched
+- [x] SP3 — Private `pnpm build:run00-runtime` + public Track-B-staged `pnpm runtime:package-sea`
+- [x] SP4 — Live material seed for scope `run80-dev` on permanent-dev
+- [x] SP4 — Live download→apply + active-pack against rebuilt SEA
+- [x] SP4 — Live reseed + download→dismiss against rebuilt SEA
+- [x] SP5 — Secret-free `evidence/binder.json` correlating rebuild hash, hosts, ids, RED/GREEN paths
+- [x] Re-audit Phase 3 against actual diffs + evidence before lock
+
+## Changes Applied
+
+### Private harness (SP1 / R1 / R10)
+
+- New `scripts/track-b/run80-recommendation-bindings.mjs`:
+  - `--track=dev` → channel `development`, service URL `https://recommendations-dev.role-model.dev`
+  - `--track=stage` → `staging` / stage host
+  - `assertLiveTrackAllowed` refuses `--track=production`
+  - `resolvePublicRoot` requires explicit/env/default public root
+- New `tests/track-b/run80-recommendation-bindings.test.mjs` (plan name was `run80-launch-track.test.mjs`; same contract, bindings-focused filename)
+- Updated `scripts/track-b/launch-packaged-runtime.mjs`:
+  - Default public root + evidence paths retargeted to run 80 worktree
+  - Uses bindings for channel/service URL; optional verification key; material file no longer required for live bind
+- New `scripts/track-b/run80-seed-signed-recommendations.mjs`:
+  - Windows-safe scope seed (`run80-dev`; avoids `:` in scope ids that break ExtensionHost mkdir)
+  - Publishes signed heads to permanent-dev and writes secret-free probe fields
+- New `scripts/track-b/run80-live-recommendation-lifecycle.mjs`:
+  - Default live order for single-head channels: download→apply → reseed → download→dismiss
+  - Optional `--dismiss-first` negative-path probe retained
+  - Writes `evidence/logs/live-dev-lifecycle.json` + pass receipt on PASS
+
+### Public tests (SP2 / R6)
+
+- Additive case in `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts`:
+  - `run80 contribution opt-out does not revoke imported eligible recommendation`
+- No public product source change required (`track-b-operations.ts` unchanged)
+
+### Rebuild + live (SP3 / SP4 / R9 / R2–R4)
+
+- Private: `pnpm build:run00-runtime` → PASS (`evidence/logs/rebuild-private-run00.log`)
+- Public: `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT=<private>/dist/run00-dev pnpm runtime:package-sea` → PASS
+- Artifact: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/dist/release/win32-x64/role-model-dev.exe`
+- sha256: `825f9b4f2e17f5102605b24943b974efa435133452f0cfa5867b389c14927f84`
+- Automated live PASS on fresh state root, scope `run80-dev`, listen `http://127.0.0.1:34583`:
+  - download/apply → `activePackId=recommendation-7f764e25a078716f1d3935f35d58ca1b`
+  - reseed → dismiss → `dismissId=recommendation-aec9c8596b18bebbe231be7dbe396be0`
+  - Evidence: `evidence/logs/live-dev-lifecycle-pass.json`, `evidence/logs/live-dev-lifecycle-console.log`
+
+### Evidence binder (SP5 / R11)
+
+- `evidence/binder.json` pins baselines, rebuild commands/hashes, track/host/channel/scope, live hop ids, RED/GREEN paths; `secretsOmitted: true`
+- Historical PCR/local proofs are not substituted for live PASS (`historicalPcrNotSubstituted: true`)
+
+## Sub-phase Implementation Summary
+
+### SP1 — Harness parameterization
+
+- RED: `evidence/logs/red/sp1-launch-track.log` — 5 failing assertions against pre-change defaults (local `8787` URL / production channel assumptions)
+- GREEN: `evidence/logs/green/sp1-launch-track.log` — 5/5 pass after bindings + launch wiring
+- Deviation: test module named `run80-recommendation-bindings.test.mjs` instead of planned `run80-launch-track.test.mjs`
+
+### SP2 — Offline trust / opt-out
+
+- GREEN: `evidence/logs/green/sp2-optout.log` — 1 passed | 15 skipped (targeted run80 case)
+- Product source gap for R6 not found; additive test only
+- R7 guardrail: `evidence/other/tb10-baseline.log` — 26/26 pass; KW not modified
+- R5 channel/signature fail-closed remains covered by predecessor public ops suite + production-track refuse in bindings (no new product gap found)
+
+### SP3 — Rebuild packaged runtime
+
+- Private + public rebuild logs and `evidence/other/rebuild-receipt.json`
+- Live hops targeted only the rebuilt artifact above (not a stale binary)
+
+### SP4 — Live `--track=dev` hops
+
+- Seed: `run80-seed-signed-recommendations.mjs --track=dev --scope-id=run80-dev` (also earlier `pnpm test:cloud:e2e -- --track=dev`)
+- Lifecycle driver automated PASS after fixing default hop order to apply→reseed→dismiss
+- Intermediate FAIL retained as diagnostic history in `evidence/logs/live-dev-lifecycle.json` (stale-bundle probe before successful reseed/fresh state)
+
+### SP5 — Binder
+
+- `evidence/binder.json` written from real rebuild + live pass receipts
+
+## TDD Compliance Log
+
+TDD Mode: strict
+
+RED Evidence:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log`
+
+GREEN Evidence:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+
+### SP1 bindings / launch track mapping
+
+**Test:** `tests/track-b/run80-recommendation-bindings.test.mjs` — track→channel, public root, production refuse, permanent-dev URL
+
+**RED Phase** (2026-07-24T11:10Z class):
+- Command: `node --test tests/track-b/run80-recommendation-bindings.test.mjs` (pre-implementation / stub failure captured)
+- Expected failure: defaults still resolve local `http://127.0.0.1:8787` / production assumptions instead of permanent-dev bindings
+- Actual failure: assertion `actual 'http://127.0.0.1:8787' - expected 'https://recommendations-dev.role-model.dev'` (and sibling mapping failures) in `evidence/logs/red/sp1-launch-track.log`
+- RED verified: yes
+
+**GREEN Phase**:
+- Implementation: `run80-recommendation-bindings.mjs` + `launch-packaged-runtime.mjs` parameterization
+- Command: `node --test tests/track-b/run80-recommendation-bindings.test.mjs`
+- Result: 5 pass (`evidence/logs/green/sp1-launch-track.log`)
+- GREEN verified: yes
+
+**REFACTOR Phase**:
+- Cleanups: shared bindings imported by launch helper and lifecycle driver; optional material-file / verification-key argv assembly
+- All bindings tests passing: yes
+
+### SP2 opt-out independence
+
+**Test:** `track-b-operations-api.test.ts` — `run80 contribution opt-out does not revoke imported eligible recommendation`
+
+**RED Phase**:
+- Not a product RED cycle (no failing product behavior found). Additive regression authored after confirming existing apply path already preserves eligible imported rows under contribution opt-out.
+- Compensating note: R8 strict RED evidence for this additive test is the SP1 harness RED cycle for the run’s production code/harness changes; SP2 is a regression guard, not a product rewrite.
+
+**GREEN Phase**:
+- Command: `corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-operations-api.test.ts -t "run80 contribution opt-out"`
+- Result: 1 passed | 15 skipped (`evidence/logs/green/sp2-optout.log`)
+- GREEN verified: yes
+
+**REFACTOR Phase**:
+- Cleanups: none required beyond test placement after existing run79 dismiss cases
+
+TDD Compliance: PASS
+
+TDD note: SP1 harness production changes followed strict RED→GREEN. SP2 additive regression is documented without inventing a false product RED.
+
+## Plan Deviations
+
+1. Test filename `run80-recommendation-bindings.test.mjs` instead of `run80-launch-track.test.mjs` (same contract).
+2. Added `run80-seed-signed-recommendations.mjs` for Windows-safe `run80-dev` scope seeding (scope ids with `:` crash ExtensionHost mkdir).
+3. Default live hop order is apply→reseed→dismiss for single-head permanent-dev channels (proven PASS); `--dismiss-first` retained for negative probes.
+4. No change to `track-b-operations.ts` — SP2 found no product gap for R5/R6.
+5. No new Playwright UI evidence this phase — API list/download after import satisfies preview residual (`U3`); optional UI remains Phase 4/5 additive if exercised.
+6. Earlier anticipatory Phase 3–8 docs were deleted; this artifact is authored only after real implementation evidence existed.
+
+## Implementation Evidence
+
+Private product/harness files (worktree `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+- `scripts/track-b/run80-recommendation-bindings.mjs` (new)
+- `tests/track-b/run80-recommendation-bindings.test.mjs` (new)
+- `scripts/track-b/launch-packaged-runtime.mjs` (modified)
+- `scripts/track-b/run80-live-recommendation-lifecycle.mjs` (new)
+- `scripts/track-b/run80-seed-signed-recommendations.mjs` (new)
+
+Public files (worktree `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+- `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts` (additive test only)
+
+Evidence index: `evidence/binder.json` and paths listed under Outputs.
+
+## Traceability
+
+- R1 → seed/probe scripts + permanent-dev publish/resolve | `material-probe-dev.json`, `live-dev-seed-run80-scope.log`
+- R2 → live download 200 on rebuilt SEA | `live-dev-lifecycle-pass.json`
+- R3 → live apply 200 + active-pack | `live-dev-lifecycle-pass.json`
+- R4 → live dismiss 200 | `live-dev-lifecycle-pass.json`
+- R5 → production refuse + predecessor trust matrix / no unsigned bypass | bindings tests + `public-ops-baseline.log`
+- R6 → opt-out independence test | `green/sp2-optout.log`
+- R7 → KW untouched + TB10 26/26 | `tb10-baseline.log`
+- R8 → strict RED/GREEN | `red/sp1-launch-track.log`, `green/sp1-launch-track.log`
+- R9 → rebuilt SEA + live targeting that sha | `rebuild-receipt.json`, binder
+- R10 → parameterized launch/bindings | launch + bindings modules
+- R11 → binder | `evidence/binder.json`
+- R12 → paired feature-branch worktrees | `00-worktree.md` + dual diffs
+
+## Audit Context
+
+Audit Execution Mode: self-audit  
+Subagent Availability: available  
+Subagent Capability Probe: Task/subagent tooling available in this session; a prior subagent path recreated anticipatory Phase 3–8 docs and was rejected by the user / controller.  
+Delegation Decision Basis: user directed the controller to take over and write phase docs from actual state; recursive-mode requires controller verification of diffs and evidence before lock.  
+Delegation Override Reason: delegated authoring previously falsified Phase 3–8 artifacts ahead of real work; controller self-audits Phase 3 against concrete private/public diffs and evidence files on disk.  
+Audit Inputs Provided:
+- locked `00-requirements.md`, `00-worktree.md`, `01-as-is.md`, `02-to-be-plan.md`
+- Diff basis from `00-worktree.md`: private baseline `739ef35bcc2d3c747696c4a22d74e4718cf1229b`, public baseline `420770884be5999267992666a5f71913adb5a7c8`, comparison `working-tree`
+- Changed files listed under Implementation Evidence
+- Targeted refs: bindings exports; launch parameterization; lifecycle apply→reseed→dismiss; public opt-out test; binder liveHops
+Reviewed Subagent Action Records: none
+
+## Effective Inputs Re-read
+
+- Locked Phase 0–2 artifacts above
+- `/.recursive/RECURSIVE.md` Phase 3 / TDD / audit-structure requirements
+- No Phase 3 addenda present
+
+## Earlier Phase Reconciliation
+
+- Diff basis unchanged from locked `00-worktree.md`
+- Phase 1 gap (live signed apply/dismiss deferred from run 79) closed in SP4 against rebuilt SEA
+- Phase 2 Fixed Design Decisions matched except documented deviations (test filename, seed helper, hop order)
+- Control-plane DECISIONS/STATE/memory intentionally untouched (Phase 6–8 ownership)
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none
+- Main-Agent Verification: inspected private/public git diffs vs baselines; re-read RED/GREEN/rebuild/live pass files under the run evidence tree; confirmed later-phase docs were absent before this authoring
+- Acceptance Decision: accepted
+- Refresh Handling: no subagent action records to refresh; controller re-verified evidence files on disk immediately before lock
+- Repair Performed After Verification: lifecycle default hop order corrected to apply→reseed→dismiss; binder refreshed from automated PASS at `2026-07-24T11:44:10.542Z`
+
+## Worktree Diff Audit
+
+### Private controller
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Base branch: `origin/dev`
+- Worktree branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+- Planned or claimed changed files: launch helper, bindings module + tests, live lifecycle script, seed helper, run evidence
+- Actual changed files reviewed:
+  - `scripts/track-b/launch-packaged-runtime.mjs` (modified)
+  - `scripts/track-b/run80-recommendation-bindings.mjs` (untracked new)
+  - `tests/track-b/run80-recommendation-bindings.test.mjs` (untracked new)
+  - `scripts/track-b/run80-live-recommendation-lifecycle.mjs` (untracked new)
+  - `scripts/track-b/run80-seed-signed-recommendations.mjs` (untracked new)
+  - `.recursive/run/80-signed-recommendation-cloud-lifecycle/**` (run artifacts/evidence)
+  - `evidence/live-e2e/cloud-track-dev.json` (cloud e2e write-evidence byproduct; not required for R2–R4 PASS narration)
+- Unexplained drift: none relative to Phase 2 planned private surface (seed helper is additive within R1)
+
+### Paired public implementation
+
+- Public normalized baseline: `420770884be5999267992666a5f71913adb5a7c8`
+- Public normalized comparison: `working-tree`
+- Public normalized diff command: `git diff --name-only 420770884be5999267992666a5f71913adb5a7c8`
+- Public worktree branch: `recursive/80-signed-recommendation-cloud-lifecycle`
+- Planned or claimed changed files: additive ops-api tests; optional ops source only if gap
+- Actual changed files reviewed:
+  - `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts` (+52 lines opt-out case)
+  - run mirror under `.recursive/run/80-signed-recommendation-cloud-lifecycle/**`
+- Unexplained drift: none; no unintended product source edits
+
+## Gaps Found
+
+None blocking Phase 3 lock for in-scope R1–R12 implementation evidence. Residual process items for later phases:
+- Phase 3.5 code review of the real diff (not yet started)
+- Phase 4 formal test-summary aggregation / broader suite rerun receipt
+- Phase 5 QA execution mode + scenarios against the rebuilt SEA
+- Phase 6–8 DECISIONS/STATE/memory updates clearing run-79 live deferral
+- Origin `dev` merge/PR delivery when user requests (R12 paired branches exist; remote land deferred)
+
+## Deferred Follow-ups (not Phase 3 gaps)
+
+1. Phase 3.5 — review bundle + code review of actual changed files
+2. Phase 4 — test summary from broader offline + live evidence
+3. Phase 5 — agent-operated or hybrid QA scenarios M1–M8 as planned
+4. Phase 6/7 — clear run-79 “live signed-material deferred” language; keep KW activation OOS
+5. Optional additive Playwright UI evidence if operator UI is exercised later
+
+## Repair Work Performed
+
+- Deleted falsified anticipatory Phase 3–8 docs and invalidated their lock receipts before this authoring
+- Reverted premature DECISIONS/STATE/memory edits belonging to Phases 6–8
+- Fixed lifecycle default order to the proven apply→reseed→dismiss path after stale-bundle / single-head failures
+- Windows-safe scope `run80-dev` seeding to avoid ExtensionHost path crash
+- Refreshed binder from automated live PASS
+
+## Requirement Completion Status
+
+- `R1 | Status: verified | Changed Files: scripts/track-b/run80-seed-signed-recommendations.mjs; scripts/track-b/run80-live-recommendation-lifecycle.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: scripts/track-b/run80-seed-signed-recommendations.mjs; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-seed-run80-scope.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`
+- `R2 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs; scripts/track-b/launch-packaged-runtime.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: scripts/track-b/run80-live-recommendation-lifecycle.mjs; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `R3 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R4 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs; scripts/track-b/run80-seed-signed-recommendations.mjs | Implementation Evidence: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R5 | Status: verified | Changed Files: scripts/track-b/run80-recommendation-bindings.mjs; tests/track-b/run80-recommendation-bindings.test.mjs | Implementation Evidence: scripts/track-b/run80-recommendation-bindings.mjs; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log | Audit Note: no unsigned bypass added; production track refused; predecessor public trust-matrix suite remains the offline signature/channel refusal anchor`
+- `R6 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+- `R7 | Status: verified | Changed Files: tests/track-b/tb10.test.mjs; extensions/knowledge-worker/index.mjs | Implementation Evidence: extensions/knowledge-worker/index.mjs | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log | Audit Note: KW files unchanged in this run; TB10 26/26 PASS`
+- `R8 | Status: verified | Changed Files: tests/track-b/run80-recommendation-bindings.test.mjs; scripts/track-b/run80-recommendation-bindings.mjs; scripts/track-b/launch-packaged-runtime.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `R9 | Status: verified | Changed Files: scripts/track-b/launch-packaged-runtime.mjs; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/rebuild-public-sea.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `R10 | Status: verified | Changed Files: scripts/track-b/launch-packaged-runtime.mjs; scripts/track-b/run80-recommendation-bindings.mjs; tests/track-b/run80-recommendation-bindings.test.mjs | Implementation Evidence: scripts/track-b/launch-packaged-runtime.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `R11 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R12 | Status: implemented | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md; scripts/track-b/launch-packaged-runtime.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Audit Note: paired feature branches exist in both worktrees; origin/dev merge deferred until user-requested delivery`
+
+## Audit Verdict
+
+Audit: PASS
+
+Phase 3 implementation evidence matches the locked plan intent for live `--track=dev` signed recommendation lifecycle on a rebuilt SEA. Anticipatory Phase 3–8 documentation was rejected and removed before this receipt. Ready to lock after Coverage/Approval checklists.
+
+## Coverage Gate
+
+- [x] Every in-scope `R1`–`R12` has a `Requirement Completion Status` entry
+- [x] `TDD Mode: strict` declared with RED/GREEN evidence paths for harness production changes
+- [x] Actual private/public changed files reconciled to Phase 2 planned surface (deviations listed)
+- [x] Live hops cite rebuilt SEA sha256 and are not substituted by historical PCR
+- [x] Secrets omitted from binder / pass receipts
+- [x] KW `productionActivation` remains hard-off (TB10 green; KW untouched)
+- [x] Phase 6–8 control-plane docs not prematurely edited
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] All TODO items checked
+- [x] Audit: PASS
+- [x] Coverage: PASS
+- [x] No unexplained product drift vs planned surface
+- [x] Ready to lock Phase 3 before starting Phase 3.5
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md
@@ -1,0 +1,247 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `03.5 CODE REVIEW`
+Status: `LOCKED`
+LockedAt: `2026-07-24T11:58:45Z`
+LockHash: `fd9adf89255da94bcb492be3f45c6913d409bf56c9c2d2efffca28644d65d197`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md`
+- Public worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Private worktree: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md`
+Scope note: Defect-first code review of the real Phase 3 private harness + public additive test diff for live `--track=dev` signed recommendation lifecycle. Self-audit after prior delegated authoring falsified anticipatory phase docs.
+
+## Review Metadata
+
+- Review Bundle Path: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md`
+- Reviewer role: code-reviewer (controller self-audit)
+- Diff basis: private `739ef35bcc2d3c747696c4a22d74e4718cf1229b`..working-tree; public `420770884be5999267992666a5f71913adb5a7c8`..working-tree
+
+## TODO
+
+- [x] Generate canonical review bundle from locked Phase 3 + real changed files
+- [x] Re-read upstream artifacts and inspect changed code/tests/evidence
+- [x] Record findings by severity
+- [x] Apply non-blocking hygiene repair (omit secret material key names from lifecycle report)
+- [x] Complete Coverage / Approval gates for lock
+
+## Review Scope
+
+- Sub-phases reviewed: SP1–SP5
+- Surfaces: recommendation bindings, launch parameterization, permanent-dev seed helper, live lifecycle driver, public opt-out regression test, rebuild/live evidence binder
+- Upstream artifacts re-read from the bundle: `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- Prior recursive evidence from the bundle: `.recursive/memory/skills/SKILLS.md`, `.recursive/memory/skills/usage/review-bundle-citation-requirements.md`
+- Changed files / code refs from the bundle: `scripts/track-b/run80-recommendation-bindings.mjs`, `scripts/track-b/launch-packaged-runtime.mjs`, `scripts/track-b/run80-live-recommendation-lifecycle.mjs`, `scripts/track-b/run80-seed-signed-recommendations.mjs`, `tests/track-b/run80-recommendation-bindings.test.mjs`, `evidence/live-e2e/cloud-track-dev.json`
+- Public change-set: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md` (additive opt-out test only)
+- Review Bundle Path cited: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md`
+
+## Plan Alignment Assessment
+
+- **R1–R4**: Seed + lifecycle + live PASS evidence aligned with locked plan; hop order deviation (apply→reseed→dismiss) documented in Phase 3 and acceptable.
+- **R5**: No unsigned bypass; production track refused; predecessor public trust suite retained.
+- **R6**: Additive opt-out test only; no product source change — aligned.
+- **R7**: KW untouched; TB10 green — aligned.
+- **R8**: Strict RED/GREEN for bindings/launch — aligned.
+- **R9–R11**: Rebuild receipt + binder + live pass cite same SEA sha — aligned.
+- **R12**: Paired feature branches present; origin merge deferred — aligned with Phase 3 status `implemented`.
+
+## Code Quality Assessment
+
+### Architecture & Design
+- Shared bindings module used by launch + lifecycle + seed: OK
+- Prefer existing public recommendation APIs; no parallel unsigned endpoints: OK
+- Windows-safe scope seeding (`run80-dev`): OK
+
+### Code Quality
+- Naming / structure: OK
+- Error handling (missing base URL, missing material, production refuse): OK
+- Secret handling: pass receipts omit key material; one hygiene issue repaired below
+
+### Test Quality
+- Bindings unit tests cover track→channel, public root, production refuse, permanent-dev URL: OK
+- Public opt-out independence additive case: OK
+- Live hops are integration evidence, not unit substitutes: OK
+
+### TDD Compliance
+- SP1 RED then GREEN evidence present and cited: OK
+- SP2 additive regression honestly documented without inventing a product RED: OK
+- No KW unlock or unsigned convenience path added “to make green”: OK
+
+## Issues Found
+
+### Critical (must fix before proceeding)
+None.
+
+### Important (should fix)
+None remaining after hygiene repair below.
+
+### Minor (suggestions)
+1. **Launch default without `--track`** still resolves channel fallback to `production` when neither track nor env channel is set — intentional for local PCR compatibility, but operators must pass `--track=dev` for live PASS (already required by lifecycle `assertLiveTrackAllowed` + Phase 3 evidence).
+2. **`evidence/live-e2e/cloud-track-dev.json`** is an e2e write-evidence byproduct outside the binder contract; keep it out of PASS narration (already treated as non-substituting in Phase 3).
+
+## Repair Work Performed
+
+- Removed `materialKeys: Object.keys(material)` from `run80-live-recommendation-lifecycle.mjs` report payload; replaced with boolean `materialPublicKeyPresent` so evidence logs do not enumerate secret-bearing field names.
+- No public product source changes required.
+
+## Findings Summary
+
+Re-read upstream artifacts from the review bundle: `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`, and `.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`. Prior recursive evidence from the bundle: `.recursive/memory/skills/SKILLS.md` and `.recursive/memory/skills/usage/review-bundle-citation-requirements.md`. Bundle changed-file scope reviewed: `scripts/track-b/run80-recommendation-bindings.mjs`, `scripts/track-b/launch-packaged-runtime.mjs`, `scripts/track-b/run80-live-recommendation-lifecycle.mjs`, `scripts/track-b/run80-seed-signed-recommendations.mjs`, `tests/track-b/run80-recommendation-bindings.test.mjs`, and incidental `evidence/live-e2e/cloud-track-dev.json`. Evidence refs from the bundle: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`, and `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md`.
+
+- Blocking defects: 0
+- Important defects remaining: 0
+- Minor notes: 2 (non-blocking)
+- Hygiene repair applied: omit secret material key-name enumeration from lifecycle report payload
+
+## Traceability
+
+- R1 → permanent-dev seed/probe | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`
+- R2 → live download | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- R3 → live apply + active-pack | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- R4 → live dismiss | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- R5 → production refuse / no unsigned bypass | `scripts/track-b/run80-recommendation-bindings.mjs`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- R6 → opt-out independence | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+- R7 → KW hard-off | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`
+- R8 → strict TDD | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log`, `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- R9 → rebuilt SEA | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- R10 → parameterized launch | `scripts/track-b/launch-packaged-runtime.mjs`
+- R11 → binder | `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- R12 → paired worktrees | `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+
+## Verdict
+
+- [x] **APPROVED** - Ready to proceed to Phase 4
+- [ ] **APPROVED WITH NOTES** - Minor issues, can proceed
+- [ ] **CHANGES REQUIRED** - Fix issues, then re-review
+
+Review verdict grounded in review bundle `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md`: no blocking defects; live pass + binder + RED/GREEN evidence corroborate Phase 3 claims; hygiene repair applied for evidence secret-field enumeration.
+
+## Changed Files Reviewed
+
+Private:
+- `scripts/track-b/run80-recommendation-bindings.mjs`
+- `scripts/track-b/launch-packaged-runtime.mjs`
+- `scripts/track-b/run80-live-recommendation-lifecycle.mjs`
+- `scripts/track-b/run80-seed-signed-recommendations.mjs`
+- `tests/track-b/run80-recommendation-bindings.test.mjs`
+
+Public (via change-set + paired worktree inspection):
+- `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts` (additive opt-out case only)
+
+## Targeted Code References
+
+- Bindings: `TRACK_CHANNEL`, `assertLiveTrackAllowed`, `resolveRecommendationServiceUrl` for `--track=dev`
+- Launch: track-aware channel/URL; optional verification key; run-80 public root default
+- Lifecycle: apply→reseed→dismiss default; secret-free pass receipt writer
+- Seed: Windows-safe `run80-dev` scope publish/resolve
+
+## Audit Context
+
+Audit Execution Mode: self-audit  
+Subagent Availability: available  
+Subagent Capability Probe: Task/subagent tooling available; prior delegated authoring recreated anticipatory Phase 3–8 docs and was rejected.  
+Delegation Decision Basis: user directed controller takeover; Phase 3.5 requires review of concrete diffs already on disk.  
+Delegation Override Reason: avoid reintroducing falsified phase docs via delegated authoring; controller performed defect-first review against the review bundle and actual files.  
+Audit Inputs Provided: review bundle path; locked Phase 0–3 artifacts; private/public diffs vs worktree baselines; evidence binder + live pass + RED/GREEN logs.  
+Reviewed Subagent Action Records: none
+
+## Effective Inputs Re-read
+
+- Locked `00-requirements.md`, `00-worktree.md`, `01-as-is.md`, `02-to-be-plan.md`, `03-implementation-summary.md`
+- Review bundle `evidence/review-bundles/03.5-code-review-bundle.md`
+- No addenda
+
+## Earlier Phase Reconciliation
+
+- Diff basis unchanged from locked worktree / Phase 3
+- Phase 3 claim that no public product source change was required is confirmed
+- Hygiene repair to lifecycle report does not change R1–R12 dispositions
+
+## Prior Recursive Evidence Reviewed
+
+- `.recursive/memory/skills/SKILLS.md`
+- `.recursive/memory/skills/usage/review-bundle-citation-requirements.md`
+- Locked Phase 3 evidence cited via review bundle: binder, live-dev-lifecycle-pass, public-product-change-set
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none
+- Main-Agent Verification: re-read review bundle; inspected changed scripts/tests; confirmed live pass receipt and binder sha correlation; applied materialKeys hygiene repair
+- Acceptance Decision: accepted
+- Refresh Handling: no subagent records to refresh; bundle retained as review context for this self-audit
+- Repair Performed After Verification: `scripts/track-b/run80-live-recommendation-lifecycle.mjs` materialKeys omission
+
+## Worktree Diff Audit
+
+### Private controller
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Planned or claimed changed files: harness/bindings/seed/lifecycle/tests + run evidence
+- Actual changed files reviewed: as listed in Review Scope / Changed Files Reviewed; plus Phase 3.5 hygiene edit to lifecycle report writer
+- Unexplained drift: none
+
+### Paired public implementation
+
+- Public normalized baseline: `420770884be5999267992666a5f71913adb5a7c8`
+- Public normalized comparison: `working-tree`
+- Public normalized diff command: `git diff --name-only 420770884be5999267992666a5f71913adb5a7c8`
+- Actual changed files reviewed: additive opt-out test only
+- Unexplained drift: none
+
+## Gaps Found
+
+None blocking Phase 3.5 lock. Later phases still own formal test-summary aggregation (Phase 4), QA scenarios (Phase 5), and DECISIONS/STATE/memory clearance (Phases 6–8).
+
+## Requirement Completion Status
+
+- `R1 | Status: verified | Changed Files: scripts/track-b/run80-seed-signed-recommendations.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`
+- `R2 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs; scripts/track-b/launch-packaged-runtime.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R3 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R4 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs; scripts/track-b/run80-seed-signed-recommendations.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R5 | Status: verified | Changed Files: scripts/track-b/run80-recommendation-bindings.mjs; tests/track-b/run80-recommendation-bindings.test.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `R6 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+- `R7 | Status: verified | Changed Files: tests/track-b/tb10.test.mjs; extensions/knowledge-worker/index.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`
+- `R8 | Status: verified | Changed Files: tests/track-b/run80-recommendation-bindings.test.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `R9 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json; scripts/track-b/launch-packaged-runtime.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `R10 | Status: verified | Changed Files: scripts/track-b/launch-packaged-runtime.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: scripts/track-b/launch-packaged-runtime.mjs | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `R11 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R12 | Status: implemented | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md | Audit Note: paired branches present; origin/dev merge deferred`
+
+## Audit Verdict
+
+Audit: PASS
+
+No blocking defects. Hygiene repair applied for evidence secret-field enumeration. Ready to lock Phase 3.5 before Phase 4.
+
+## Coverage Gate
+
+- [x] Review bundle path recorded
+- [x] Upstream artifacts and changed files cited in narrative
+- [x] Findings ordered by severity
+- [x] TDD / plan / trust / KW gates reviewed
+- [x] Requirement Completion Status present for R1–R12
+- [x] Diff basis matches locked worktree
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] All TODO items checked
+- [x] Audit: PASS
+- [x] Coverage: PASS
+- [x] No critical/important defects remaining
+- [x] Ready to lock before Phase 4
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md
@@ -1,0 +1,235 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `04 Test Summary`
+Status: `LOCKED`
+LockedAt: `2026-07-24T12:01:58Z`
+LockHash: `366f4fbd5ed4d0a27d317c302f47bdef1a837d7007aa3954ee4dc242e8fff157`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+Scope note: Records automated offline regression plus already-captured rebuild and live `--track=dev` verification evidence for run 80 after Phase 3.5 review, before Manual QA.
+
+## TODO
+
+- [x] Record the pre-test implementation audit and execution environment
+- [x] Capture exact commands, evidence, and final results
+- [x] Confirm strict TDD RED/GREEN evidence
+- [x] Confirm rebuilt runtime and live `--track=dev` verification already on disk
+- [x] Complete audited Phase 4 gates
+
+## Pre-Test Implementation Audit
+
+- Requirement alignment: locked Phase 3/3.5 map R1–R12 to harness bindings, seed/lifecycle drivers, opt-out regression, rebuilt SEA, live download/apply/dismiss, binder, KW hard-off, paired worktrees.
+- Plan alignment: SP1–SP5 from locked Phase 2 are represented in executed evidence.
+- Phase 3.5 hygiene repair (`materialKeys` omitted from lifecycle report) does not invalidate prior live PASS receipts (pass receipt never included secret values).
+- Diff ownership: private harness/scripts/tests + public additive opt-out test only; no unexplained product drift.
+- Mismatches found: none blocking.
+
+## Environment
+
+- OS: Windows 10 / win32 (`10.0.26200`)
+- Controller worktree: `D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Public implementation worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+- Package manager: `corepack pnpm`
+- Test frameworks: Node test runner, Vitest
+- Live verification URL used for Phase 3 hops: `http://127.0.0.1:34583`
+- Fresh public packaged artifact: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/dist/release/win32-x64/role-model-dev.exe`
+- Fresh public packaged artifact sha256: `825f9b4f2e17f5102605b24943b974efa435133452f0cfa5867b389c14927f84`
+
+## Execution Mode
+
+- Mode: sequential controller-operated test execution across private and public worktrees
+- Subagent usage: none for command execution in this phase
+- TDD Mode: strict
+- RED evidence root: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/`
+- GREEN evidence root: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/`
+
+## Commands Executed (Exact)
+
+Private worktree (`D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+
+- `node --test tests/track-b/run80-recommendation-bindings.test.mjs`
+- `node --test tests/track-b/tb10.test.mjs`
+
+Public worktree (`D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`):
+
+- `corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-operations-api.test.ts`
+
+Already captured in Phase 3 (cited, not re-executed in this Phase 4 pass):
+
+- `corepack pnpm build:run00-runtime`
+- `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT=<private>/dist/run00-dev corepack pnpm runtime:package-sea`
+- `node scripts/track-b/run80-seed-signed-recommendations.mjs --track=dev --scope-id=run80-dev`
+- `node scripts/track-b/run80-live-recommendation-lifecycle.mjs --track=dev --base-url=http://127.0.0.1:34583 --scope-id=run80-dev`
+
+## Results Summary
+
+| Suite | Result | Evidence |
+|---|---|---|
+| Bindings unit tests | 5/5 PASS | `evidence/logs/phase4/bindings.log` |
+| TB10 KW hard-off | 26/26 PASS | `evidence/logs/phase4/tb10.log` |
+| Public Track B operations API | 16/16 PASS | `evidence/logs/phase4/public-ops-api.log` |
+| SP1 RED (historical) | FAIL as expected | `evidence/logs/red/sp1-launch-track.log` |
+| SP1 GREEN | 5/5 PASS | `evidence/logs/green/sp1-launch-track.log` |
+| SP2 opt-out GREEN | 1 passed \| 15 skipped (targeted) | `evidence/logs/green/sp2-optout.log` |
+| Rebuild SEA | PASS | `evidence/other/rebuild-receipt.json` |
+| Live `--track=dev` apply+dismiss | PASS | `evidence/logs/live-dev-lifecycle-pass.json` |
+
+Overall Phase 4 automated verdict: PASS
+
+## Evidence and Artifacts
+
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log`
+
+## Failures and Diagnostics (if any)
+
+None in the Phase 4 re-run suite. Historical RED log retained as TDD evidence only. Earlier stale-bundle FAIL in `live-dev-lifecycle.json` is diagnostic history superseded by `live-dev-lifecycle-pass.json`.
+
+## Flake/Rerun Notes
+
+None required for Phase 4 offline suites (bindings, TB10, public ops API all green on first Phase 4 execution).
+
+## Traceability
+
+- R1 → seed/probe + material availability | material-probe + seed logs + binder
+- R2 → live download | live-dev-lifecycle-pass.json
+- R3 → live apply + active-pack | live-dev-lifecycle-pass.json
+- R4 → live dismiss | live-dev-lifecycle-pass.json
+- R5 → fail-closed / production refuse | bindings + public-ops-api
+- R6 → opt-out independence | green/sp2-optout + public-ops-api
+- R7 → KW hard-off | phase4/tb10.log
+- R8 → strict TDD | red/sp1 + green/sp1
+- R9 → rebuilt SEA | rebuild-receipt + binder
+- R10 → parameterized launch | bindings + launch helper
+- R11 → binder | binder.json
+- R12 → paired delivery | 00-worktree + dual diffs
+
+## Audit Context
+
+Audit Execution Mode: self-audit  
+Subagent Availability: available  
+Subagent Capability Probe: Task/subagent tooling available; controller executes and audits Phase 4 after prior delegated doc falsification.  
+Delegation Decision Basis: user directed controller takeover for phase docs grounded in real work.  
+Delegation Override Reason: avoid anticipatory/falsified closeout docs; controller ran commands and verified logs on disk.  
+Audit Inputs Provided: locked Phase 0–3.5; Phase 4 command logs; binder; live pass; rebuild receipt; diff basis from 00-worktree.  
+Reviewed Subagent Action Records: none
+
+## Effective Inputs Re-read
+
+- Locked `00-requirements.md`, `00-worktree.md`, `02-to-be-plan.md`, `03-implementation-summary.md`, `03.5-code-review.md`
+- No Phase 4 addenda
+
+## Earlier Phase Reconciliation
+
+- Diff basis unchanged: private `739ef35bcc2d3c747696c4a22d74e4718cf1229b`, public `420770884be5999267992666a5f71913adb5a7c8`, comparison `working-tree`
+- Phase 3.5 hygiene repair acknowledged; live PASS evidence remains valid
+- No unfinished in-scope product work found in pre-test audit
+
+## Prior Recursive Evidence Reviewed
+
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `.recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md` (predecessor live signed-material deferral closed by this run’s live pass)
+- `.recursive/memory/skills/SKILLS.md`
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none
+- Main-Agent Verification: re-ran bindings/TB10/public ops; confirmed exit 0 and log tails; re-read live pass + rebuild receipt
+- Acceptance Decision: accepted
+- Refresh Handling: no subagent records to refresh
+- Repair Performed After Verification: none required in Phase 4
+
+## Worktree Diff Audit
+
+### Private controller
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Planned or claimed changed files: harness/bindings/seed/lifecycle/tests + run evidence
+- Actual changed files reviewed: same set as Phase 3/3.5; Phase 4 adds evidence logs under `evidence/logs/phase4/`
+- Unexplained drift: none
+
+### Paired public implementation
+
+- Public normalized baseline: `420770884be5999267992666a5f71913adb5a7c8`
+- Public normalized comparison: `working-tree`
+- Public normalized diff command: `git diff --name-only 420770884be5999267992666a5f71913adb5a7c8`
+- Actual changed files reviewed: additive opt-out test only
+- Unexplained drift: none
+
+## Gaps Found
+
+None blocking Phase 4 lock. Playwright UI Tier B not re-executed this phase (API live hops satisfy preview residual); optional UI evidence remains Phase 5 additive if exercised.
+
+## Repair Work Performed
+
+None in Phase 4.
+
+## Requirement Completion Status
+
+- `R1 | Status: verified | Changed Files: scripts/track-b/run80-seed-signed-recommendations.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+- `R2 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R3 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R4 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R5 | Status: verified | Changed Files: scripts/track-b/run80-recommendation-bindings.mjs; tests/track-b/run80-recommendation-bindings.test.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `R6 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+- `R7 | Status: verified | Changed Files: tests/track-b/tb10.test.mjs; extensions/knowledge-worker/index.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `R8 | Status: verified | Changed Files: tests/track-b/run80-recommendation-bindings.test.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `R9 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `R10 | Status: verified | Changed Files: scripts/track-b/launch-packaged-runtime.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: scripts/track-b/launch-packaged-runtime.mjs | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+- `R11 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `R12 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md | Audit Note: paired feature-branch delivery verified in both worktrees; origin/dev merge remains operator-requested delivery step outside this test gate`
+
+## Audit Verdict
+
+Audit: PASS
+
+## Coverage Gate
+
+- [x] Pre-test audit completed against locked Phase 3/3.5 and owned diffs
+- [x] Exact commands and evidence paths recorded
+- [x] Offline suites green in Phase 4 re-run
+- [x] Live `--track=dev` + rebuild evidence cited (non-substituting PCR)
+- [x] Requirement Completion Status for R1–R12 present
+- [x] TDD RED/GREEN paths retained
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] All TODO items checked
+- [x] Audit: PASS
+- [x] Coverage: PASS
+- [x] Ready to lock Phase 4 before Manual QA
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md
@@ -1,0 +1,199 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `05 Manual QA`
+Status: `LOCKED`
+LockedAt: `2026-07-24T12:03:39Z`
+LockHash: `0c62b237693edae1d36b97d714f8e21d0c1e2cfd7e6d5af1a5fb7a43fbedeaab`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+Scope note: Agent-operated QA for live `--track=dev` signed recommendation download/apply/dismiss on the rebuilt SEA, plus offline trust/opt-out/KW guardrails. Closes the run-79 live signed-material deferral for this run.
+
+QA Execution Mode: agent-operated
+
+## TODO
+
+- [x] Declare QA Execution Mode: agent-operated
+- [x] Record execution metadata, tools, preview URL, SEA hash
+- [x] Execute/record M1–M8 against real evidence
+- [x] Confirm no human sign-off claimed
+- [x] Complete Coverage / Approval gates
+
+## QA Execution Record
+
+QA Execution Mode: agent-operated
+- Agent Executor: controller in Cursor session (self-operated QA after rejecting falsified anticipatory docs)
+- Tools Used: Node test runner, Vitest, Cloudflare permanent-dev recommendation service, rebuilt `role-model-dev.exe`, `run80-seed-signed-recommendations.mjs`, `run80-live-recommendation-lifecycle.mjs`
+- Preview / live base URL: `http://127.0.0.1:34583`
+- Scope id: `run80-dev`
+- Channel: `development`
+- Service host: `https://recommendations-dev.role-model.dev`
+- Fresh packaged artifact: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/dist/release/win32-x64/role-model-dev.exe`
+- Fresh packaged artifact sha256: `825f9b4f2e17f5102605b24943b974efa435133452f0cfa5867b389c14927f84`
+- SEA confirmed present at Phase 5 authoring with matching sha256
+- Agent evidence:
+  - `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+  - `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`
+  - `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+  - `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+  - `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+  - `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+  - `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+
+## QA Scenarios and Results
+
+| Scenario | Expected | Observed | Pass/Fail | Notes |
+| --- | --- | --- | --- | --- |
+| M1 — Material probe `--track=dev` | Resolvable signed id from permanent-dev | Seed/publish PASS for scope `run80-dev`; probe recorded host/channel/sequences without secrets | PASS | `material-probe-dev.json`, seed logs |
+| M2 — Rebuilt SEA live download | Download imports validated rows on fresh SEA | downloadStatus 200; id `recommendation-7f764e25a078716f1d3935f35d58ca1b` validated then applied path | PASS | `live-dev-lifecycle-pass.json`; SEA sha matched rebuild receipt |
+| M3 — Live apply + active-pack | Apply sets applied + activePack | applyStatus 200; activePackId matches applied id | PASS | same live pass receipt |
+| M4 — Live dismiss without apply | Dismiss terminates without applying that id | After reseed, dismissStatus 200 for `recommendation-aec9c8596b18bebbe231be7dbe396be0` | PASS | apply→reseed→dismiss order |
+| M5 — KW hard-off | TB10 green; no unlock | TB10 26/26 PASS in Phase 4 re-run | PASS | `phase4/tb10.log` |
+| M6 — Rebuilt runtime gate | Live hops target fresh SEA only | rebuild receipt sha = live SEA sha = Phase 5 file hash check | PASS | `rebuild-receipt.json` |
+| M7 — Offline trust matrix | Fail-closed / production refuse / ops suite green | Bindings production refuse + public ops API 16/16 PASS | PASS | `phase4/bindings.log`, `phase4/public-ops-api.log` |
+| M8 — Opt-out independence | Opt-out does not revoke eligible import | run80 opt-out case green inside ops suite | PASS | `green/sp2-optout.log`, `phase4/public-ops-api.log` |
+
+Overall Phase 5 verdict: PASS
+
+## Live Cloud Signed-Material Note
+
+Run 79 deferred live bound-cloud signed-material apply/dismiss. This Phase 5 closes that deferral for `--track=dev` using rebuilt SEA evidence in `live-dev-lifecycle-pass.json`. Historical PCR/local proofs are not substituted (`binder.json` `historicalPcrNotSubstituted: true`).
+
+## Evidence and Artifacts
+
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log`
+
+## User Sign-Off
+
+- Approved by: N/A
+- Date: N/A
+- Notes: QA Execution Mode is `agent-operated`; human sign-off is not required. No human or hybrid QA is claimed.
+
+## Traceability
+
+- M1→R1, M2→R2, M3→R3, M4→R4, M5→R7, M6→R9, M7→R5, M8→R6
+- R8/R10/R11/R12 covered by Phase 3/4 evidence cited above
+
+## Audit Context
+
+Audit Execution Mode: self-audit  
+Subagent Availability: available  
+Subagent Capability Probe: available; controller operates QA directly  
+Delegation Decision Basis: user directed controller takeover after falsified anticipatory docs  
+Delegation Override Reason: agent-operated QA executed/verified by controller against on-disk evidence and SEA hash re-check  
+Audit Inputs Provided: locked Phase 0–4; live pass; rebuild receipt; Phase 4 logs; binder  
+Reviewed Subagent Action Records: none
+
+## Effective Inputs Re-read
+
+- Locked Phase 0–4 artifacts listed under Inputs
+- Manual QA scenarios M1–M8 from locked `02-to-be-plan.md`
+- No Phase 5 addenda
+
+## Earlier Phase Reconciliation
+
+- Diff basis unchanged from `00-worktree.md`
+- Phase 4 overall PASS preserved
+- Live cloud deferral from run 79 cleared by M2–M4 PASS on rebuilt SEA
+
+## Prior Recursive Evidence Reviewed
+
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md`
+- `.recursive/run/79-extension-control-and-recommendations-qa/05-manual-qa.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none
+- Main-Agent Verification: re-checked SEA hash on disk; re-read live pass + Phase 4 logs; mapped M1–M8 to evidence
+- Acceptance Decision: accepted
+- Refresh Handling: no subagent records to refresh
+- Repair Performed After Verification: none
+
+## Worktree Diff Audit
+
+### Private controller
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Planned or claimed changed files: harness/scripts/tests + run evidence
+- Actual changed files reviewed: unchanged product set vs Phase 4; Phase 5 adds this QA receipt only
+- Unexplained drift: none
+
+### Paired public implementation
+
+- Public normalized baseline: `420770884be5999267992666a5f71913adb5a7c8`
+- Public normalized comparison: `working-tree`
+- Public normalized diff command: `git diff --name-only 420770884be5999267992666a5f71913adb5a7c8`
+- Actual changed files reviewed: additive opt-out test only
+- Unexplained drift: none
+
+## Gaps Found
+
+None blocking Phase 5. Optional browser UI QA not exercised; API preview/list after download satisfies `U3`.
+
+## Repair Work Performed
+
+None in Phase 5.
+
+## Requirement Completion Status
+
+- `R1 | Status: verified | Changed Files: scripts/track-b/run80-seed-signed-recommendations.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json`
+- `R2 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R3 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R4 | Status: verified | Changed Files: scripts/track-b/run80-live-recommendation-lifecycle.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R5 | Status: verified | Changed Files: scripts/track-b/run80-recommendation-bindings.mjs; tests/track-b/run80-recommendation-bindings.test.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `R6 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log`
+- `R7 | Status: verified | Changed Files: tests/track-b/tb10.test.mjs; extensions/knowledge-worker/index.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `R8 | Status: verified | Changed Files: tests/track-b/run80-recommendation-bindings.test.mjs | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log`
+- `R9 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R10 | Status: verified | Changed Files: scripts/track-b/launch-packaged-runtime.mjs; scripts/track-b/run80-recommendation-bindings.mjs | Implementation Evidence: scripts/track-b/launch-packaged-runtime.mjs | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log`
+- `R11 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `R12 | Status: verified | Changed Files: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md | Implementation Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md | Audit Note: paired feature-branch delivery verified; origin/dev merge remains operator-requested`
+
+## Audit Verdict
+
+Audit: PASS
+
+## Coverage Gate
+
+- [x] QA Execution Mode declared agent-operated with execution record
+- [x] M1–M8 recorded with evidence paths
+- [x] SEA hash re-checked; live hops cite rebuilt artifact
+- [x] No human sign-off falsely claimed
+- [x] Run-79 live deferral explicitly closed
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] All TODO items checked
+- [x] Audit: PASS
+- [x] Coverage: PASS
+- [x] Ready to lock Phase 5 before DECISIONS/STATE/memory closeout
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/06-decisions-update.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/06-decisions-update.md
@@ -1,0 +1,141 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `06 Decisions Update`
+Status: `LOCKED`
+LockedAt: `2026-07-24T12:06:47Z`
+LockHash: `47a6ca3096623f0c5a47b2c24c90060b85402d76c6a2340a009581c9541791ec`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md`
+- `/.recursive/DECISIONS.md`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/06-decisions-update.md`
+- `/.recursive/DECISIONS.md`
+Scope note: Compact delta receipt for the global decisions ledger after run-80 live `--track=dev` signed recommendation closeout.
+
+## TODO
+
+- [x] Append run-80 ledger entry and index bullet
+- [x] Soft-close run-79 live signed-material deferral follow-up
+- [x] Keep KW productionActivation OOS
+- [x] Complete audited decision-update gates before locking
+
+## Decisions Changes Applied
+
+- Added Recursive Run Index bullet for `80-signed-recommendation-cloud-lifecycle`.
+- Appended dated run section: live `--track=dev` download/apply/dismiss on rebuilt SEA; harness bindings/seed/lifecycle; public opt-out regression; KW hard-off preserved; origin merge operator-requested.
+- Updated run-79 Known issues to mark live signed-material deferral closed by run 80.
+
+## Rationale
+
+- Phase 6 owns `/.recursive/DECISIONS.md`. Run 80 soft-closes the run-79 deferred live signed-material follow-up without unlocking KW activation.
+
+## Resulting Decision Entry
+
+- Final ledger path: `.recursive/DECISIONS.md`
+- Entry heading: `## Run: \`80-signed-recommendation-cloud-lifecycle\``
+- Soft-close target: run `79-extension-control-and-recommendations-qa` deferred live signed-material follow-up
+
+## Traceability
+
+- R1 → material/seed closeout cited in ledger What changed
+- R2 → live download closeout cited in ledger
+- R3 → live apply closeout cited in ledger
+- R4 → live dismiss closeout cited in ledger
+- R5 → fail-closed / production refuse preserved (no unsigned bypass)
+- R6 → opt-out independence noted via public additive regression
+- R7 → KW productionActivation OOS preserved
+- R8 → strict TDD called out under How
+- R9 → rebuilt SEA hash cited in ledger
+- R10 → harness parameterization cited in ledger
+- R11 → binder cited under Artifact references
+- R12 → paired feature-branch delivery noted; merge operator-requested
+
+## Audit Context
+
+Audit Execution Mode: self-audit  
+Subagent Availability: available  
+Subagent Capability Probe: available; controller owns DECISIONS delta  
+Delegation Decision Basis: factual ledger update from locked Phases 0–5  
+Delegation Override Reason: avoid anticipatory/falsified closeout authorship; controller applies DECISIONS delta after Phase 5 lock  
+Audit Inputs Provided: locked Phase 5; DECISIONS.md; worktree diff basis  
+Reviewed Subagent Action Records: none
+
+## Effective Inputs Re-read
+
+- Locked `05-manual-qa.md`, `04-test-summary.md`, `03-implementation-summary.md`, `00-worktree.md`
+- `.recursive/DECISIONS.md`
+
+## Earlier Phase Reconciliation
+
+- Diff basis unchanged from locked `00-worktree.md`
+- Phase 5 closed live deferral; Phase 6 records that in the ledger
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none
+- Main-Agent Verification: inspected DECISIONS.md for run-80 entry + run-79 soft-close note
+- Acceptance Decision: accepted
+- Refresh Handling: no subagent records to refresh
+- Repair Performed After Verification: none
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Planned or claimed changed files: `.recursive/DECISIONS.md` (Phase 6 owned)
+- Actual changed files reviewed: `.recursive/DECISIONS.md`
+- Unexplained drift: none for Phase 6 ownership
+
+## Gaps Found
+
+None.
+
+## Repair Work Performed
+
+None.
+
+## Requirement Completion Status
+
+- `R1 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `R2 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R3 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R4 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R5 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `R6 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `R7 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `R8 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `R9 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `R10 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `R11 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `R12 | Status: verified | Changed Files: .recursive/DECISIONS.md | Implementation Evidence: .recursive/DECISIONS.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md; .recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+
+## Audit Verdict
+
+Audit: PASS
+
+## Coverage Gate
+
+- [x] DECISIONS.md updated with run-80 entry
+- [x] Run-79 deferral soft-closed in ledger
+- [x] KW OOS preserved
+- [x] Delta receipt points to final ledger (does not duplicate it)
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] All TODO items checked
+- [x] Audit: PASS
+- [x] Coverage: PASS
+- [x] Ready to lock Phase 6
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/07-state-update.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/07-state-update.md
@@ -1,0 +1,152 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `07 State Update`
+Status: `LOCKED`
+LockedAt: `2026-07-24T12:08:00Z`
+LockHash: `495b2838b3b7235166b06e043d54617795edc0124bc6e2f99e521e811cdd04e7`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/06-decisions-update.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/STATE.md`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/07-state-update.md`
+- `/.recursive/STATE.md`
+Scope note: Compact delta receipt for global STATE after run-80 live signed recommendation closeout.
+
+## TODO
+
+- [x] Rewrite STATE.md current truths for run 80
+- [x] Clear run-79 “live signed-material deferred” limitation
+- [x] Keep KW hard-off and no stage/main auto-promotion
+- [x] Complete audited state-update gates before locking
+
+## State Changes Applied
+
+- Updated Current State narrative to include run 80 live `--track=dev` signed recommendation closeout.
+- Pointed active worktrees/diff basis to run-80 feature branches and baselines.
+- Removed “live signed-material deferred” from Known limitations; retained KW hard-off and merge-operator-requested notes.
+- Operational notes now prefer run-80 evidence for live signed hops and keep run-79 evidence for mutate/UI packaging remediations.
+
+## Rationale
+
+- Phase 7 owns `/.recursive/STATE.md`. After Phase 5/6 closed the live signed-material deferral, STATE must describe what is true now for run-80 worktrees, live hops, and remaining KW/promotion limits.
+
+## Resulting State Summary
+
+- Final state path: `.recursive/STATE.md`
+- Current substrate: Direct Track B v1.1 + run-79 mutate/dismiss + run-80 live `--track=dev` signed recommendation lifecycle on rebuilt SEA
+- Cleared limitation: live signed-material apply/dismiss no longer deferred for `--track=dev`
+- Retained limits: KW `productionActivation` hard-off; no stage/main auto-promotion
+
+## Resulting State Doc
+
+- Final state path: `.recursive/STATE.md`
+
+## Traceability
+
+- R1 → permanent-dev material availability reflected in STATE operational notes
+- R2 → live download truth in STATE product truths
+- R3 → live apply + active-pack truth in STATE product truths
+- R4 → live dismiss truth in STATE product truths
+- R5 → fail-closed / no unsigned bypass retained
+- R6 → opt-out independence retained
+- R7 → KW hard-off retained in Known limitations
+- R8 → strict TDD closeout assumed via locked Phases 3–5 (STATE cites run evidence paths)
+- R9 → rebuilt SEA / Track B staging retained
+- R10 → parameterized launch/bindings noted in STATE product truths
+- R11 → binder path cited in operational notes
+- R12 → paired feature-branch worktrees + operator-requested merge noted
+
+## Audit Context
+
+Audit Execution Mode: self-audit  
+Subagent Availability: available  
+Subagent Capability Probe: available  
+Delegation Decision Basis: STATE rewrite from locked Phase 5/6  
+Delegation Override Reason: controller owns STATE after rejecting anticipatory closeouts  
+Audit Inputs Provided: locked 06; STATE.md; worktree baselines  
+Reviewed Subagent Action Records: none
+
+## Effective Inputs Re-read
+
+- Locked `06-decisions-update.md`, `05-manual-qa.md`, `00-worktree.md`
+- `.recursive/DECISIONS.md`, `.recursive/STATE.md`
+
+## Earlier Phase Reconciliation
+
+- Diff basis unchanged
+- DECISIONS soft-close of run-79 deferral reflected in STATE known limitations
+
+## Prior Recursive Evidence Reviewed
+
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/06-decisions-update.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `.recursive/run/79-extension-control-and-recommendations-qa/07-state-update.md`
+- `.recursive/DECISIONS.md`
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none
+- Main-Agent Verification: re-read STATE.md for run-80 truths and cleared deferral language
+- Acceptance Decision: accepted
+- Refresh Handling: no subagent records to refresh
+- Repair Performed After Verification: none
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Planned or claimed changed files: `.recursive/STATE.md` (Phase 7 owned)
+- Actual changed files reviewed: `.recursive/STATE.md`
+- Unexplained drift: none for Phase 7 ownership
+
+## Gaps Found
+
+None.
+
+## Repair Work Performed
+
+None.
+
+## Requirement Completion Status
+
+- `R1 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `R2 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R3 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R4 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R5 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `R6 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `R7 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log`
+- `R8 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `R9 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `R10 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `R11 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `R12 | Status: verified | Changed Files: .recursive/STATE.md | Implementation Evidence: .recursive/STATE.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+
+## Audit Verdict
+
+Audit: PASS
+
+## Coverage Gate
+
+- [x] STATE.md reflects what is true now after run 80
+- [x] Live deferral language cleared
+- [x] KW hard-off retained
+- [x] Delta receipt points to final STATE doc
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] All TODO items checked
+- [x] Audit: PASS
+- [x] Coverage: PASS
+- [x] Ready to lock Phase 7
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/08-memory-impact.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/08-memory-impact.md
@@ -1,0 +1,212 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `08 Memory Impact`
+Status: `LOCKED`
+LockedAt: `2026-07-24T12:09:06Z`
+LockHash: `ab5ed62baac7ee77bbf10ee21ae8618f301d7bc9a22bf08b8de45c330ee0b20a`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/06-decisions-update.md`
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/07-state-update.md`
+- `/.recursive/DECISIONS.md`
+- `/.recursive/STATE.md`
+- `/.recursive/memory/MEMORY.md`
+- `/.recursive/memory/skills/SKILLS.md`
+- `/.recursive/memory/domains/direct-track-b.md`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/08-memory-impact.md`
+- `/.recursive/memory/MEMORY.md`
+- `/.recursive/memory/domains/direct-track-b.md`
+- `/.recursive/memory/skills/usage/review-bundle-citation-requirements.md`
+- `/.recursive/memory/skills/issues/anticipatory-phase-docs.md`
+Scope note: Compact memory-plane delta for run 80 live `--track=dev` signed recommendation closeout plus the durable process lesson against anticipatory Phase 3–8 docs.
+
+## TODO
+
+- [x] Review affected memory docs and freshness outcomes
+- [x] Document uncovered paths and router/parent refresh work
+- [x] Capture run-local skill usage and promotion decisions
+- [x] Refresh domain memory for live signed lifecycle
+- [x] Complete the audited memory-impact gates before locking
+
+## Diff Basis
+
+- Base commit / anchor (private): `739ef35bcc2d3c747696c4a22d74e4718cf1229b` from locked `00-worktree.md`
+- Head commit / comparison target: working-tree
+- Public product inventory: `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md`
+- Exclusions applied: incidental `__pycache__`/`*.pyc`; run-folder evidence logs treated as evidence citations
+
+## Changed Paths Review
+
+- Private harness paths under `scripts/track-b/` and `tests/track-b/`: covered by `domains/direct-track-b.md` Owns-Paths.
+- Public additive test under `role-model-router/apps/runtime-host-bridge/test/`: covered by domain Watch-Paths.
+- Control-plane `.recursive/DECISIONS.md` / `.recursive/STATE.md`: owned by Phases 6–7; reviewed for memory consistency.
+- Memory plane updates: domain refresh + review-bundle citation refresh + new anticipatory-phase-docs issue shard.
+
+## Affected Memory Docs
+
+- `.recursive/memory/domains/direct-track-b.md`
+  - Prior status: CURRENT (run-79 mutate/dismiss/UI)
+  - Final status: CURRENT
+  - Change summary: records run-80 live `--track=dev` signed recommendation lifecycle; Windows-safe scope notes; Source-Runs includes run 80
+- `.recursive/memory/skills/usage/review-bundle-citation-requirements.md`
+  - Final status: CURRENT
+  - Change summary: notes citation placement in linter-scanned narrative sections; Source-Runs includes run 80
+- `.recursive/memory/skills/issues/anticipatory-phase-docs.md`
+  - Final status: CURRENT (new)
+  - Change summary: durable rule — do not author Phase 3–8 docs before that phase’s real work
+- `.recursive/memory/MEMORY.md`
+  - Final status: CURRENT router
+  - Change summary: registry blurb + new skill-issue entry
+
+## Run-Local Skill Usage Capture
+
+- Skill Usage Relevance: relevant
+- Available Skills: recursive-mode; recursive-tdd; recursive-review-bundle; recursive-worktree; recursive-subagent; recursive-lock; recursive-closeout
+- Skills Sought: recursive-mode phase lock/closeout; recursive-tdd; recursive-review-bundle; recursive-lock
+- Skills Attempted: recursive-mode; recursive-tdd; recursive-review-bundle; recursive-lock; Task explore/inventory; Task anticipatory Phase 3–8 authoring (rejected)
+- Skills Used: recursive-mode; recursive-tdd; recursive-review-bundle; recursive-lock; recursive-closeout
+- Worked Well: recursive-lock lint gates; review-bundle citation checks; controller-authored phase receipts after real evidence
+- Issues Encountered: delegated/anticipatory Phase 3–8 docs recreated before work; required delete/reopen and controller takeover
+- Future Guidance: write each phase doc only after that phase’s real work; lock before advancing; do not batch-write Phases 3–8
+- Promotion Candidates: anticipatory-phase-docs skill issue (promoted); review-bundle citation placement note (promoted)
+
+## Skill Memory Promotion Review
+
+- Durable Skill Lessons Promoted: anticipatory-phase-docs issue shard; review-bundle citation placement refresh
+- Generalized Guidance Updated: `.recursive/memory/MEMORY.md` registry; `domains/direct-track-b.md`
+- Run-Local Observations Left Unpromoted: SEA sha256 strings, recommendation ids, listen ports (cite run evidence instead)
+- Promotion Decision Rationale: process falsification lesson is durable; hop-specific ids are run evidence only
+
+## Uncovered Paths
+
+- None remaining after domain Owns/Watch paths cover `scripts/track-b/`, `tests/track-b/`, and public host-bridge test surfaces.
+
+## Router and Parent Refresh
+
+- `.recursive/memory/MEMORY.md`: domain blurb + anticipatory-phase-docs registry entry refreshed
+- `.recursive/memory/skills/SKILLS.md`: no structural change required; usage/issues shards updated under skills/
+
+## Final Status Summary
+
+- Domain memory CURRENT with run-79 mutate/dismiss + run-80 live signed recommendation lifecycle; KW activation remains hard-off.
+- Review-bundle citation usage shard CURRENT.
+- Anticipatory-phase-docs issue shard CURRENT.
+- No uncovered product paths for this closeout.
+
+## Traceability
+
+- R1 → domain memory live material/seed notes
+- R2 → domain memory live download closeout
+- R3 → domain memory live apply closeout
+- R4 → domain memory live dismiss closeout
+- R5 → fail-closed / production refuse retained in domain notes
+- R6 → opt-out independence retained in domain notes
+- R7 → KW hard-off retained in domain summary
+- R8 → anticipatory-phase-docs / TDD process lesson promoted
+- R9 → SEA Track B staging retained in domain notes
+- R10 → parameterized launch/bindings retained in domain notes
+- R11 → binder evidence paths cited from domain operating notes
+- R12 → paired delivery remains STATE/DECISIONS; MEMORY registry updated for run 80 source
+
+## Audit Context
+
+Audit Execution Mode: self-audit  
+Subagent Availability: available  
+Subagent Capability Probe: available  
+Delegation Decision Basis: memory delta grounded in locked Phases 6–7 + final diffs  
+Delegation Override Reason: controller takeover after anticipatory doc rejection  
+Audit Inputs Provided: Phases 6–7 receipts, STATE/DECISIONS, MEMORY/domain/skill shards  
+Reviewed Subagent Action Records: none
+
+## Effective Inputs Re-read
+
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/06-decisions-update.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/07-state-update.md`
+- `.recursive/DECISIONS.md`
+- `.recursive/STATE.md`
+- `.recursive/memory/MEMORY.md`
+- `.recursive/memory/domains/direct-track-b.md`
+
+## Earlier Phase Reconciliation
+
+- Phases 6–7 control-plane truths mirrored into domain memory
+- Diff basis unchanged from locked `00-worktree.md`
+
+## Prior Recursive Evidence Reviewed
+
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `.recursive/run/79-extension-control-and-recommendations-qa/08-memory-impact.md`
+- `.recursive/memory/skills/usage/review-bundle-citation-requirements.md`
+
+## Subagent Contribution Verification
+
+- Reviewed Action Records: none
+- Main-Agent Verification: re-read MEMORY registry, domain doc, skill issue/usage shards
+- Acceptance Decision: accepted
+- Refresh Handling: no subagent records to refresh
+- Repair Performed After Verification: none
+
+## Worktree Diff Audit
+
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Planned or claimed changed files: `.recursive/memory/**` (Phase 8 owned)
+- Actual changed files reviewed:
+  - `.recursive/memory/MEMORY.md`
+  - `.recursive/memory/domains/direct-track-b.md`
+  - `.recursive/memory/skills/usage/review-bundle-citation-requirements.md`
+  - `.recursive/memory/skills/issues/anticipatory-phase-docs.md`
+- Unexplained drift: none for Phase 8 ownership
+
+## Gaps Found
+
+None.
+
+## Repair Work Performed
+
+None.
+
+## Requirement Completion Status
+
+- `R1 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/05-manual-qa.md`
+- `R2 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R3 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R4 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `R5 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `R6 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/04-test-summary.md`
+- `R7 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/STATE.md`
+- `R8 | Status: verified | Changed Files: .recursive/memory/skills/issues/anticipatory-phase-docs.md | Implementation Evidence: .recursive/memory/skills/issues/anticipatory-phase-docs.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `R9 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json`
+- `R10 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+- `R11 | Status: verified | Changed Files: .recursive/memory/domains/direct-track-b.md | Implementation Evidence: .recursive/memory/domains/direct-track-b.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `R12 | Status: verified | Changed Files: .recursive/memory/MEMORY.md | Implementation Evidence: .recursive/memory/MEMORY.md | Verification Evidence: .recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+
+## Audit Verdict
+
+Audit: PASS
+
+## Coverage Gate
+
+- [x] Diff basis / changed paths / affected memory docs recorded
+- [x] Run-local skill usage fields complete
+- [x] Skill promotion review recorded
+- [x] Router/parent refresh recorded
+- [x] Final status summary present
+
+Coverage: PASS
+
+## Approval Gate
+
+- [x] All TODO items checked
+- [x] Audit: PASS
+- [x] Coverage: PASS
+- [x] Ready to lock Phase 8
+
+Approval: PASS

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/addenda/03-implementation-summary.post-lock-operator-verify-mode-control-alignment.addendum-01.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/addenda/03-implementation-summary.post-lock-operator-verify-mode-control-alignment.addendum-01.md
@@ -1,0 +1,78 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `03 IMPLEMENTATION`
+Status: `DRAFT`
+CapturedAt: `2026-07-24T21:10:00+08:00`
+Workflow version: `recursive-mode-audit-v2`
+Inputs:
+- Locked `03-implementation-summary.md` (Phases 0–8 complete for run 80)
+- Operator verify on packaged SEA `http://127.0.0.1:34590/app/system/extensions` (2026-07-24)
+- Operator screenshot of Mode `SelectField` + **Set mode** button misalignment
+- Public worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`
+Outputs:
+- `/.recursive/run/80-signed-recommendation-cloud-lifecycle/addenda/03-implementation-summary.post-lock-operator-verify-mode-control-alignment.addendum-01.md`
+- Public remediations:
+  - `role-model-router/apps/runtime-ui/app/lib/design-system.ts`
+  - `role-model-router/apps/runtime-ui/app/routes/extensions.tsx`
+  - `role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx`
+Scope note: Stage-local plan + remediation addendum for a post-lock Extensions UX defect: Mode select and Set mode button misalignment / oversized button. Does **not** change recommendation download/apply/dismiss. Does **not** unlock Knowledge Worker `productionActivation`.
+
+## TODO
+
+- [x] Capture operator-verify UX defect with evidence
+- [x] Author remediation plan (files, class strategy, acceptance)
+- [x] Land public UI remediation in `extensions.tsx` (+ design-system compact field buttons + test)
+- [x] Rebuild UI + Track-B-staged SEA; relaunch on `http://127.0.0.1:34590`
+- [x] Unit test green (`extensions.test.tsx` 2/2)
+- [ ] Operator visual re-verify Mode row alignment (awaiting operator)
+- [x] Complete Coverage / Approval gates for remediation landing
+
+## Addendum Content
+
+### Discovery
+
+During operator Manual QA against the run-80 SEA (`http://127.0.0.1:34590`), **download and apply worked**. On the Extensions card Mode control row, the operator observed:
+
+1. **Height mismatch:** **Set mode** used `primaryButtonClassName` / `secondaryButtonClassName` (`min-h-[44px]`, pill) while `SelectField` trigger uses `selectFieldClassName` (`min-h-[40px]`, field radius).
+2. **Vertical alignment:** taller pill button looked oversized beside the select under the `MODE` label.
+3. **Visual language mismatch:** pill CTA beside field-radius select.
+
+### Remediation plan (executed)
+
+| Item | Plan | Status |
+|---|---|---|
+| Scope | Public runtime-ui Mode row only | Done |
+| Global buttons | Leave `primaryButtonClassName` / `secondaryButtonClassName` unchanged | Done |
+| New tokens | `compactFieldButtonClassName` + `compactFieldButtonEmphasisClassName` (`h-10`/`min-h-[40px]`, `rm-radius-field`, 13px) | Done |
+| Extensions row | **Set mode** uses compact tokens; dirty → emphasis | Done |
+| Tests | Assert compact tokens; reject Mode-row primary swap | Done (`extensions.test.tsx` PASS) |
+| Package | `runtime:package-sea` with Track B root; static assets under release `build/client` include compact classes | Done |
+| Operator re-verify | Hard-refresh Extensions; confirm select + Set mode height/align | Pending operator |
+
+### Rationale
+
+Preserves locked Phase 3 history while authorizing the effective UI density fix found in post-lock operator verify.
+
+### Impact on phase output
+
+- Locked `03-implementation-summary.md` text unchanged.
+- Effective Mode row: select + compact field-aligned **Set mode** button.
+
+## Traceability Impact
+
+- Extensions Mode UX polish only. Live recommendation R1–R4 dispositions unchanged (operator already confirmed download/apply PASS).
+
+## Coverage Gate
+
+- Effective inputs reviewed: locked Phase 3; operator screenshot; this addendum
+- Remediation landed and unit-tested
+- Packaged UI assets contain `h-10 min-h-[40px]` compact field button classes
+- Out-of-scope: KW unlock; stage/main promotion
+
+Coverage: PASS
+
+## Approval Gate
+
+- Objective readiness checks: plan authored before code; remediations match plan; tests green; SEA relaunched for operator re-verify
+- Remaining blocker: operator visual confirmation of Mode row (checkbox above)
+
+Approval: PASS (remediation landed; operator re-verify outstanding)

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json
@@ -1,0 +1,65 @@
+{
+  "contract": "Run80EvidenceBinderV1",
+  "runId": "80-signed-recommendation-cloud-lifecycle",
+  "finishedAt": "2026-07-24T11:44:10.542Z",
+  "pins": {
+    "privateBaseline": "739ef35bcc2d3c747696c4a22d74e4718cf1229b",
+    "publicBaseline": "420770884be5999267992666a5f71913adb5a7c8",
+    "note": "working-tree feature branches recursive/80-signed-recommendation-cloud-lifecycle"
+  },
+  "rebuild": {
+    "privateBuildRun00": {
+      "command": "pnpm build:run00-runtime",
+      "exitCode": 0,
+      "log": "evidence/logs/rebuild-private-run00.log",
+      "dist": "dist/run00-dev"
+    },
+    "publicPackageSea": {
+      "command": "ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT=<private>/dist/run00-dev pnpm runtime:package-sea",
+      "exitCode": 0,
+      "log": "evidence/logs/rebuild-public-sea.log",
+      "artifactPath": "D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/dist/release/win32-x64/role-model-dev.exe",
+      "sha256": "825f9b4f2e17f5102605b24943b974efa435133452f0cfa5867b389c14927f84"
+    }
+  },
+  "trackDev": {
+    "host": "https://recommendations-dev.role-model.dev",
+    "channel": "development",
+    "scopeId": "run80-dev",
+    "keyId": "role-model-recommendations-dev-v1",
+    "seedLog": "evidence/logs/live-dev-seed-run80-scope.log",
+    "materialProbe": "evidence/other/material-probe-dev.json"
+  },
+  "liveHops": {
+    "runtime": "rebuilt role-model-dev.exe on http://127.0.0.1:34583",
+    "scopeId": "run80-dev",
+    "downloadApply": {
+      "downloadStatus": 200,
+      "applyStatus": 200,
+      "activePackId": "recommendation-7f764e25a078716f1d3935f35d58ca1b"
+    },
+    "downloadDismiss": {
+      "downloadStatus": 200,
+      "dismissStatus": 200,
+      "dismissId": "recommendation-aec9c8596b18bebbe231be7dbe396be0"
+    },
+    "historicalPcrNotSubstituted": true,
+    "evidence": "evidence/logs/live-dev-lifecycle-pass.json"
+  },
+  "tdd": {
+    "mode": "strict",
+    "red": [
+      "evidence/logs/red/sp1-launch-track.log"
+    ],
+    "green": [
+      "evidence/logs/green/sp1-launch-track.log",
+      "evidence/logs/green/sp2-optout.log"
+    ]
+  },
+  "offline": {
+    "bindingsTests": "tests/track-b/run80-recommendation-bindings.test.mjs",
+    "optOutTest": "role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts (run80 contribution opt-out)",
+    "tb10Baseline": "evidence/other/tb10-baseline.log"
+  },
+  "secretsOmitted": true
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp1-launch-track.log
@@ -1,0 +1,13 @@
+Γ£ö run80 RED/GREEN: --track=dev maps channel to development (not production) (2.6447ms)
+Γ£ö run80: explicit channel wins over track mapping (0.4017ms)
+Γ£ö run80: production track is refused for live lifecycle (1.2069ms)
+Γ£ö run80: public root required and prefers explicit arg (0.8764ms)
+Γ£ö run80: track=dev defaults recommendation service URL to permanent-dev host (0.3439ms)
+Γä╣ tests 5
+Γä╣ suites 0
+Γä╣ pass 5
+Γä╣ fail 0
+Γä╣ cancelled 0
+Γä╣ skipped 0
+Γä╣ todo 0
+Γä╣ duration_ms 148.5216

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/green/sp2-optout.log
@@ -1,0 +1,12 @@
+
+ RUN  v3.2.4 D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/apps/runtime-host-bridge
+
+(node:8716) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ Γ£ô test/track-b-operations-api.test.ts (16 tests | 15 skipped) 32ms
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 15 skipped (16)
+   Start at  19:10:40
+   Duration  5.34s (transform 2.57s, setup 0ms, collect 3.54s, tests 32ms, environment 0ms, prepare 747ms)
+

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-console.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-console.log
@@ -1,0 +1,45 @@
+{
+  "track": "dev",
+  "channel": "development",
+  "serviceUrl": "https://recommendations-dev.role-model.dev",
+  "scopeId": "run80-dev",
+  "keyId": "role-model-recommendations-dev-v1",
+  "seeds": {
+    "a": {
+      "ingest": 202,
+      "publish": 202,
+      "publishStatus": "published",
+      "resolve": "available",
+      "channelSequence": 7,
+      "bundleUri": "https://recommendations-dev.role-model.dev/snapshots/development/stable/advanced/run80-dev/sequence-7/manifest.json"
+    },
+    "b": {
+      "ingest": 202,
+      "publish": 202,
+      "publishStatus": "published",
+      "resolve": "available",
+      "channelSequence": 8,
+      "bundleUri": "https://recommendations-dev.role-model.dev/snapshots/development/stable/advanced/run80-dev/sequence-8/manifest.json"
+    }
+  },
+  "verdict": "PASS",
+  "finishedAt": "2026-07-24T11:44:07.930Z"
+}
+{
+  "track": "dev",
+  "channel": "development",
+  "serviceUrl": "https://recommendations-dev.role-model.dev",
+  "baseUrl": "http://127.0.0.1:34583",
+  "scopeId": "run80-dev",
+  "recommendationIds": [
+    "recommendation-7f764e25a078716f1d3935f35d58ca1b"
+  ],
+  "downloadStatus": 200,
+  "applyStatus": 200,
+  "dismissStatus": 200,
+  "dismissId": "recommendation-aec9c8596b18bebbe231be7dbe396be0",
+  "activePackId": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+  "activePackPresent": true,
+  "verdict": "PASS",
+  "finishedAt": "2026-07-24T11:44:10.542Z"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json
@@ -1,0 +1,19 @@
+{
+  "track": "dev",
+  "channel": "development",
+  "serviceUrl": "https://recommendations-dev.role-model.dev",
+  "baseUrl": "http://127.0.0.1:34583",
+  "scopeId": "run80-dev",
+  "recommendationIds": [
+    "recommendation-7f764e25a078716f1d3935f35d58ca1b"
+  ],
+  "downloadStatus": 200,
+  "applyStatus": 200,
+  "dismissStatus": 200,
+  "dismissId": "recommendation-aec9c8596b18bebbe231be7dbe396be0",
+  "activePackId": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+  "activePackPresent": true,
+  "verdict": "PASS",
+  "finishedAt": "2026-07-24T11:44:10.542Z",
+  "contract": "Run80LiveRecommendationLifecycleV1"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle.json
@@ -1,0 +1,136 @@
+{
+  "contract": "Run80LiveRecommendationLifecycleV1",
+  "track": "dev",
+  "channel": "development",
+  "serviceUrl": "https://recommendations-dev.role-model.dev",
+  "baseUrl": "http://127.0.0.1:34583",
+  "materialPathPresent": true,
+  "materialKeys": [
+    "schemaVersion",
+    "destinationPrivateKey",
+    "destinationPublicKey",
+    "recommendationPrivatePkcs8Base64",
+    "recommendationPublicSpkiBase64",
+    "internalServiceToken"
+  ],
+  "startedAt": "2026-07-24T11:43:28.902Z",
+  "steps": {
+    "download": {
+      "status": 200,
+      "body": [
+        {
+          "id": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+          "version": "6",
+          "provenance": "cloud:fc36d80233b4f54aaa4ec82fa9498053d55c6880bf26effc8bd6eadaad38ad88",
+          "status": "validated",
+          "signatureValid": true,
+          "policyAllowed": true,
+          "endpointId": "endpoint:candidate-b",
+          "modelId": "model:candidate-b",
+          "preferredFor": [
+            "coding"
+          ],
+          "action": "prefer",
+          "confidence": 0.8
+        }
+      ],
+      "text": "[{\"id\":\"recommendation-7f764e25a078716f1d3935f35d58ca1b\",\"version\":\"6\",\"provenance\":\"cloud:fc36d80233b4f54aaa4ec82fa9498053d55c6880bf26effc8bd6eadaad38ad88\",\"status\":\"validated\",\"signatureValid\":true,\"policyAllowed\":true,\"endpointId\":\"endpoint:candidate-b\",\"modelId\":\"model:candidate-b\",\"preferredFor\":[\"coding\"],\"action\":\"prefer\",\"confidence\":0.8}]\n"
+    },
+    "apply": {
+      "status": 200,
+      "body": {
+        "recommendations": [
+          {
+            "id": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+            "version": "6",
+            "provenance": "cloud:fc36d80233b4f54aaa4ec82fa9498053d55c6880bf26effc8bd6eadaad38ad88",
+            "status": "applied",
+            "signatureValid": true,
+            "policyAllowed": true,
+            "endpointId": "endpoint:candidate-b",
+            "modelId": "model:candidate-b",
+            "preferredFor": [
+              "coding"
+            ],
+            "action": "prefer",
+            "confidence": 0.8
+          }
+        ],
+        "activePack": {
+          "id": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+          "version": "6",
+          "appliedAt": "2026-07-24T11:43:31.626Z"
+        }
+      },
+      "text": "{\"recommendations\":[{\"id\":\"recommendation-7f764e25a078716f1d3935f35d58ca1b\",\"version\":\"6\",\"provenance\":\"cloud:fc36d80233b4f54aaa4ec82fa9498053d55c6880bf26effc8bd6eadaad38ad88\",\"status\":\"applied\",\"signatureValid\":true,\"policyAllowed\":true,\"endpointId\":\"endpoint:candidate-b\",\"modelId\":\"model:candidate-b\",\"preferredFor\":[\"coding\"],\"action\":\"prefer\",\"confidence\":0.8}],\"activePack\":{\"id\":\"recommendation-7f764e25a078716f1d3935f35d58ca1b\",\"version\":\"6\",\"appliedAt\":\"2026-07-24T11:43:31.626Z\"}}\n"
+    },
+    "activePack": {
+      "status": 200,
+      "body": {
+        "id": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+        "version": "6",
+        "appliedAt": "2026-07-24T11:43:31.626Z"
+      },
+      "text": "{\"id\":\"recommendation-7f764e25a078716f1d3935f35d58ca1b\",\"version\":\"6\",\"appliedAt\":\"2026-07-24T11:43:31.626Z\"}\n"
+    },
+    "reseed": {
+      "exitCode": 0,
+      "stdoutTail": "serviceUrl\": \"https://recommendations-dev.role-model.dev\",\n  \"scopeId\": \"run80-dev\",\n  \"keyId\": \"role-model-recommendations-dev-v1\",\n  \"seeds\": {\n    \"a\": {\n      \"ingest\": 202,\n      \"publish\": 202,\n      \"publishStatus\": \"published\",\n      \"resolve\": \"available\",\n      \"channelSequence\": 7,\n      \"bundleUri\": \"https://recommendations-dev.role-model.dev/snapshots/development/stable/advanced/run80-dev/sequence-7/manifest.json\"\n    },\n    \"b\": {\n      \"ingest\": 202,\n      \"publish\": 202,\n      \"publishStatus\": \"published\",\n      \"resolve\": \"available\",\n      \"channelSequence\": 8,\n      \"bundleUri\": \"https://recommendations-dev.role-model.dev/snapshots/development/stable/advanced/run80-dev/sequence-8/manifest.json\"\n    }\n  },\n  \"verdict\": \"PASS\",\n  \"finishedAt\": \"2026-07-24T11:44:07.930Z\"\n}\n"
+    },
+    "redownload": {
+      "status": 200,
+      "body": [
+        {
+          "id": "recommendation-aec9c8596b18bebbe231be7dbe396be0",
+          "version": "8",
+          "provenance": "cloud:17f19b9422a0e8aaf2dcab28598ee6bdebbecb47f38110010d55be59271355bc",
+          "status": "validated",
+          "signatureValid": true,
+          "policyAllowed": true,
+          "endpointId": "endpoint:candidate-b",
+          "modelId": "model:candidate-b",
+          "preferredFor": [
+            "coding"
+          ],
+          "action": "prefer",
+          "confidence": 0.8
+        }
+      ],
+      "text": "[{\"id\":\"recommendation-aec9c8596b18bebbe231be7dbe396be0\",\"version\":\"8\",\"provenance\":\"cloud:17f19b9422a0e8aaf2dcab28598ee6bdebbecb47f38110010d55be59271355bc\",\"status\":\"validated\",\"signatureValid\":true,\"policyAllowed\":true,\"endpointId\":\"endpoint:candidate-b\",\"modelId\":\"model:candidate-b\",\"preferredFor\":[\"coding\"],\"action\":\"prefer\",\"confidence\":0.8}]\n"
+    },
+    "dismiss": {
+      "status": 200,
+      "body": {
+        "recommendations": [
+          {
+            "id": "recommendation-aec9c8596b18bebbe231be7dbe396be0",
+            "version": "8",
+            "provenance": "cloud:17f19b9422a0e8aaf2dcab28598ee6bdebbecb47f38110010d55be59271355bc",
+            "status": "dismissed",
+            "signatureValid": true,
+            "policyAllowed": true,
+            "endpointId": "endpoint:candidate-b",
+            "modelId": "model:candidate-b",
+            "preferredFor": [
+              "coding"
+            ],
+            "action": "prefer",
+            "confidence": 0.8
+          }
+        ],
+        "activePack": {
+          "id": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+          "version": "6",
+          "appliedAt": "2026-07-24T11:43:31.626Z"
+        }
+      },
+      "text": "{\"recommendations\":[{\"id\":\"recommendation-aec9c8596b18bebbe231be7dbe396be0\",\"version\":\"8\",\"provenance\":\"cloud:17f19b9422a0e8aaf2dcab28598ee6bdebbecb47f38110010d55be59271355bc\",\"status\":\"dismissed\",\"signatureValid\":true,\"policyAllowed\":true,\"endpointId\":\"endpoint:candidate-b\",\"modelId\":\"model:candidate-b\",\"preferredFor\":[\"coding\"],\"action\":\"prefer\",\"confidence\":0.8}],\"activePack\":{\"id\":\"recommendation-7f764e25a078716f1d3935f35d58ca1b\",\"version\":\"6\",\"appliedAt\":\"2026-07-24T11:43:31.626Z\"}}\n"
+    }
+  },
+  "recommendationIds": [
+    "recommendation-7f764e25a078716f1d3935f35d58ca1b"
+  ],
+  "dismissId": "recommendation-aec9c8596b18bebbe231be7dbe396be0",
+  "verdict": "PASS",
+  "finishedAt": "2026-07-24T11:44:10.542Z"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-seed-run80-scope.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-seed-run80-scope.log
@@ -1,0 +1,27 @@
+{
+  "track": "dev",
+  "channel": "development",
+  "serviceUrl": "https://recommendations-dev.role-model.dev",
+  "scopeId": "run80-dev",
+  "keyId": "role-model-recommendations-dev-v1",
+  "seeds": {
+    "a": {
+      "ingest": 202,
+      "publish": 202,
+      "publishStatus": "published",
+      "resolve": "available",
+      "channelSequence": 1,
+      "bundleUri": "https://recommendations-dev.role-model.dev/snapshots/development/stable/advanced/run80-dev/sequence-1/manifest.json"
+    },
+    "b": {
+      "ingest": 202,
+      "publish": 202,
+      "publishStatus": "published",
+      "resolve": "available",
+      "channelSequence": 2,
+      "bundleUri": "https://recommendations-dev.role-model.dev/snapshots/development/stable/advanced/run80-dev/sequence-2/manifest.json"
+    }
+  },
+  "verdict": "PASS",
+  "finishedAt": "2026-07-24T11:19:13.068Z"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-seed.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-seed.log
@@ -1,0 +1,19 @@
+
+> @role-model/internal@1.1.0 test:cloud:e2e D:\DEV\role-model-internal\.worktrees\80-signed-recommendation-cloud-lifecycle
+> node scripts/track-b/cloud-track-e2e.mjs "--" "--track=dev" "--write-evidence"
+
+{
+  "track": "dev",
+  "verdict": "PASS",
+  "reportPath": "C:\\Users\\erikb\\AppData\\Local\\Temp\\cloud-track-dev-e2e.json",
+  "ingest": 202,
+  "duplicate": 200,
+  "historyMatch": 1,
+  "publish": 202,
+  "publishStatus": "published",
+  "resolve": 200,
+  "resolveStatus": "available",
+  "keyId": "role-model-recommendations-dev-v1",
+  "crossChannel": 400,
+  "workersDevClosed": true
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/bindings.log
@@ -1,0 +1,13 @@
+Γ£ö run80 RED/GREEN: --track=dev maps channel to development (not production) (1.5676ms)
+Γ£ö run80: explicit channel wins over track mapping (0.2204ms)
+Γ£ö run80: production track is refused for live lifecycle (1.0701ms)
+Γ£ö run80: public root required and prefers explicit arg (0.3742ms)
+Γ£ö run80: track=dev defaults recommendation service URL to permanent-dev host (0.3292ms)
+Γä╣ tests 5
+Γä╣ suites 0
+Γä╣ pass 5
+Γä╣ fail 0
+Γä╣ cancelled 0
+Γä╣ skipped 0
+Γä╣ todo 0
+Γä╣ duration_ms 142.0466

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/public-ops-api.log
@@ -1,0 +1,23 @@
+
+ RUN  v3.2.4 D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/apps/runtime-host-bridge
+
+(node:20872) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ Γ£ô test/track-b-operations-api.test.ts (16 tests) 8039ms
+   Γ£ô Track B operations APIs > fails closed instead of issuing unauthenticated calls to an owned operations endpoint  864ms
+   Γ£ô Track B operations APIs > serves extension lifecycle and storage retention through bounded callbacks  756ms
+   Γ£ô Track B operations APIs > fails closed when an operations capability is not wired  658ms
+   Γ£ô Track B operations APIs > production backend never infers extension health from the catalog  663ms
+   Γ£ô Track B operations APIs > local Track B bridge seed marks catalog extensions ready without ExtensionHost override  647ms
+   Γ£ô Track B operations APIs > production backend reports readiness only from the supervised ExtensionHost  621ms
+   Γ£ô Track B operations APIs > production backend clean start uses the canonical Advanced aggregate defaults  654ms
+   Γ£ô Track B operations APIs > production request completion reports only aggregate metrics to the private operations boundary  879ms
+   Γ£ô Track B operations APIs > production Responses requests report aggregate metrics through the same private operations boundary  844ms
+   Γ£ô Track B operations APIs > production backend reads and atomically updates real bridge storage state  691ms
+   Γ£ô Track B operations APIs > run79 HTTP exposes extensions mutate and recommendations dismiss routes  694ms
+
+ Test Files  1 passed (1)
+      Tests  16 passed (16)
+   Start at  19:59:29
+   Duration  11.21s (transform 1.71s, setup 0ms, collect 2.38s, tests 8.04s, environment 0ms, prepare 261ms)
+

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/phase4/tb10.log
@@ -1,0 +1,36 @@
+(node:18716) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+Γ£ö TB10-TEST-UNIT replays deterministically (5.9425ms)
+Γ£ö TB10-TEST-CONTRACT binds evaluation group provenance (5.4788ms)
+Γ£ö TB10-TEST-INTEGRATION derives shadow candidates (3.0999ms)
+Γ£ö TB10-TEST-REGRESSION never activates production (1.8252ms)
+Γ£ö TB10-TEST-MUTATION activation guard is immutable (0.452ms)
+Γ£ö TB10-TEST-FALSE-SUCCESS rejects holdout failure (1.766ms)
+Γ£ö TB10-TEST-ROLLBACK discards derived candidates (1.7178ms)
+Γ£ö TB10-TEST-HEALTH operates without Verifiers (1.4906ms)
+Γ£ö TB10-TEST-REPLAY-CORE-PACKAGE checkpoints cancellation (0.6282ms)
+Γ£ö TB10-TEST-EVALUATION-RUNNER-PACKAGE enforces no egress (1.4243ms)
+Γ£ö TB10-TEST-TRAJECTORY-SIGNALS-PACKAGE emits bounded diagnostics (1.571ms)
+Γ£ö TB10-TEST-PROFILE-LEARNER-PACKAGE keeps attribution dimensions separate (2.307ms)
+Γ£ö TB10-TEST-KNOWLEDGE-WORKER-PACKAGE requires review and redaction (1.2264ms)
+Γ£ö TB10-TEST-TRACK-A-EXCLUSION packages are reference-only learners (0.303ms)
+Γ£ö TB10-REVIEW-REPLAY shares immutable prefixes and binds source decision provenance (28.2057ms)
+Γ£ö TB10-REVIEW-REPLAY cancellation resumes from a hash-bound checkpoint (0.8191ms)
+Γ£ö TB10-REVIEW-EVAL runs through Evaluation Core with no external environment (2.0521ms)
+Γ£ö TB10-REVIEW-SIGNALS are provenance-bound uncertain diagnostics, never labels (0.2702ms)
+Γ£ö TB10-REVIEW-PROFILE preserves propensity, bias, confidence, promotion and rollback evidence (1.1382ms)
+Γ£ö TB10-REVIEW-KNOWLEDGE requires comparable positive/negative groups and disjoint validation (2.2028ms)
+Γ£ö TB10-REVIEW-SAFETY rejects caller-asserted knowledge and missing diagnostic provenance (1.3678ms)
+Γ£ö TB10-REVIEW-SAFETY executes only trusted registered scorers (1.627ms)
+Γ£ö TB10-REVIEW-BOUNDARY accepts only finite declarative scorers and complete execution provenance (1.8523ms)
+Γ£ö TB10-REVIEW-RECEIPTS rejects forged profile and knowledge promotion gates (2.0031ms)
+Γ£ö TB10-REVIEW-RECEIPTS bind nested evidence and model fields (0.6613ms)
+Γ£ö TB10-REVIEW-REPLAY uses collision-safe prefix hashes and durable restart checkpoints (32.8205ms)
+Γä╣ tests 26
+Γä╣ suites 0
+Γä╣ pass 26
+Γä╣ fail 0
+Γä╣ cancelled 0
+Γä╣ skipped 0
+Γä╣ todo 0
+Γä╣ duration_ms 251.8649

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/rebuild-private-run00.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/rebuild-private-run00.log
@@ -1,0 +1,5 @@
+
+> @role-model/internal@1.1.0 build:run00-runtime D:\DEV\role-model-internal\.worktrees\80-signed-recommendation-cloud-lifecycle
+> node scripts/track-b/build-runtime-distribution.mjs
+
+{"status":"PASS","extensionCount":13,"sidecarSha256":"a7793a22b0cd8c1a05478b7e0650a105a104b0f47343903dc02c0066edf5da6b"}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/rebuild-public-sea.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/rebuild-public-sea.log
@@ -1,0 +1,186 @@
+
+> role-model@0.0.0 runtime:package-sea D:\DEV\role-model\.worktrees\80-signed-recommendation-cloud-lifecycle
+> corepack pnpm --filter @role-model-router/runtime-ui build && corepack pnpm --filter @role-model-router/runtime-host-bridge... build && corepack pnpm --filter @role-model-router/runtime-host-bridge run package-sea
+
+
+> @role-model-router/runtime-ui@ build D:\DEV\role-model\.worktrees\80-signed-recommendation-cloud-lifecycle\role-model-router\apps\runtime-ui
+> react-router build && tsc --noEmit
+
+vite v7.3.2 building client environment for production...
+transforming...
+Γ£ô 2376 modules transformed.
+rendering chunks...
+computing gzip size...
+build/client/.vite/manifest.json                           24.79 kB Γöé gzip:   2.26 kB
+build/client/assets/root-KUJIdOyn.css                      54.24 kB Γöé gzip:  10.31 kB
+build/client/assets/index-CgUeC-Zx.js                       0.15 kB Γöé gzip:   0.15 kB
+build/client/assets/live-refresh-DcaagJbF.js                0.16 kB Γöé gzip:   0.14 kB
+build/client/assets/local-models-DEleTGZf.js                0.16 kB Γöé gzip:   0.16 kB
+build/client/assets/router-candidate-labels-DZOqVj1T.js     0.67 kB Γöé gzip:   0.41 kB
+build/client/assets/theme-CxtVguy4.js                       0.77 kB Γöé gzip:   0.45 kB
+build/client/assets/shell-header-context-BBtNcHzJ.js        0.78 kB Γöé gzip:   0.40 kB
+build/client/assets/not-found-Cga0vorq.js                   1.03 kB Γöé gzip:   0.55 kB
+build/client/assets/routing-mode-0L6xYTH_.js                1.04 kB Γöé gzip:   0.48 kB
+build/client/assets/legacy-redirect-Bh8_0Ivo.js             1.19 kB Γöé gzip:   0.43 kB
+build/client/assets/local-matrix-BydzX2aG.js                1.29 kB Γöé gzip:   0.52 kB
+build/client/assets/llama-swap-setup-DjrOlpYQ.js            1.50 kB Γöé gzip:   0.74 kB
+build/client/assets/local-choose-Bdp7kuFw.js                1.98 kB Γöé gzip:   0.84 kB
+build/client/assets/integrations-downstream-DVyRhHBS.js     2.52 kB Γöé gzip:   1.01 kB
+build/client/assets/local-swap-Dnn0JGnM.js                  3.39 kB Γöé gzip:   1.38 kB
+build/client/assets/control-runtime-config-yrhbNTOH.js      3.45 kB Γöé gzip:   1.54 kB
+build/client/assets/router-decisions-B5aFb4w-.js            3.62 kB Γöé gzip:   1.42 kB
+build/client/assets/local-policy-DBT_FmLl.js                3.74 kB Γöé gzip:   1.60 kB
+build/client/assets/root-DHsJNxoo.js                        3.80 kB Γöé gzip:   1.68 kB
+build/client/assets/local-peers-BCuzr4_D.js                 4.03 kB Γöé gzip:   1.65 kB
+build/client/assets/integrations-upstream-CXDpRiC-.js       4.09 kB Γöé gzip:   1.58 kB
+build/client/assets/app-layout-D8Ll21mQ.js                  4.15 kB Γöé gzip:   1.75 kB
+build/client/assets/local-logs-BmUKpIEr.js                  4.27 kB Γöé gzip:   1.68 kB
+build/client/assets/system-peers-CIPe4NTP.js                4.32 kB Γöé gzip:   1.70 kB
+build/client/assets/studio-rerank-BwR2IwWT.js               4.34 kB Γöé gzip:   1.88 kB
+build/client/assets/observe-activity-DLlwZKKm.js            4.52 kB Γöé gzip:   1.75 kB
+build/client/assets/runtime-Rk5Z9v9k.js                     4.57 kB Γöé gzip:   1.66 kB
+build/client/assets/studio-images-cbA7fdm6.js               4.80 kB Γöé gzip:   1.94 kB
+build/client/assets/observe-logs-BU5DD78y.js                4.84 kB Γöé gzip:   1.85 kB
+build/client/assets/session-readiness-B19NYOXn.js           4.85 kB Γöé gzip:   1.71 kB
+build/client/assets/storage-retention-DuuwC5aK.js           5.38 kB Γöé gzip:   2.10 kB
+build/client/assets/llama-swap-setup-hint-CXcbnFCt.js       5.42 kB Γöé gzip:   1.96 kB
+build/client/assets/endpoints-DSAyaWTp.js                   5.55 kB Γöé gzip:   1.95 kB
+build/client/assets/studio-advanced-C12hLly3.js             5.58 kB Γöé gzip:   2.22 kB
+build/client/assets/control-controller-B2QMnvXc.js          5.66 kB Γöé gzip:   1.93 kB
+build/client/assets/router-candidates-SRfb9QsS.js           5.67 kB Γöé gzip:   2.03 kB
+build/client/assets/local-peer-models-NzoFueDw.js           5.80 kB Γöé gzip:   2.05 kB
+build/client/assets/local-model-role-picker-Oq-rvC8v.js     5.84 kB Γöé gzip:   2.20 kB
+build/client/assets/router-decision-detail-etIOB5G7.js      5.93 kB Γöé gzip:   1.97 kB
+build/client/assets/studio-audio-B2Bx_aP3.js                6.25 kB Γöé gzip:   2.45 kB
+build/client/assets/workbench-oeNGA_pp.js                   7.03 kB Γöé gzip:   2.61 kB
+build/client/assets/local-llama-swap-models-BY-oh5co.js     7.17 kB Γöé gzip:   2.43 kB
+build/client/assets/page-primitives-B1o4RUsl.js             7.59 kB Γöé gzip:   2.80 kB
+build/client/assets/dashboard-CRms3Fu1.js                   7.89 kB Γöé gzip:   2.95 kB
+build/client/assets/observe-routing-D8xmRZng.js             8.17 kB Γöé gzip:   3.06 kB
+build/client/assets/control-routing-strategy-B5wh26Ib.js    8.67 kB Γöé gzip:   3.03 kB
+build/client/assets/router-config-Cdo6TJIz.js               8.94 kB Γöé gzip:   2.33 kB
+build/client/assets/requests-Bmt6pO-X.js                    9.01 kB Γöé gzip:   3.25 kB
+build/client/assets/router-DKH_waeH.js                      9.55 kB Γöé gzip:   2.79 kB
+build/client/assets/extensions-DMUUWtgD.js                 11.86 kB Γöé gzip:   4.08 kB
+build/client/assets/control-roles-DuMvqmIg.js              16.17 kB Γöé gzip:   4.38 kB
+build/client/assets/runtime-api-CBWddt2m.js                16.72 kB Γöé gzip:   4.12 kB
+build/client/assets/request-detail-BKUhtD86.js             19.96 kB Γöé gzip:   5.96 kB
+build/client/assets/view-models-C-Gvp3gS.js                21.07 kB Γöé gzip:   6.79 kB
+build/client/assets/control-models-CL-70b5H.js             22.49 kB Γöé gzip:   6.31 kB
+build/client/assets/providers-ySiNV_S_.js                  24.22 kB Γöé gzip:   7.31 kB
+build/client/assets/cn-B5V-leUE.js                         26.34 kB Γöé gzip:   8.26 kB
+build/client/assets/design-system-D3TueiZS.js              27.31 kB Γöé gzip:   8.68 kB
+build/client/assets/control-benchmark-Bqto2zad.js          29.39 kB Γöé gzip:   8.74 kB
+build/client/assets/chunk-EVOBXE3Y-CbLStoMq.js            128.07 kB Γöé gzip:  43.13 kB
+build/client/assets/entry.client-CUjFWg5_.js              190.57 kB Γöé gzip:  60.05 kB
+build/client/assets/telemetry-route-models-CFuEzy5A.js    434.22 kB Γöé gzip: 116.75 kB
+Γ£ô built in 14.22s
+vite v7.3.2 building ssr environment for production...
+transforming...
+Γ£ô 10 modules transformed.
+rendering chunks...
+build/server/.vite/manifest.json                0.23 kB
+build/server/assets/server-build-KUJIdOyn.css  54.24 kB
+build/server/index.js                          71.23 kB
+
+Γ£ô 1 asset cleaned from React Router server build.
+build\server\assets\server-build-KUJIdOyn.css
+
+SPA Mode: Generated build\client\index.html
+Removing the server build in D:\DEV\role-model\.worktrees\80-signed-recommendation-cloud-lifecycle\role-model-router\apps\runtime-ui\build\server due to ssr:false
+Γ£ô built in 682ms
+Scope: 26 of 44 workspace projects
+role-model-router/packages/catalog build$ tsc -p tsconfig.json
+packages/protocol-types build$ tsc -p tsconfig.json
+role-model-router/packages/bench-judge build$ tsc -p tsconfig.json
+.../packages/process-supervisor build$ tsc -p tsconfig.json
+role-model-router/packages/bench-judge build: Done
+role-model-router/packages/tool-registry build$ tsc -p tsconfig.json
+packages/protocol-types build: Done
+.../packages/vendor-abstraction build$ tsc -p tsconfig.json
+.../packages/process-supervisor build: Done
+role-model-router/packages/catalog build: Done
+role-model-router/packages/tool-registry build: Done
+.../packages/vendor-abstraction build: Done
+.../packages/profile-aggregator build$ tsc -p tsconfig.json
+role-model-router/packages/trace build$ tsc -p tsconfig.json
+role-model-router/packages/core build$ tsc -p tsconfig.json
+.../packages/provider-account build$ tsc -p tsconfig.json
+role-model-router/packages/trace build: Done
+role-model-router/packages/usage build$ tsc -p tsconfig.json
+.../packages/profile-aggregator build: Done
+role-model-router/packages/bench-routing build$ tsc -p tsconfig.json
+.../packages/provider-account build: Done
+.../packages/vendor-llama-swap build$ tsc -p tsconfig.json
+role-model-router/packages/core build: Done
+.../packages/vendor-litellm build$ tsc -p tsconfig.json
+role-model-router/packages/usage build: Done
+.../packages/vendor-llama-swap build: Done
+role-model-router/packages/bench-routing build: Done
+.../packages/vendor-litellm build: Done
+role-model-router/packages/sqlite-memory build$ tsc -p tsconfig.json
+role-model-router/packages/provider-mcp build$ tsc -p tsconfig.json
+role-model-router/packages/provider-mcp build: Done
+role-model-router/packages/sqlite-memory build: Done
+.../packages/context-envelope build$ tsc -p tsconfig.json
+.../packages/context-envelope build: Done
+.../packages/retrieval-receipt build$ tsc -p tsconfig.json
+.../packages/retrieval-receipt build: Done
+.../packages/endpoint-registry build$ tsc -p tsconfig.json
+.../packages/endpoint-registry build: Done
+.../packages/protocol-routing build$ tsc -p tsconfig.json
+.../packages/protocol-routing build: Done
+.../packages/adapter-execution build$ tsc -p tsconfig.json
+.../packages/provider-anthropic build$ tsc -p tsconfig.json
+.../packages/provider-anthropic build: Done
+.../packages/adapter-execution build: Done
+.../packages/provider-openai build$ tsc -p tsconfig.json
+.../packages/runtime-observability build$ tsc -p tsconfig.json
+.../packages/provider-openai build: Done
+.../packages/runtime-observability build: Done
+.../packages/provider-litellm build$ tsc -p tsconfig.json
+.../packages/provider-litellm build: Done
+.../apps/runtime-host-bridge build$ tsc -p tsconfig.json
+.../apps/runtime-host-bridge build: Done
+
+> @role-model-router/runtime-host-bridge@0.0.0 package-sea D:\DEV\role-model\.worktrees\80-signed-recommendation-cloud-lifecycle\role-model-router\apps\runtime-host-bridge
+> tsx src/package-sea.ts
+
+go: downloading github.com/gin-gonic/gin v1.10.0
+go: downloading github.com/billziss-gh/golib v0.2.0
+go: downloading gopkg.in/yaml.v3 v3.0.1
+go: downloading github.com/klauspost/compress v1.18.5
+go: downloading github.com/fxamacker/cbor/v2 v2.9.1
+go: downloading github.com/tidwall/sjson v1.2.5
+go: downloading github.com/tidwall/gjson v1.18.0
+go: downloading github.com/tidwall/pretty v1.2.1
+go: downloading github.com/tidwall/match v1.1.1
+go: downloading github.com/x448/float16 v0.8.4
+go: downloading github.com/gin-contrib/sse v0.1.0
+go: downloading google.golang.org/protobuf v1.34.1
+go: downloading github.com/pelletier/go-toml/v2 v2.2.2
+go: downloading github.com/ugorji/go/codec v1.2.12
+go: downloading github.com/mattn/go-isatty v0.0.20
+go: downloading golang.org/x/net v0.47.0
+go: downloading github.com/go-playground/validator/v10 v10.20.0
+go: downloading github.com/gabriel-vasile/mimetype v1.4.3
+go: downloading golang.org/x/text v0.31.0
+go: downloading github.com/leodido/go-urn v1.4.0
+go: downloading golang.org/x/crypto v0.45.0
+go: downloading github.com/go-playground/universal-translator v0.18.1
+go: downloading github.com/go-playground/locales v0.14.1
+go: downloading golang.org/x/sys v0.38.0
+Γû▓ [WARNING] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]
+
+    ../../packages/sqlite-memory/dist/legacy-migration.js:202:60:
+      202 Γöé ...nput.routerRoot ?? path.resolve(import.meta.dirname, "../../..");
+          Γò╡                                    ~~~~~~~~~~~
+
+  You need to set the output format to "esm" for "import.meta" to work correctly.
+
+Wrote single executable preparation blob to ./dist/sea-prep.blob
+{
+  "outputPath": "D:\\DEV\\role-model\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\role-model-router\\dist\\release\\win32-x64\\role-model-dev.exe",
+  "target": "win32-x64",
+  "sha256": "825f9b4f2e17f5102605b24943b974efa435133452f0cfa5867b389c14927f84"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/red/sp1-launch-track.log
@@ -1,0 +1,124 @@
+Γ£û run80 RED/GREEN: --track=dev maps channel to development (not production) (3.2269ms)
+Γ£û run80: explicit channel wins over track mapping (1.7846ms)
+Γ£û run80: production track is refused for live lifecycle (0.6775ms)
+Γ£û run80: public root required and prefers explicit arg (0.4696ms)
+Γ£û run80: track=dev defaults recommendation service URL to permanent-dev host (0.4481ms)
+Γä╣ tests 5
+Γä╣ suites 0
+Γä╣ pass 0
+Γä╣ fail 5
+Γä╣ cancelled 0
+Γä╣ skipped 0
+Γä╣ todo 0
+Γä╣ duration_ms 160.3454
+
+Γ£û failing tests:
+
+test at ..\..\..\role-model-internal\.worktrees\80-signed-recommendation-cloud-lifecycle\tests\track-b\run80-recommendation-bindings.test.mjs:10:1
+Γ£û run80 RED/GREEN: --track=dev maps channel to development (not production) (3.2269ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  + actual - expected
+  
+  + 'production'
+  - 'development'
+  
+      at TestContext.<anonymous> (file:///D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle/tests/track-b/run80-recommendation-bindings.test.mjs:11:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1106:25)
+      at Test.start (node:internal/test_runner/test:1003:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 'production',
+    expected: 'development',
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+
+test at ..\..\..\role-model-internal\.worktrees\80-signed-recommendation-cloud-lifecycle\tests\track-b\run80-recommendation-bindings.test.mjs:16:1
+Γ£û run80: explicit channel wins over track mapping (1.7846ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  + actual - expected
+  
+  + 'production'
+  - 'development'
+  
+      at TestContext.<anonymous> (file:///D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle/tests/track-b/run80-recommendation-bindings.test.mjs:17:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1106:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:788:18)
+      at Test.postRun (node:internal/test_runner/test:1235:19)
+      at Test.run (node:internal/test_runner/test:1163:12)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 'production',
+    expected: 'development',
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+
+test at ..\..\..\role-model-internal\.worktrees\80-signed-recommendation-cloud-lifecycle\tests\track-b\run80-recommendation-bindings.test.mjs:23:1
+Γ£û run80: production track is refused for live lifecycle (0.6775ms)
+  AssertionError [ERR_ASSERTION]: Missing expected exception.
+      at TestContext.<anonymous> (file:///D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle/tests/track-b/run80-recommendation-bindings.test.mjs:24:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1106:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:788:18)
+      at Test.postRun (node:internal/test_runner/test:1235:19)
+      at Test.run (node:internal/test_runner/test:1163:12)
+      at async Test.processPendingSubtests (node:internal/test_runner/test:788:7) {
+    generatedMessage: false,
+    code: 'ERR_ASSERTION',
+    actual: undefined,
+    expected: /refuse|production/i,
+    operator: 'throws',
+    diff: 'simple'
+  }
+
+test at ..\..\..\role-model-internal\.worktrees\80-signed-recommendation-cloud-lifecycle\tests\track-b\run80-recommendation-bindings.test.mjs:28:1
+Γ£û run80: public root required and prefers explicit arg (0.4696ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  + actual - expected
+  
+  + ''
+  - 'D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle'
+  
+      at TestContext.<anonymous> (file:///D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle/tests/track-b/run80-recommendation-bindings.test.mjs:29:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1106:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:788:18)
+      at Test.postRun (node:internal/test_runner/test:1235:19)
+      at Test.run (node:internal/test_runner/test:1163:12)
+      at async Test.processPendingSubtests (node:internal/test_runner/test:788:7) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: '',
+    expected: 'D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle',
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+
+test at ..\..\..\role-model-internal\.worktrees\80-signed-recommendation-cloud-lifecycle\tests\track-b\run80-recommendation-bindings.test.mjs:39:1
+Γ£û run80: track=dev defaults recommendation service URL to permanent-dev host (0.4481ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  + actual - expected
+  
+  + 'http://127.0.0.1:8787'
+  - 'https://recommendations-dev.role-model.dev'
+         ^
+  
+      at TestContext.<anonymous> (file:///D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle/tests/track-b/run80-recommendation-bindings.test.mjs:40:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1106:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:788:18)
+      at Test.postRun (node:internal/test_runner/test:1235:19)
+      at Test.run (node:internal/test_runner/test:1163:12)
+      at async Test.processPendingSubtests (node:internal/test_runner/test:788:7) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 'http://127.0.0.1:8787',
+    expected: 'https://recommendations-dev.role-model.dev',
+    operator: 'strictEqual',
+    diff: 'simple'
+  }

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/live-dev-pass-receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/live-dev-pass-receipt.json
@@ -1,0 +1,30 @@
+{
+  "contract": "Run80LiveDevPassReceiptV1",
+  "runId": "80-signed-recommendation-cloud-lifecycle",
+  "sourceBinder": "evidence/binder.json",
+  "track": "dev",
+  "channel": "development",
+  "host": "https://recommendations-dev.role-model.dev",
+  "scopeId": "run80-dev",
+  "runtime": {
+    "listen": "127.0.0.1:34582",
+    "artifact": "role-model-router/dist/release/win32-x64/role-model-dev.exe",
+    "sha256": "825f9b4f2e17f5102605b24943b974efa435133452f0cfa5867b389c14927f84"
+  },
+  "downloadApply": {
+    "downloadStatus": 200,
+    "applyStatus": 200,
+    "activePackId": "recommendation-e020dcaa09c84832e70c85a41d70d963"
+  },
+  "downloadDismiss": {
+    "downloadStatus": 200,
+    "dismissStatus": 200,
+    "dismissId": "recommendation-bb036a21766e5673f975b55e6225f61e"
+  },
+  "notes": [
+    "Initial lifecycle console log captured a pre-reseed stale-bundle 400; Windows-safe scope run80-dev reseed then succeeded.",
+    "Authoritative PASS pins live in binder.json; this receipt mirrors secret-free hop outcomes for Phase 3–5 citations.",
+    "historicalPcrNotSubstituted: true"
+  ],
+  "finishedAt": "2026-07-24T11:22:02.130Z"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/material-probe-dev.json
@@ -1,0 +1,18 @@
+{
+  "track": "dev",
+  "channel": "development",
+  "serviceUrl": "https://recommendations-dev.role-model.dev",
+  "baseUrl": "http://127.0.0.1:34583",
+  "scopeId": "run80-dev",
+  "recommendationIds": [
+    "recommendation-7f764e25a078716f1d3935f35d58ca1b"
+  ],
+  "downloadStatus": 200,
+  "applyStatus": 200,
+  "dismissStatus": 200,
+  "dismissId": "recommendation-aec9c8596b18bebbe231be7dbe396be0",
+  "activePackId": "recommendation-7f764e25a078716f1d3935f35d58ca1b",
+  "activePackPresent": true,
+  "verdict": "PASS",
+  "finishedAt": "2026-07-24T11:44:10.542Z"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-ops-baseline.log
@@ -1,0 +1,23 @@
+
+ RUN  v3.2.4 D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/apps/runtime-host-bridge
+
+(node:20916) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ Γ£ô test/track-b-operations-api.test.ts (15 tests) 8855ms
+   Γ£ô Track B operations APIs > fails closed instead of issuing unauthenticated calls to an owned operations endpoint  815ms
+   Γ£ô Track B operations APIs > serves extension lifecycle and storage retention through bounded callbacks  770ms
+   Γ£ô Track B operations APIs > fails closed when an operations capability is not wired  688ms
+   Γ£ô Track B operations APIs > production backend never infers extension health from the catalog  825ms
+   Γ£ô Track B operations APIs > local Track B bridge seed marks catalog extensions ready without ExtensionHost override  705ms
+   Γ£ô Track B operations APIs > production backend reports readiness only from the supervised ExtensionHost  1107ms
+   Γ£ô Track B operations APIs > production backend clean start uses the canonical Advanced aggregate defaults  743ms
+   Γ£ô Track B operations APIs > production request completion reports only aggregate metrics to the private operations boundary  935ms
+   Γ£ô Track B operations APIs > production Responses requests report aggregate metrics through the same private operations boundary  838ms
+   Γ£ô Track B operations APIs > production backend reads and atomically updates real bridge storage state  698ms
+   Γ£ô Track B operations APIs > run79 HTTP exposes extensions mutate and recommendations dismiss routes  674ms
+
+ Test Files  1 passed (1)
+      Tests  15 passed (15)
+   Start at  18:51:59
+   Duration  12.14s (transform 1.64s, setup 0ms, collect 2.36s, tests 8.85s, environment 0ms, prepare 351ms)
+

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md
@@ -1,0 +1,16 @@
+# Run 80 public product change-set
+
+Public worktree: `D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle`  
+Branch: `recursive/80-signed-recommendation-cloud-lifecycle`  
+Public baseline: `420770884be5999267992666a5f71913adb5a7c8`
+
+## Changed files
+
+- `role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts`
+  - Additive run80 contribution opt-out independence case (R6).
+  - No product source change required; existing apply/dismiss trust behavior remained green.
+
+## Not changed (intentional)
+
+- `role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts` — no product gap for R5/R6 after SP2.
+- Extensions UI — API live hops satisfy UI-or-API residual for apply/dismiss (no new Playwright surface this run).

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-surface-inventory.json
@@ -1,0 +1,20 @@
+{
+  "runId": "80-signed-recommendation-cloud-lifecycle",
+  "capturedAt": "2026-07-24T10:55:00Z",
+  "publicApis": {
+    "recommendationsDownload": "POST /api/role-model/recommendations/download",
+    "recommendationsApply": "POST /api/role-model/recommendations/apply",
+    "recommendationsDismiss": "POST /api/role-model/recommendations/dismiss",
+    "recommendationsActivePack": "GET /api/role-model/recommendations/active-pack"
+  },
+  "liveTrackDev": {
+    "recommendationsHost": "https://recommendations-dev.role-model.dev",
+    "channel": "development",
+    "keyId": "role-model-recommendations-dev-v1"
+  },
+  "gaps": [
+    "live SEA download/apply/dismiss against --track=dev not closed",
+    "launch-packaged-runtime defaults production channel and run-00 public root",
+    "no run-80 evidence binder"
+  ]
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/rebuild-receipt.json
@@ -1,0 +1,10 @@
+{
+  "privateBuildExit": 0,
+  "publicSeaExit": 0,
+  "artifactPath": "D:/DEV/role-model/.worktrees/80-signed-recommendation-cloud-lifecycle/role-model-router/dist/release/win32-x64/role-model-dev.exe",
+  "artifactSha256": "825f9b4f2e17f5102605b24943b974efa435133452f0cfa5867b389c14927f84",
+  "trackBDistributionRoot": "D:/DEV/role-model-internal/.worktrees/80-signed-recommendation-cloud-lifecycle/dist/run00-dev",
+  "listenUrlUsed": "http://127.0.0.1:34582",
+  "scopeId": "run80-dev",
+  "channel": "development"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/tb10-baseline.log
@@ -1,0 +1,36 @@
+(node:7836) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+Γ£ö TB10-TEST-UNIT replays deterministically (5.7083ms)
+Γ£ö TB10-TEST-CONTRACT binds evaluation group provenance (5.6475ms)
+Γ£ö TB10-TEST-INTEGRATION derives shadow candidates (3.247ms)
+Γ£ö TB10-TEST-REGRESSION never activates production (1.9799ms)
+Γ£ö TB10-TEST-MUTATION activation guard is immutable (0.49ms)
+Γ£ö TB10-TEST-FALSE-SUCCESS rejects holdout failure (1.7595ms)
+Γ£ö TB10-TEST-ROLLBACK discards derived candidates (1.7186ms)
+Γ£ö TB10-TEST-HEALTH operates without Verifiers (1.1042ms)
+Γ£ö TB10-TEST-REPLAY-CORE-PACKAGE checkpoints cancellation (0.548ms)
+Γ£ö TB10-TEST-EVALUATION-RUNNER-PACKAGE enforces no egress (1.5828ms)
+Γ£ö TB10-TEST-TRAJECTORY-SIGNALS-PACKAGE emits bounded diagnostics (1.6206ms)
+Γ£ö TB10-TEST-PROFILE-LEARNER-PACKAGE keeps attribution dimensions separate (2.3965ms)
+Γ£ö TB10-TEST-KNOWLEDGE-WORKER-PACKAGE requires review and redaction (1.1878ms)
+Γ£ö TB10-TEST-TRACK-A-EXCLUSION packages are reference-only learners (0.2979ms)
+Γ£ö TB10-REVIEW-REPLAY shares immutable prefixes and binds source decision provenance (20.6008ms)
+Γ£ö TB10-REVIEW-REPLAY cancellation resumes from a hash-bound checkpoint (0.8351ms)
+Γ£ö TB10-REVIEW-EVAL runs through Evaluation Core with no external environment (2.3535ms)
+Γ£ö TB10-REVIEW-SIGNALS are provenance-bound uncertain diagnostics, never labels (0.3071ms)
+Γ£ö TB10-REVIEW-PROFILE preserves propensity, bias, confidence, promotion and rollback evidence (1.1966ms)
+Γ£ö TB10-REVIEW-KNOWLEDGE requires comparable positive/negative groups and disjoint validation (2.4334ms)
+Γ£ö TB10-REVIEW-SAFETY rejects caller-asserted knowledge and missing diagnostic provenance (1.3865ms)
+Γ£ö TB10-REVIEW-SAFETY executes only trusted registered scorers (1.5201ms)
+Γ£ö TB10-REVIEW-BOUNDARY accepts only finite declarative scorers and complete execution provenance (2.002ms)
+Γ£ö TB10-REVIEW-RECEIPTS rejects forged profile and knowledge promotion gates (2.0713ms)
+Γ£ö TB10-REVIEW-RECEIPTS bind nested evidence and model fields (0.7077ms)
+Γ£ö TB10-REVIEW-REPLAY uses collision-safe prefix hashes and durable restart checkpoints (33.0501ms)
+Γä╣ tests 26
+Γä╣ suites 0
+Γä╣ pass 26
+Γä╣ fail 0
+Γä╣ cancelled 0
+Γä╣ skipped 0
+Γä╣ todo 0
+Γä╣ duration_ms 257.6645

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md
@@ -1,0 +1,72 @@
+Run: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/`
+Phase: `03.5 Code Review`
+Role: `code-reviewer`
+Bundle Path: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/review-bundles/03.5-code-review-bundle.md`
+Artifact Path: `/.recursive/run/80-signed-recommendation-cloud-lifecycle/03.5-code-review.md`
+Artifact Content Hash: `5fb54c5af4109293ece7f7a47916e687579beb71b65faad2fcfada21797c8170`
+GeneratedAt: `2026-07-24T11:58:44Z`
+
+## Bundle Scope
+- Canonical delegated review bundle for recursive-mode audit/review work.
+- Regenerate this bundle if the draft, changed files, or required evidence changes materially before review.
+
+## Routing
+- Routed CLI: `none`
+- Routed Model: `none`
+- Routing Config Path: `none`
+- Routing Discovery Path: `none`
+
+## Diff Basis
+- Baseline type: `local commit`
+- Baseline reference: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Comparison reference: `working-tree`
+- Normalized baseline: `739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+- Normalized comparison: `working-tree`
+- Normalized diff command: `git diff --name-only 739ef35bcc2d3c747696c4a22d74e4718cf1229b`
+
+## Changed Files Reviewed
+- `evidence/live-e2e/cloud-track-dev.json`
+- `scripts/track-b/launch-packaged-runtime.mjs`
+- `scripts/track-b/run80-live-recommendation-lifecycle.mjs`
+- `scripts/track-b/run80-recommendation-bindings.mjs`
+- `scripts/track-b/run80-seed-signed-recommendations.mjs`
+- `tests/track-b/run80-recommendation-bindings.test.mjs`
+
+## Upstream Artifacts To Re-read
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-requirements.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/00-worktree.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/01-as-is.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/02-to-be-plan.md`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/03-implementation-summary.md`
+
+## Relevant Addenda
+- none
+
+## Prior Recursive Evidence
+- `.recursive/memory/skills/SKILLS.md`
+- `.recursive/memory/skills/usage/review-bundle-citation-requirements.md`
+
+## Control-Plane Docs
+- `.recursive/RECURSIVE.md`
+
+## Targeted Code References
+- `scripts/track-b/run80-recommendation-bindings.mjs`
+- `scripts/track-b/launch-packaged-runtime.mjs`
+- `scripts/track-b/run80-live-recommendation-lifecycle.mjs`
+- `scripts/track-b/run80-seed-signed-recommendations.mjs`
+- `tests/track-b/run80-recommendation-bindings.test.mjs`
+
+## Evidence References
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/binder.json`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/logs/live-dev-lifecycle-pass.json`
+- `.recursive/run/80-signed-recommendation-cloud-lifecycle/evidence/other/public-product-change-set.md`
+
+## Audit Questions
+- `Do changed files match locked Phase 2 scope without unsigned bypass or KW unlock?`
+
+## Required Output
+- `Findings ordered by severity; Audit Verdict PASS/FAIL`
+
+## Notes
+- Review output is invalid if it does not cite the upstream artifacts, diff basis, changed files, and final verdict.
+- If this bundle is incomplete, reject delegation and perform the audit as self-audit.

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/00-requirements.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/00-requirements.receipt.json
@@ -1,0 +1,9 @@
+{
+  "artifact": "00-requirements.md",
+  "artifact_hash": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\00-requirements.md",
+  "locked_at": "2026-07-24T10:52:36Z",
+  "prerequisite_hashes": {},
+  "previous_receipt_hash": null,
+  "receipt_hash": "97e278759c5ac740446855e9dc5c89fa141a6c85e447281a22e4e2a444fd1db5"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/00-worktree.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/00-worktree.receipt.json
@@ -1,0 +1,11 @@
+{
+  "artifact": "00-worktree.md",
+  "artifact_hash": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\00-worktree.md",
+  "locked_at": "2026-07-24T10:53:30Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "dd09393e62c0b86ac1a0e6c7f77ddb9b847634bf7ab2db59d8672107ca739cfb"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/01-as-is.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/01-as-is.receipt.json
@@ -1,0 +1,12 @@
+{
+  "artifact": "01-as-is.md",
+  "artifact_hash": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\01-as-is.md",
+  "locked_at": "2026-07-24T11:04:42Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "e4c05adc0f6ba499f3cd408e887d3fe947219604cdea1788c152a3ea488564d6"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/02-to-be-plan.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/02-to-be-plan.receipt.json
@@ -1,0 +1,13 @@
+{
+  "artifact": "02-to-be-plan.md",
+  "artifact_hash": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\02-to-be-plan.md",
+  "locked_at": "2026-07-24T11:05:08Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "a2aa392b36a36f43df31fb8ad8c8e5d17ba62d2890a99eb461b24131359b5366"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/03-implementation-summary.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/03-implementation-summary.receipt.json
@@ -1,0 +1,14 @@
+{
+  "artifact": "03-implementation-summary.md",
+  "artifact_hash": "811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\03-implementation-summary.md",
+  "locked_at": "2026-07-24T11:53:05Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+    "02-to-be-plan.md": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "eaeeb56587b723a5533752a1011fe7791b4510cd1315b0c86a9a2ab9aaeed72c"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/03.5-code-review.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/03.5-code-review.receipt.json
@@ -1,0 +1,15 @@
+{
+  "artifact": "03.5-code-review.md",
+  "artifact_hash": "fd9adf89255da94bcb492be3f45c6913d409bf56c9c2d2efffca28644d65d197",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\03.5-code-review.md",
+  "locked_at": "2026-07-24T11:58:45Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+    "02-to-be-plan.md": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5",
+    "03-implementation-summary.md": "811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "5e8e66273144a6012ff1f2cdf5269946e2d418415b3ae7549aa3b96cf1ea9af7"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/04-test-summary.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/04-test-summary.receipt.json
@@ -1,0 +1,16 @@
+{
+  "artifact": "04-test-summary.md",
+  "artifact_hash": "366f4fbd5ed4d0a27d317c302f47bdef1a837d7007aa3954ee4dc242e8fff157",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\04-test-summary.md",
+  "locked_at": "2026-07-24T12:01:58Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+    "02-to-be-plan.md": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5",
+    "03-implementation-summary.md": "811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4",
+    "03.5-code-review.md": "fd9adf89255da94bcb492be3f45c6913d409bf56c9c2d2efffca28644d65d197"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "75796e8b1812ef1f20ce7d1e965d1c658c31a83b8c1e5260ead6fadd804b2b58"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/05-manual-qa.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/05-manual-qa.receipt.json
@@ -1,0 +1,17 @@
+{
+  "artifact": "05-manual-qa.md",
+  "artifact_hash": "0c62b237693edae1d36b97d714f8e21d0c1e2cfd7e6d5af1a5fb7a43fbedeaab",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\05-manual-qa.md",
+  "locked_at": "2026-07-24T12:03:39Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+    "02-to-be-plan.md": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5",
+    "03-implementation-summary.md": "811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4",
+    "03.5-code-review.md": "fd9adf89255da94bcb492be3f45c6913d409bf56c9c2d2efffca28644d65d197",
+    "04-test-summary.md": "366f4fbd5ed4d0a27d317c302f47bdef1a837d7007aa3954ee4dc242e8fff157"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "75772b89a15ea4c339fa0c552dc8a54861b5742918f5c302505e9f6c06560087"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/06-decisions-update.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/06-decisions-update.receipt.json
@@ -1,0 +1,18 @@
+{
+  "artifact": "06-decisions-update.md",
+  "artifact_hash": "47a6ca3096623f0c5a47b2c24c90060b85402d76c6a2340a009581c9541791ec",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\06-decisions-update.md",
+  "locked_at": "2026-07-24T12:06:47Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+    "02-to-be-plan.md": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5",
+    "03-implementation-summary.md": "811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4",
+    "03.5-code-review.md": "fd9adf89255da94bcb492be3f45c6913d409bf56c9c2d2efffca28644d65d197",
+    "04-test-summary.md": "366f4fbd5ed4d0a27d317c302f47bdef1a837d7007aa3954ee4dc242e8fff157",
+    "05-manual-qa.md": "0c62b237693edae1d36b97d714f8e21d0c1e2cfd7e6d5af1a5fb7a43fbedeaab"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "4fbb9c3be49b6b0752eb44b35eeb4eacf7421903498b532eddf9fc2640b109fe"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/07-state-update.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/07-state-update.receipt.json
@@ -1,0 +1,19 @@
+{
+  "artifact": "07-state-update.md",
+  "artifact_hash": "495b2838b3b7235166b06e043d54617795edc0124bc6e2f99e521e811cdd04e7",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\07-state-update.md",
+  "locked_at": "2026-07-24T12:08:00Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+    "02-to-be-plan.md": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5",
+    "03-implementation-summary.md": "811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4",
+    "03.5-code-review.md": "fd9adf89255da94bcb492be3f45c6913d409bf56c9c2d2efffca28644d65d197",
+    "04-test-summary.md": "366f4fbd5ed4d0a27d317c302f47bdef1a837d7007aa3954ee4dc242e8fff157",
+    "05-manual-qa.md": "0c62b237693edae1d36b97d714f8e21d0c1e2cfd7e6d5af1a5fb7a43fbedeaab",
+    "06-decisions-update.md": "47a6ca3096623f0c5a47b2c24c90060b85402d76c6a2340a009581c9541791ec"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "6e3c9bcaaf0fd2dd90e17df0c37d005a10e650b24cdaa940f9cb1233514510ee"
+}

--- a/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/08-memory-impact.receipt.json
+++ b/.recursive/run/80-signed-recommendation-cloud-lifecycle/locks/08-memory-impact.receipt.json
@@ -1,0 +1,20 @@
+{
+  "artifact": "08-memory-impact.md",
+  "artifact_hash": "ab5ed62baac7ee77bbf10ee21ae8618f301d7bc9a22bf08b8de45c330ee0b20a",
+  "artifact_path": "D:\\DEV\\role-model-internal\\.worktrees\\80-signed-recommendation-cloud-lifecycle\\.recursive\\run\\80-signed-recommendation-cloud-lifecycle\\08-memory-impact.md",
+  "locked_at": "2026-07-24T12:09:06Z",
+  "prerequisite_hashes": {
+    "00-requirements.md": "efe0dd456210f8a5802c65dad97af9ffd1dd608b6c3334226d08afac723cca3b",
+    "00-worktree.md": "41b0adb1d5ad80745a035932e9e7150cb5784e33974173dc351342d6401976bd",
+    "01-as-is.md": "56dc46a2260006d6dde8b6aa684bcde26f56bfd8dc2b921a37fc689c05d28def",
+    "02-to-be-plan.md": "df224086abb6d0e6587032da2314420e26e43e4ebe09ea463c888335e2eba1a5",
+    "03-implementation-summary.md": "811f77c45c3c2e9e3a8321a6e70249e7814117a008904c08a00c46ec5eaac3f4",
+    "03.5-code-review.md": "fd9adf89255da94bcb492be3f45c6913d409bf56c9c2d2efffca28644d65d197",
+    "04-test-summary.md": "366f4fbd5ed4d0a27d317c302f47bdef1a837d7007aa3954ee4dc242e8fff157",
+    "05-manual-qa.md": "0c62b237693edae1d36b97d714f8e21d0c1e2cfd7e6d5af1a5fb7a43fbedeaab",
+    "06-decisions-update.md": "47a6ca3096623f0c5a47b2c24c90060b85402d76c6a2340a009581c9541791ec",
+    "07-state-update.md": "495b2838b3b7235166b06e043d54617795edc0124bc6e2f99e521e811cdd04e7"
+  },
+  "previous_receipt_hash": null,
+  "receipt_hash": "3be1ac18b883578ac11253e1bdde8ad688b30972e0a24e3b5b699a603f0a1476"
+}

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -1137,6 +1137,58 @@ describe("Track B operations APIs", () => {
     await expect(ops.dismissRecommendation({ id: "missing" })).rejects.toThrow(/not found/i);
   });
 
+  test("run80 contribution opt-out does not revoke imported eligible recommendation", async () => {
+    const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run80-optout-${Date.now()}`);
+    roots.push(runtimeStateRoot);
+    const statePath = path.join(runtimeStateRoot, "track-b-production-bridge.json");
+    await mkdir(runtimeStateRoot, { recursive: true });
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        schemaVersion: "role-model.track-b-production-bridge.v1",
+        protocolVersion: "1.0",
+        revision: 1,
+        generatedAt: new Date().toISOString(),
+        extensions: [],
+        storageServices: [],
+        retention: { managedPolicy: false, receipts: [], activeJob: null },
+        contribution: {
+          mode: "contributor",
+          contributionTier: "advanced",
+          recommendationTier: "advanced",
+          recommendationAccess: "preview_and_apply",
+          allowCloudUpload: false,
+          authorizationState: "revoked",
+          revocationEpoch: 1,
+          queuedCount: 0,
+          managed: false,
+        },
+        recommendations: [
+          {
+            id: "pack-optout",
+            version: "1",
+            status: "validated",
+            signatureValid: true,
+            policyAllowed: true,
+            provenance: "cloud:bundle-optout",
+          },
+        ],
+        recommendationRevision: 3,
+        activePack: null,
+      }),
+    );
+    const ops = createTrackBOperations({ statePath, catalog: [] });
+    const listed = await ops.listRecommendations();
+    expect(listed.find((row) => row.id === "pack-optout")).toMatchObject({
+      status: "validated",
+      signatureValid: true,
+    });
+    const applied = (await ops.applyRecommendation({ id: "pack-optout" })) as {
+      activePack: { id: string };
+    };
+    expect(applied.activePack.id).toBe("pack-optout");
+  });
+
   test("run79 HTTP exposes extensions mutate and recommendations dismiss routes", async () => {
     const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run79-http-${Date.now()}`);
     roots.push(runtimeStateRoot);

--- a/role-model-router/apps/runtime-ui/app/lib/design-system.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/design-system.ts
@@ -1020,6 +1020,13 @@ export const primaryButtonClassName =
 export const secondaryButtonClassName =
   "inline-flex min-h-[44px] items-center justify-center rounded-[var(--rm-radius-pill)] border border-[var(--rm-border-strong)] bg-[var(--rm-panel)] px-[22px] py-[11px] text-[15px] font-semibold leading-5 tracking-[-0.01em] text-[var(--rm-accent-ink)] transition hover:border-[var(--rm-accent)] hover:bg-[var(--rm-accent-ghost)] hover:text-[var(--rm-accent-ink)] active:scale-95 disabled:opacity-60";
 
+/** Companion control beside SelectField — match select trigger height/radius, not pill CTAs. */
+export const compactFieldButtonClassName =
+  "inline-flex h-10 min-h-[40px] items-center justify-center rounded-[var(--rm-radius-field)] border border-[var(--rm-border-strong)] bg-[var(--rm-panel)] px-4 text-[13px] font-semibold leading-[18px] tracking-[-0.01em] text-[var(--rm-accent-ink)] transition hover:border-[var(--rm-accent)] hover:bg-[var(--rm-accent-ghost)] hover:text-[var(--rm-accent-ink)] active:scale-95 disabled:opacity-60";
+
+export const compactFieldButtonEmphasisClassName =
+  "inline-flex h-10 min-h-[40px] items-center justify-center rounded-[var(--rm-radius-field)] border border-[var(--rm-accent)] bg-[var(--rm-accent)] px-4 text-[13px] font-semibold leading-[18px] tracking-[-0.01em] text-[color:var(--rm-on-primary)] transition hover:border-[var(--rm-accent-focus)] hover:bg-[var(--rm-accent-focus)] active:scale-95 disabled:opacity-60";
+
 export const utilityButtonClassName =
   "inline-flex min-h-[44px] items-center justify-center rounded-[var(--rm-radius-md)] border border-[var(--rm-border)] bg-[var(--rm-surface)] px-[15px] py-2 text-[13px] font-semibold leading-4 tracking-[-0.01em] text-[var(--rm-fg)] transition hover:border-[var(--rm-border-strong)] hover:bg-[var(--rm-panel)]";
 

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
@@ -38,6 +38,12 @@ describe("ExtensionsRoute", () => {
     expect(routeSource).toContain("mutateExtension");
     expect(routeSource).toContain("dismissRecommendation");
     expect(routeSource).toContain("SelectField");
+    expect(routeSource).toContain("Set mode");
+    expect(routeSource).toContain("compactFieldButtonClassName");
+    expect(routeSource).toContain("compactFieldButtonEmphasisClassName");
+    expect(routeSource).not.toMatch(
+      /Set mode[\s\S]{0,200}primaryButtonClassName|modeDirty \? primaryButtonClassName/,
+    );
     expect(routeSource).toContain("formatModeLabel");
     expect(routeSource).toContain("Set mode");
     expect(routeSource).not.toMatch(/>\s*Enable\s*</);

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
@@ -10,6 +10,8 @@ import {
   StatusPill,
 } from "../components/page-primitives";
 import {
+  compactFieldButtonClassName,
+  compactFieldButtonEmphasisClassName,
   compactTitleClassName,
   mutedPanelClassName,
   primaryButtonClassName,
@@ -522,7 +524,11 @@ export function ExtensionsRouteView() {
                       </SelectField>
                     </div>
                     <button
-                      className={modeDirty ? primaryButtonClassName : secondaryButtonClassName}
+                      className={
+                        modeDirty
+                          ? compactFieldButtonEmphasisClassName
+                          : compactFieldButtonClassName
+                      }
                       disabled={busy || !modeDirty}
                       onClick={() => void applyMode(extension.id, draftMode)}
                       type="button"


### PR DESCRIPTION
## Summary
- Ship run 80 recommendation opt-out coverage and compact field-aligned Mode / Set mode controls.
- Dual-repo run-80 artifacts for live `--track=dev` signed recommendation lifecycle.

## Test plan
- [x] Local public CI: `pnpm ci:check`
- [ ] Confirm PR targets `dev` only