### PR TITLE
Complete Direct Track B semantic runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,17 +196,32 @@ jobs:
           RUNTIME_LIVE_BASE_URL: http://127.0.0.1:3462
         shell: bash
         run: |
+          recommendation_material="$RUNNER_TEMP/run87-recommendation-material.json"
+          node _private/scripts/track-b/run87-recommendation-fixture-server.mjs \
+            --port 3471 \
+            --material-file "$recommendation_material" \
+            > run87-recommendation-service.log 2>&1 &
+          recommendation_pid=$!
+          for attempt in {1..30}; do
+            test -s "$recommendation_material" && break
+            sleep 1
+          done
+          test -s "$recommendation_material"
           node _private/scripts/track-b/launch-packaged-runtime.mjs \
             --public-root "$GITHUB_WORKSPACE" \
             --manifest "$GITHUB_WORKSPACE/_private/dist/run00-dev/track-b-runtime-manifest.json" \
+            --qa-extension-manifest "$GITHUB_WORKSPACE/role-model-router/apps/runtime-host-bridge/test/fixtures/recursive-87-synthetic-extension.manifest.json" \
+            --fixture-root "$GITHUB_WORKSPACE/role-model-router/apps/runtime-host-bridge/test/fixtures" \
             --port 3462 \
             --track dev \
+            --recommendation-service-url http://127.0.0.1:3471 \
+            --recommendation-material-file "$recommendation_material" \
             --scope-id run87-ci \
             --state-root "$RUNNER_TEMP/run87-packaged-state" \
             --evidence-root "$RUNNER_TEMP/run87-packaged-evidence" \
             > track-b-runtime.log 2>&1 &
           runtime_pid=$!
-          trap 'kill "$runtime_pid" 2>/dev/null || true' EXIT
+          trap 'kill "$runtime_pid" "$recommendation_pid" 2>/dev/null || true' EXIT
           for attempt in {1..120}; do
             curl --fail --silent http://127.0.0.1:3462/healthz >/dev/null && break
             sleep 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build public workspace for paired private imports
+        run: pnpm run build
       - name: Install private paired checkout
         working-directory: _private
         run: corepack pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  PRIVATE_PAIRED_SHA: ${{ vars.ROLE_MODEL_PAIRED_PRIVATE_SHA }}
 
 permissions:
   contents: read
@@ -142,3 +143,71 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run smoke
+
+  track-b-runtime:
+    name: track-b-runtime
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate exact private paired revision
+        shell: bash
+        run: |
+          if [[ ! "$PRIVATE_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ROLE_MODEL_PAIRED_PRIVATE_SHA must be an exact 40-character commit."
+            exit 1
+          fi
+      - name: Checkout exact private paired repository
+        uses: actions/checkout@v4
+        with:
+          repository: try-works/role-model-internal
+          ref: ${{ env.PRIVATE_PAIRED_SHA }}
+          token: ${{ secrets.ROLE_MODEL_INTERNAL_READ_TOKEN }}
+          path: _private
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Install private paired checkout
+        working-directory: _private
+        run: corepack pnpm install --frozen-lockfile
+      - name: Build and verify exact paired private runtime
+        working-directory: _private
+        env:
+          ROLE_MODEL_PUBLIC_WORKTREE: ${{ github.workspace }}
+          NODE_OPTIONS: --conditions=runtime
+        run: |
+          corepack pnpm build:run00-runtime
+          node --test tests/track-b/run87-*.test.mjs tests/track-b/runtime-distribution.test.mjs
+      - name: Run Track B host CI contract
+        run: pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/recursive-87-ci-contract.test.ts
+      - name: Install Chromium
+        run: pnpm --filter @role-model-router/runtime-ui exec playwright install --with-deps chromium
+      - name: Build live runtime UI
+        run: pnpm --filter @role-model-router/runtime-ui build
+      - name: Run tagged Track B browser gate against the packaged paired runtime
+        env:
+          RUNTIME_LIVE_BASE_URL: http://127.0.0.1:3462
+        shell: bash
+        run: |
+          node _private/scripts/track-b/launch-packaged-runtime.mjs \
+            --public-root "$GITHUB_WORKSPACE" \
+            --manifest "$GITHUB_WORKSPACE/_private/dist/run00-dev/track-b-runtime-manifest.json" \
+            --port 3462 \
+            --track dev \
+            --scope-id run87-ci \
+            --state-root "$RUNNER_TEMP/run87-packaged-state" \
+            --evidence-root "$RUNNER_TEMP/run87-packaged-evidence" \
+            > track-b-runtime.log 2>&1 &
+          runtime_pid=$!
+          trap 'kill "$runtime_pid" 2>/dev/null || true' EXIT
+          for attempt in {1..120}; do
+            curl --fail --silent http://127.0.0.1:3462/healthz >/dev/null && break
+            sleep 1
+          done
+          curl --fail http://127.0.0.1:3462/healthz
+          pnpm --filter @role-model-router/runtime-ui exec playwright test --grep @recursive:87-direct-track-b-semantic-completion

--- a/packages/extension-host/index.mjs
+++ b/packages/extension-host/index.mjs
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { appendFile, mkdir, readFile } from "node:fs/promises";
-import { basename, dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   defineExtension,
@@ -21,22 +21,36 @@ const resolveNodeWorkerExecutable = (configured = process.env.ROLE_MODEL_EXTENSI
 };
 
 class ProcessWorker {
-  constructor(moduleUrl, onExit, startupTimeoutMs, workerExecPath) {
+  constructor(moduleUrl, onExit, startupTimeoutMs, workerExecPath, extensionId, stateRoot) {
     this.moduleUrl = normalizeModuleUrl(moduleUrl);
     this.onExit = onExit;
     this.startupTimeoutMs = startupTimeoutMs;
     this.workerExecPath = workerExecPath;
+    this.extensionId = extensionId;
+    this.stateRoot = stateRoot;
     this.pending = new Map();
     this.child = null;
+    this.stderr = "";
     this.exited = true;
     this.stopping = false;
   }
   async start() {
     if (this.child && !this.exited) return;
+    if (this.stateRoot) await mkdir(this.stateRoot, { recursive: true });
+    this.stopping = false;
     this.exited = false;
     this.child = spawn(this.workerExecPath, [runtimePath, this.moduleUrl], {
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
+      env: {
+        ...process.env,
+        ROLE_MODEL_EXTENSION_ID: this.extensionId,
+        ...(this.stateRoot ? { ROLE_MODEL_EXTENSION_STATE_ROOT: this.stateRoot } : {}),
+      },
+    });
+    this.stderr = "";
+    this.child.stderr.on("data", (chunk) => {
+      this.stderr = `${this.stderr}${chunk.toString("utf8")}`.slice(-4096);
     });
     let bytes = Buffer.alloc(0);
     let settled = false;
@@ -68,9 +82,16 @@ class ProcessWorker {
     this.child.once("exit", (code, signal) => {
       const expected = this.stopping;
       this.exited = true;
-      for (const item of this.pending.values()) item.reject(new Error("worker exited"));
+      const detail = this.stderr.trim();
+      for (const item of this.pending.values())
+        item.reject(new Error(detail ? `worker exited: ${detail}` : "worker exited"));
       this.pending.clear();
-      if (!settled) rejectReady(new Error(`worker exited during startup (${code ?? signal})`));
+      if (!settled)
+        rejectReady(
+          new Error(
+            `worker exited during startup (${code ?? signal})${detail ? `: ${detail}` : ""}`,
+          ),
+        );
       if (!expected) this.onExit?.(code, signal);
     });
     let timer;
@@ -121,6 +142,12 @@ class ProcessWorker {
       });
     });
     this.child = null;
+  }
+  state() {
+    return {
+      pid: this.exited ? null : (this.pid ?? null),
+      exited: this.exited,
+    };
   }
 }
 
@@ -174,6 +201,49 @@ export class ExtensionHost {
       "utf8",
     );
   }
+  #recoverExitedProcess(record) {
+    if (record.kind !== "process" || !record.autoRestart || !record.worker.exited) return null;
+    if (record.restartPromise) return record.restartPromise;
+    record.restartPromise = (async () => {
+      while (record.autoRestart && record.worker.exited) {
+        if (record.restarts >= this.maxRestarts) {
+          record.lifecycle = "degraded";
+          await this.#journal({
+            type: "restart_exhausted",
+            extensionId: record.descriptor.id,
+            restart: record.restarts,
+          });
+          return;
+        }
+        await delay(this.restartBackoffMs * 2 ** record.restarts);
+        if (!record.autoRestart || !record.worker.exited) return;
+        record.restarts += 1;
+        this.#restartCount += 1;
+        record.lifecycle = "starting";
+        try {
+          await record.worker.start();
+          record.lifecycle = "ready";
+          await this.#journal({
+            type: "restarted",
+            extensionId: record.descriptor.id,
+            restart: record.restarts,
+          });
+          return;
+        } catch (error) {
+          record.lifecycle = "exited";
+          await this.#journal({
+            type: "restart_failed",
+            extensionId: record.descriptor.id,
+            restart: record.restarts,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    })().finally(() => {
+      record.restartPromise = null;
+    });
+    return record.restartPromise;
+  }
   register(descriptor, worker) {
     const validated = this.#validateDescriptor(descriptor);
     if (typeof worker !== "function") throw new Error("worker function required");
@@ -193,20 +263,27 @@ export class ExtensionHost {
       kind: "process",
       lifecycle: "starting",
       restarts: 0,
+      autoRestart: false,
+      restartPromise: null,
     };
     record.worker = new ProcessWorker(
       normalized,
       () => {
         record.lifecycle = "exited";
+        if (record.autoRestart) void this.#recoverExitedProcess(record);
       },
       this.startupTimeoutMs,
       this.workerExecPath,
+      validated.id,
+      this.journalPath ? join(dirname(this.journalPath), "workers", validated.id) : null,
     );
     this.#workers.set(validated.id, record);
     try {
       await record.worker.start();
       record.lifecycle = "ready";
+      record.autoRestart = true;
     } catch (error) {
+      record.autoRestart = false;
       this.#workers.delete(validated.id);
       throw error;
     }
@@ -234,14 +311,84 @@ export class ExtensionHost {
     const latest = new Map();
     for (const line of content.split(/\r?\n/).filter(Boolean)) {
       const row = JSON.parse(line);
-      if (row.type === "installed") latest.set(row.descriptor.id, row);
+      if (row.type === "installed") {
+        latest.set(row.descriptor.id, { ...row, desiredState: "ready" });
+        continue;
+      }
+      const extensionId = row.extensionId;
+      if (!extensionId || !latest.has(extensionId)) continue;
+      if (row.type === "removed") latest.delete(extensionId);
+      else if (row.type === "stopped")
+        latest.set(extensionId, { ...latest.get(extensionId), desiredState: "stopped" });
+      else if (row.type === "started" || row.type === "restarted")
+        latest.set(extensionId, { ...latest.get(extensionId), desiredState: "ready" });
     }
-    for (const row of latest.values())
-      if (!this.#workers.has(row.descriptor.id))
+    for (const row of latest.values()) {
+      if (!this.#workers.has(row.descriptor.id)) {
         await this.registerProcess(row.descriptor, row.moduleUrl, { journal: false });
+        if (row.desiredState === "stopped") {
+          const record = this.#workers.get(row.descriptor.id);
+          record.lifecycle = "stopping";
+          await record.worker.stop();
+          record.lifecycle = "stopped";
+        }
+      }
+    }
   }
   disable() {
     this.#enabled = false;
+  }
+  extensionState(id) {
+    const record = this.#workers.get(id);
+    if (!record) throw new Error(`unknown extension ${id}`);
+    return {
+      id,
+      lifecycle: record.lifecycle,
+      pid: record.kind === "process" ? record.worker.state().pid : null,
+      restarts: record.restarts ?? 0,
+    };
+  }
+  listExtensionStates() {
+    return [...this.#workers.keys()].sort().map((id) => this.extensionState(id));
+  }
+  async stopProcess(id) {
+    const record = this.#workers.get(id);
+    if (!record || record.kind !== "process") throw new Error(`unknown process extension ${id}`);
+    record.lifecycle = "stopping";
+    record.autoRestart = false;
+    await record.worker.stop();
+    record.lifecycle = "stopped";
+    await this.#journal({ type: "stopped", extensionId: id, pid: null });
+    return this.extensionState(id);
+  }
+  async startProcess(id) {
+    const record = this.#workers.get(id);
+    if (!record || record.kind !== "process") throw new Error(`unknown process extension ${id}`);
+    if (record.lifecycle === "ready" && !record.worker.exited) return this.extensionState(id);
+    record.lifecycle = "starting";
+    await record.worker.start();
+    record.lifecycle = "ready";
+    record.autoRestart = true;
+    await this.#journal({ type: "started", extensionId: id, pid: record.worker.state().pid });
+    return this.extensionState(id);
+  }
+  async restartProcess(id) {
+    const record = this.#workers.get(id);
+    if (!record || record.kind !== "process") throw new Error(`unknown process extension ${id}`);
+    await this.stopProcess(id);
+    record.restarts = (record.restarts ?? 0) + 1;
+    this.#restartCount += 1;
+    const state = await this.startProcess(id);
+    await this.#journal({ type: "restarted", extensionId: id, restart: record.restarts });
+    return state;
+  }
+  async removeProcess(id) {
+    const record = this.#workers.get(id);
+    if (!record || record.kind !== "process") throw new Error(`unknown process extension ${id}`);
+    await this.stopProcess(id);
+    record.autoRestart = false;
+    this.#workers.delete(id);
+    await this.#journal({ type: "removed", extensionId: id });
   }
   rotateAuthorizationEpoch(epoch) {
     if (!Number.isInteger(epoch) || epoch <= this.authorizationEpoch)
@@ -292,23 +439,15 @@ export class ExtensionHost {
   }
   async #ensureProcess(record) {
     if (record.kind !== "process" || !record.worker.exited) return;
-    if (record.restarts >= this.maxRestarts) throw new Error("worker restart budget exhausted");
-    await delay(this.restartBackoffMs * 2 ** record.restarts);
-    record.restarts += 1;
-    this.#restartCount += 1;
-    record.worker.stopping = false;
-    await record.worker.start();
-    record.lifecycle = "ready";
-    await this.#journal({
-      type: "restarted",
-      extensionId: record.descriptor.id,
-      restart: record.restarts,
-    });
+    await this.#recoverExitedProcess(record);
+    if (record.worker.exited) throw new Error("worker restart budget exhausted");
   }
   invoke(id, envelope) {
     if (!this.#enabled) return Promise.reject(new Error("extension discovery disabled"));
     const registered = this.#workers.get(id);
     if (!registered) return Promise.reject(new Error(`unknown extension ${id}`));
+    if (registered.lifecycle === "stopped" || registered.lifecycle === "stopping")
+      return Promise.reject(new Error(`extension ${id} is disabled or stopped`));
     if (
       !envelope?.requestId ||
       !this.protocolVersions.has(envelope.protocolVersion) ||
@@ -385,7 +524,10 @@ export class ExtensionHost {
   }
   async shutdown() {
     for (const record of this.#workers.values())
-      if (record.kind === "process") await record.worker.stop();
+      if (record.kind === "process") {
+        record.autoRestart = false;
+        await record.worker.stop();
+      }
     await this.#journal({ type: "shutdown" });
   }
   health() {
@@ -402,6 +544,7 @@ export class ExtensionHost {
         0,
       ),
       restartCount: this.#restartCount,
+      workerStates: this.listExtensionStates(),
     };
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       '@role-model-router/tool-registry':
         specifier: workspace:*
         version: link:../../packages/tool-registry
+      '@role-model-router/trace':
+        specifier: workspace:*
+        version: link:../../packages/trace
       '@role-model-router/vendor-abstraction':
         specifier: workspace:*
         version: link:../../packages/vendor-abstraction

--- a/role-model-router/apps/runtime-host-bridge/package.json
+++ b/role-model-router/apps/runtime-host-bridge/package.json
@@ -31,6 +31,7 @@
     "@role-model-router/runtime-observability": "workspace:*",
     "@role-model-router/sqlite-memory": "workspace:*",
     "@role-model-router/tool-registry": "workspace:*",
+    "@role-model-router/trace": "workspace:*",
     "@role-model-router/vendor-abstraction": "workspace:*",
     "@role-model-router/vendor-llama-swap": "workspace:*",
     "@role-model-router/vendor-litellm": "workspace:*",

--- a/role-model-router/apps/runtime-host-bridge/scripts/start-for-qa.ts
+++ b/role-model-router/apps/runtime-host-bridge/scripts/start-for-qa.ts
@@ -109,6 +109,7 @@ type QaBridgeBackend = Pick<
   | "listRoles"
   | "listModels"
   | "listExtensions"
+  | "mutateExtension"
   | "readStorageRetention"
   | "dryRunStorageRetention"
   | "updateStorageRetentionPolicy"
@@ -759,6 +760,7 @@ export async function seedQaTelemetry(
 
     persistRuntimeObservationBundle({
       databasePath,
+      channel: "development",
       observation: {
         ...baseBundle,
         requestId: fixture.requestId,
@@ -993,6 +995,7 @@ export function createQaServerOptions(
     listRoles: backend.listRoles,
     listModels: backend.listModels,
     listExtensions: backend.listExtensions,
+    mutateExtension: backend.mutateExtension,
     readStorageRetention: backend.readStorageRetention,
     dryRunStorageRetention: backend.dryRunStorageRetention,
     updateStorageRetentionPolicy: backend.updateStorageRetentionPolicy,

--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -15,15 +15,15 @@ import {
   resolveBridgeServerOptions,
   startBridgeServer,
 } from "./index.js";
-import { createPrivateKwJoinWorkerFactory } from "./kw-private-loader.js";
-import { configureKwPromptInjectHost } from "./kw-prompt-inject-host.js";
 import { readPackagedRuntimeProfile } from "./runtime-channel.js";
 import { migrateLegacyProductionState } from "./runtime-state-migration.js";
-import { setKwJoinWorkerFactory } from "./track-b-operations.js";
 import {
   createOwnedTrackBSidecarSpec,
   createPackagedProductionRuntime,
   createProductionExtensionRuntime,
+  createTrackBPostObservationOutbox,
+  runTrackBPostObservation,
+  trackBDistributionRequiresSQLiteMaintenance,
 } from "./track-b-runtime.js";
 
 type CliBackend = Pick<
@@ -47,6 +47,11 @@ type CliBackend = Pick<
   | "listModels"
   | "listExtensions"
   | "mutateExtension"
+  | "readTrackBQaExtensions"
+  | "readTrackBShadowReceipts"
+  | "readGraphMigration"
+  | "advanceGraphMigration"
+  | "rollbackGraphMigration"
   | "readStorageRetention"
   | "dryRunStorageRetention"
   | "updateStorageRetentionPolicy"
@@ -200,6 +205,7 @@ export function createCliServerOptions(
     port: number;
     staticRoot?: string;
     runtimeStateRoot?: string;
+    runtimeChannel?: "development" | "stage" | "production";
   },
   backendOrResolver: CliBackend | CliBackendResolver,
   shutdown?: () => Promise<void>,
@@ -232,6 +238,7 @@ export function createCliServerOptions(
     port: options.port,
     staticRoot: options.staticRoot,
     runtimeStateRoot: options.runtimeStateRoot,
+    runtimeChannel: options.runtimeChannel,
     shutdown,
     registry: resolveBackend()?.effectiveRegistry ?? EMPTY_REGISTRY,
     getRegistry: () => resolveBackend()?.effectiveRegistry ?? EMPTY_REGISTRY,
@@ -304,6 +311,21 @@ export function createCliServerOptions(
     mutateExtension: bindBackendMethod(
       "mutateExtension",
     ) as StartBridgeServerOptions["mutateExtension"],
+    readTrackBQaExtensions: bindBackendMethod(
+      "readTrackBQaExtensions",
+    ) as StartBridgeServerOptions["readTrackBQaExtensions"],
+    readTrackBShadowReceipts: bindBackendMethod(
+      "readTrackBShadowReceipts",
+    ) as StartBridgeServerOptions["readTrackBShadowReceipts"],
+    readGraphMigration: bindBackendMethod(
+      "readGraphMigration",
+    ) as StartBridgeServerOptions["readGraphMigration"],
+    advanceGraphMigration: bindBackendMethod(
+      "advanceGraphMigration",
+    ) as StartBridgeServerOptions["advanceGraphMigration"],
+    rollbackGraphMigration: bindBackendMethod(
+      "rollbackGraphMigration",
+    ) as StartBridgeServerOptions["rollbackGraphMigration"],
     readStorageRetention: bindBackendMethod(
       "readStorageRetention",
     ) as StartBridgeServerOptions["readStorageRetention"],
@@ -604,6 +626,9 @@ export async function main(): Promise<void> {
       "track-b-runtime-manifest": {
         type: "string",
       },
+      "track-b-qa-extension-manifest": {
+        type: "string",
+      },
       "artifact-digest-key-file": {
         type: "string",
       },
@@ -704,6 +729,7 @@ export async function main(): Promise<void> {
         port: options.port,
         staticRoot,
         runtimeStateRoot: options.runtimeStateRoot,
+        runtimeChannel: packagedProfile?.channel ?? "development",
       },
       {
         getBackend: () => backend,
@@ -752,15 +778,68 @@ export async function main(): Promise<void> {
           throw error;
         })
       : null;
+    const qaManifestPath =
+      args.values["track-b-qa-extension-manifest"]?.trim() ||
+      process.env.ROLE_MODEL_TRACK_B_QA_EXTENSION_MANIFEST?.trim() ||
+      null;
+    const qaManifest = qaManifestPath
+      ? (JSON.parse(await readFile(qaManifestPath, "utf8")) as {
+          readonly schemaVersion: string;
+          readonly extensions?: readonly {
+            readonly descriptor: {
+              readonly id: string;
+              readonly protocolVersion: string;
+              readonly capabilities: readonly string[];
+            };
+            readonly modulePath: string;
+            readonly artifactSha256: string;
+          }[];
+        })
+      : null;
+    if (
+      qaManifest &&
+      (qaManifest.schemaVersion !== "role-model.track-b-qa-extension-manifest.v1" ||
+        !qaManifest.extensions?.length)
+    ) {
+      throw new Error("invalid explicit Track B QA extension manifest");
+    }
+    const qaExtensions = (qaManifest?.extensions ?? []).map((extension) => ({
+      ...extension,
+      modulePath: path.resolve(path.dirname(qaManifestPath as string), extension.modulePath),
+    }));
+    const qaStartupReceipts = new Map<string, Record<string, unknown>>();
     if (packagedProfile?.channel === "production" && !trackBManifestText) {
       throw new Error("packaged production runtime is missing its Track B distribution");
     }
-    const createBackend = (trackBOperationsEndpoint?: string, trackBOperationsToken?: string) =>
-      createRuntimeBridgeBackend({
+    const postObservationOutbox = createTrackBPostObservationOutbox({
+      filePath: path.join(
+        options.runtimeStateRoot,
+        options.scopeId,
+        "track-b",
+        "post-observation-outbox.json",
+      ),
+    });
+    const drainPostObservationOutbox = async (
+      runtime: Awaited<ReturnType<typeof createProductionExtensionRuntime>>,
+    ) =>
+      postObservationOutbox.drain((observation) =>
+        runTrackBPostObservation(runtime, observation, {
+          scope: options.scopeId,
+          channel: packagedProfile?.channel ?? "development",
+          authorizationEpoch: 1,
+        }),
+      );
+    const createBackend = async (
+      trackBOperationsEndpoint?: string,
+      trackBOperationsToken?: string,
+      runStartupSQLiteMaintenance = true,
+    ) => {
+      const created = await createRuntimeBridgeBackend({
         fixtureRoot: resolveCliFixtureRoot(options.repoRoot, args.values["fixture-root"]),
         repoRoot: options.repoRoot,
         runtimeStateRoot: options.runtimeStateRoot,
         scopeId: options.scopeId,
+        runtimeChannel: packagedProfile?.channel ?? "development",
         unifiedRuntimeConfigPath: options.unifiedRuntimeConfigPath,
         ...(trackBOperationsEndpoint ? { trackBOperationsEndpoint } : {}),
         ...(trackBOperationsToken ? { trackBOperationsToken } : {}),
@@ -778,11 +857,62 @@ export async function main(): Promise<void> {
             supervisor: health.supervisor,
           };
         },
+        trackBExtensionRuntime: () => extensionRuntimeRef.current,
+        trackBQaExtensionCatalog: () =>
+          qaExtensions.map((extension) => ({
+            id: extension.descriptor.id,
+            name: extension.descriptor.id,
+            description: "Explicit test-only packaged-runtime extension.",
+            routingDependency: false,
+            testOnly: true,
+            protocolVersion: extension.descriptor.protocolVersion,
+            capabilities: extension.descriptor.capabilities,
+            ...(qaStartupReceipts.has(extension.descriptor.id)
+              ? { qaStartupReceipt: qaStartupReceipts.get(extension.descriptor.id) }
+              : {}),
+          })),
+        trackBPostObservationReceipts: () => postObservationOutbox.read(),
+        ...(trackBManifestText
+          ? {
+              trackBPostObservation: async (observation: Readonly<Record<string, unknown>>) => {
+                await postObservationOutbox.enqueue(observation);
+                const runtime = extensionRuntimeRef.current;
+                if (!runtime) return { status: "queued_for_extension_runtime" };
+                await drainPostObservationOutbox(runtime);
+                return { status: "processed" };
+              },
+            }
+          : {}),
       });
+      if (trackBOperationsEndpoint && trackBOperationsToken && runStartupSQLiteMaintenance) {
+        const response = await fetch(`${trackBOperationsEndpoint}/sqlite-maintenance`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${trackBOperationsToken}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            nowMs: Date.now(),
+            maxDeleteRows: 256,
+            idle: true,
+            lockRisk: "low",
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(`Track B startup SQLite maintenance failed with ${response.status}`);
+        }
+      }
+      return created;
+    };
     if (trackBManifestText && trackBManifestPath) {
       const manifest = JSON.parse(trackBManifestText) as {
         readonly schemaVersion: string;
         readonly sidecar: { readonly modulePath: string; readonly artifactSha256: string };
+        readonly publicRuntimeAdapter?: {
+          readonly modulePath: string;
+          readonly artifactSha256: string;
+          readonly routerRoot: string;
+        };
         readonly extensions: readonly {
           readonly descriptor: {
             readonly id: string;
@@ -793,24 +923,20 @@ export async function main(): Promise<void> {
           readonly artifactSha256: string;
         }[];
       };
-      if (manifest.schemaVersion !== "role-model.track-b-runtime-distribution.v1") {
+      if (
+        manifest.schemaVersion !== "role-model.track-b-runtime-distribution.v1" &&
+        manifest.schemaVersion !== "role-model.track-b-runtime-distribution.v2"
+      ) {
         throw new Error("unsupported packaged Track B distribution");
+      }
+      if (
+        manifest.schemaVersion === "role-model.track-b-runtime-distribution.v2" &&
+        !manifest.publicRuntimeAdapter
+      ) {
+        throw new Error("v2 Track B distribution is missing its public runtime adapter");
       }
       const distributionRoot = path.dirname(trackBManifestPath);
       const trackBStateRoot = path.join(options.runtimeStateRoot, options.scopeId, "track-b");
-      // Must match createTrackBOperations statePath (scope root), not trackBStateRoot/extensions.
-      configureKwPromptInjectHost({
-        bridgeStatePath: path.join(
-          options.runtimeStateRoot,
-          options.scopeId,
-          "track-b-production-bridge.json",
-        ),
-      });
-      setKwJoinWorkerFactory(
-        createPrivateKwJoinWorkerFactory({
-          distributionRoot,
-        }),
-      );
       // Start extension-host registration in parallel with sidecar/backend bring-up, but
       // mark core APIs ready as soon as the packaged backend exists. Waiting on all
       // packaged extensions previously kept /api/role-model/* at 503 runtime_initializing.
@@ -822,6 +948,7 @@ export async function main(): Promise<void> {
           ...extension,
           modulePath: path.resolve(distributionRoot, extension.modulePath),
         })),
+        qaExtensions,
       });
       packagedRuntime = await createPackagedProductionRuntime({
         stateRoot: trackBStateRoot,
@@ -844,9 +971,32 @@ export async function main(): Promise<void> {
             args.values["aggregate-ingestion-url"] ??
             process.env.ROLE_MODEL_AGGREGATE_INGESTION_URL,
           aggregateScope: args.values["aggregate-scope"] ?? process.env.ROLE_MODEL_AGGREGATE_SCOPE,
+          ...(manifest.publicRuntimeAdapter
+            ? {
+                sqliteDatabasePath: path.join(
+                  options.runtimeStateRoot,
+                  options.scopeId,
+                  "memory",
+                  "memory.sqlite",
+                ),
+                publicRuntimeAdapterPath: path.resolve(
+                  distributionRoot,
+                  manifest.publicRuntimeAdapter.modulePath,
+                ),
+                publicRouterRoot: path.resolve(
+                  distributionRoot,
+                  manifest.publicRuntimeAdapter.routerRoot,
+                ),
+                migrationScope: options.scopeId,
+              }
+            : {}),
         }),
         createBackend: ({ trackBOperationsEndpoint, trackBOperationsToken }) =>
-          createBackend(trackBOperationsEndpoint, trackBOperationsToken),
+          createBackend(
+            trackBOperationsEndpoint,
+            trackBOperationsToken,
+            trackBDistributionRequiresSQLiteMaintenance(manifest),
+          ),
       });
       backend = packagedRuntime.backend;
       bootstrapState.status = "ready";
@@ -854,6 +1004,25 @@ export async function main(): Promise<void> {
       try {
         extensionRuntime = await extensionRuntimePromise;
         extensionRuntimeRef.current = extensionRuntime;
+        for (const extension of qaExtensions) {
+          const capability = extension.descriptor.capabilities.find(
+            (candidate) => candidate !== "health:probe",
+          );
+          if (!capability)
+            throw new Error(`QA extension has no business capability: ${extension.descriptor.id}`);
+          const requestId = `run87:packaged-qa:${extension.descriptor.id}`;
+          const receipt = await extensionRuntime.invoke(extension.descriptor.id, {
+            requestId,
+            protocolVersion: extension.descriptor.protocolVersion,
+            channel: packagedProfile?.channel ?? "development",
+            scope: options.scopeId,
+            authorizationEpoch: 1,
+            capability,
+            payload: { packagedQa: true },
+          });
+          qaStartupReceipts.set(extension.descriptor.id, { ...receipt, requestId });
+        }
+        await drainPostObservationOutbox(extensionRuntime);
       } catch (error) {
         console.error("[role-model] extension host failed after core runtime was ready:", error);
       }

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -118,11 +118,6 @@ import {
   parseAndSanitizeControllerRoutingGuidance,
 } from "./controller-routing-contract.js";
 import { createDownstreamOpenAIDiscovery } from "./downstream-openai-discovery.js";
-import {
-  deriveDefaultKwPromptInjectQuery,
-  withKwProductionAutoArm,
-} from "./kw-prompt-inject-host.js";
-import { applyKwPromptInjectToMessagesSync } from "./kw-prompt-inject.js";
 import { resolveModelCapabilityProfile } from "./model-capability-resolver.js";
 import {
   filterEndpointsByCapabilityRequirements,
@@ -2567,6 +2562,7 @@ export interface StartBridgeServerOptions {
   readonly host: string;
   readonly port: number;
   readonly runtimeStateRoot?: string;
+  readonly runtimeChannel?: "development" | "stage" | "production";
   readonly registry: EndpointRegistryResult;
   readonly getRegistry?: () => EndpointRegistryResult;
   readonly getExecutionCatalog?: () => NormalizedCatalog;
@@ -2602,6 +2598,11 @@ export interface StartBridgeServerOptions {
   readonly listModels?: () => Promise<readonly unknown[]>;
   readonly listExtensions?: () => Promise<readonly unknown[]>;
   readonly mutateExtension?: (body: Record<string, unknown>) => Promise<unknown>;
+  readonly readTrackBQaExtensions?: () => Promise<readonly unknown[]>;
+  readonly readTrackBShadowReceipts?: () => Promise<unknown>;
+  readonly readGraphMigration?: () => Promise<unknown>;
+  readonly advanceGraphMigration?: (body: Record<string, unknown>) => Promise<unknown>;
+  readonly rollbackGraphMigration?: () => Promise<unknown>;
   readonly readStorageRetention?: () => Promise<unknown>;
   readonly dryRunStorageRetention?: () => Promise<unknown>;
   readonly updateStorageRetentionPolicy?: (body: Record<string, unknown>) => Promise<unknown>;
@@ -2802,6 +2803,11 @@ export interface RuntimeBridgeBackend {
   listModels(): Promise<readonly BridgeRuntimeModelRecord[]>;
   listExtensions(): Promise<readonly unknown[]>;
   mutateExtension(body: Record<string, unknown>): Promise<unknown>;
+  readTrackBQaExtensions(): Promise<readonly unknown[]>;
+  readTrackBShadowReceipts(): Promise<unknown>;
+  readGraphMigration(): Promise<unknown>;
+  advanceGraphMigration(body: Record<string, unknown>): Promise<unknown>;
+  rollbackGraphMigration(): Promise<unknown>;
   readStorageRetention(): Promise<unknown>;
   dryRunStorageRetention(): Promise<unknown>;
   updateStorageRetentionPolicy(body: Record<string, unknown>): Promise<unknown>;
@@ -3121,6 +3127,8 @@ export interface CreateRuntimeBridgeBackendOptions {
   readonly repoRoot: string;
   readonly runtimeStateRoot: string;
   readonly scopeId: string;
+  /** Runtime deployment channel used by every durable storage authority check. */
+  readonly runtimeChannel?: "development" | "stage" | "production";
   readonly unifiedRuntimeConfigPath?: string;
   readonly networkFetcher?: typeof fetch;
   readonly fixtureRoot?: string;
@@ -3131,6 +3139,15 @@ export interface CreateRuntimeBridgeBackendOptions {
     readonly host?: { readonly extensions?: readonly string[] };
     readonly supervisor?: Readonly<Record<string, unknown>>;
   };
+  readonly trackBExtensionRuntime?: () => {
+    listExtensions(): readonly unknown[] | Promise<readonly unknown[]>;
+    mutateExtension(input: Record<string, unknown>): unknown | Promise<unknown>;
+  } | null;
+  readonly trackBQaExtensionCatalog?: () => readonly Record<string, unknown>[];
+  readonly trackBPostObservation?: (
+    observation: Readonly<Record<string, unknown>>,
+  ) => Promise<unknown>;
+  readonly trackBPostObservationReceipts?: () => Promise<unknown>;
   readonly codexAuthAdapter?: CodexAuthAdapter;
   readonly codexExecutionAdapter?: CodexExecutionAdapter;
 }
@@ -3252,8 +3269,6 @@ export interface BridgeExecutionRequestOptions {
   readonly transportPreference?: RuntimeExecutionRequest["transportPreference"];
   readonly ignoreExecutionFailureCooldowns?: boolean;
   readonly abortSignal?: AbortSignal;
-  readonly kwProductionActivation?: boolean;
-  readonly kwPromptInjectQuery?: Record<string, unknown>;
 }
 
 class BridgeHttpError extends Error {
@@ -4644,8 +4659,7 @@ function readBridgeExecutionRequestOptions(
           ...(endpointIdHeader ? { endpointId: endpointIdHeader } : {}),
           ...(requestedRoleIdHeader ? { requestedRoleId: requestedRoleIdHeader } : {}),
         };
-  // Durable KW ON auto-arms inject (FD8); never trust client headers for activation.
-  return withKwProductionAutoArm(baseOptions);
+  return baseOptions;
 }
 
 function buildBridgeExecutionSessionAffinity(
@@ -6766,18 +6780,7 @@ function applyRequestedRoleExecutionPolicy(input: {
     rolePolicyMessages.length > 0
       ? ([...rolePolicyMessages, ...input.messages] as const)
       : input.messages;
-  const kwInject = applyKwPromptInjectToMessagesSync({
-    messages: withRolePolicy,
-    hostProductionActivation: input.requestOptions?.kwProductionActivation === true,
-    sessionId: input.requestOptions?.sessionId,
-    requestId: input.requestOptions?.clientRequestId,
-    query:
-      input.requestOptions?.kwPromptInjectQuery ??
-      (input.requestOptions?.kwProductionActivation === true
-        ? deriveDefaultKwPromptInjectQuery(input.messages)
-        : undefined),
-  });
-  const messages = kwInject.messages as typeof input.messages;
+  const messages = withRolePolicy;
   const toolPolicyMode = roleDefinition?.tool_policy?.mode ?? "allowed";
   const allowedTools = roleDefinition?.tool_policy?.allowed_tools ?? [];
   const tools =
@@ -14031,6 +14034,33 @@ function createRequestHandler(options: StartBridgeServerOptions) {
       return;
     }
 
+    if (request.method === "GET" && url.pathname === "/api/role-model/extensions/qa") {
+      if (!options.readTrackBQaExtensions) {
+        writeJson(response, 404, { error: "not found" });
+        return;
+      }
+      writeJson(response, 200, await options.readTrackBQaExtensions());
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/role-model/track-b/shadow-receipts") {
+      if (!options.readTrackBShadowReceipts) {
+        writeJson(response, 404, { error: "not found" });
+        return;
+      }
+      writeJson(response, 200, await options.readTrackBShadowReceipts());
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/role-model/graph-migration") {
+      if (!options.readGraphMigration) {
+        writeJson(response, 404, { error: "not found" });
+        return;
+      }
+      writeJson(response, 200, await options.readGraphMigration());
+      return;
+    }
+
     if (request.method === "GET" && url.pathname === "/api/role-model/storage-retention") {
       if (!options.readStorageRetention) {
         writeJson(response, 404, { error: "not found" });
@@ -14063,6 +14093,16 @@ function createRequestHandler(options: StartBridgeServerOptions) {
         method: "PUT",
         callback: options.updateStorageRetentionPolicy,
         body: true,
+      },
+      "/api/role-model/graph-migration/advance": {
+        method: "POST",
+        callback: options.advanceGraphMigration,
+        body: true,
+      },
+      "/api/role-model/graph-migration/rollback": {
+        method: "POST",
+        callback: options.rollbackGraphMigration,
+        body: false,
       },
       "/api/role-model/storage-retention/execute": {
         method: "POST",
@@ -15422,8 +15462,37 @@ function listen(server: Server, host: string, port: number): Promise<number> {
   });
 }
 
-function appendRuntimeHttpTrace(runtimeStateRoot: string, message: string): void {
+export const RUNTIME_HOST_STORAGE_REGISTRY = Object.freeze({
+  schemaVersion: "role-model.storage-registry.v1",
+  entries: Object.freeze([
+    Object.freeze({
+      id: "runtime_logs",
+      owner: "runtime-host",
+      channels: Object.freeze(["development", "stage", "production"] as const),
+    }),
+  ]),
+});
+
+export function assertRuntimeHostStorageWriteAllowed(storageClass: string, channel: string): void {
+  const registration = RUNTIME_HOST_STORAGE_REGISTRY.entries.find(
+    (entry) => entry.id === storageClass,
+  );
+  const normalizedChannel = channel === "staging" ? "stage" : channel;
+  if (!registration) throw new Error(`unregistered storage class: ${storageClass}`);
+  if (
+    !registration.channels.includes(normalizedChannel as "development" | "stage" | "production")
+  ) {
+    throw new Error(`storage class ${storageClass} is not writable in ${channel || "unknown"}`);
+  }
+}
+
+function appendRuntimeHttpTrace(
+  runtimeStateRoot: string,
+  runtimeChannel: string,
+  message: string,
+): void {
   try {
+    assertRuntimeHostStorageWriteAllowed("runtime_logs", runtimeChannel);
     const logPath = path.join(runtimeStateRoot, "logs", "runtime-http.log");
     mkdirSync(path.dirname(logPath), { recursive: true });
     appendFileSync(logPath, `${new Date().toISOString()} ${message}\n`, "utf8");
@@ -15437,6 +15506,7 @@ export async function startBridgeServer(options: StartBridgeServerOptions): Prom
     const requestStart = Date.now();
     const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
     const runtimeStateRoot = options.runtimeStateRoot;
+    const runtimeChannel = options.runtimeChannel ?? "development";
     const shouldTraceRequest =
       typeof runtimeStateRoot === "string" &&
       runtimeStateRoot.length > 0 &&
@@ -15448,11 +15518,13 @@ export async function startBridgeServer(options: StartBridgeServerOptions): Prom
     if (shouldTraceRequest) {
       appendRuntimeHttpTrace(
         runtimeStateRoot,
+        runtimeChannel,
         `request-start method=${request.method} path=${requestPath}`,
       );
       response.on("finish", () => {
         appendRuntimeHttpTrace(
           runtimeStateRoot,
+          runtimeChannel,
           `request-finish method=${request.method} path=${requestPath} status=${response.statusCode} duration_ms=${Date.now() - requestStart}`,
         );
       });
@@ -15460,6 +15532,7 @@ export async function startBridgeServer(options: StartBridgeServerOptions): Prom
         if (!response.writableEnded) {
           appendRuntimeHttpTrace(
             runtimeStateRoot,
+            runtimeChannel,
             `request-close method=${request.method} path=${requestPath} duration_ms=${Date.now() - requestStart}`,
           );
         }
@@ -15492,6 +15565,7 @@ export async function startBridgeServer(options: StartBridgeServerOptions): Prom
 export async function createRuntimeBridgeBackend(
   options: CreateRuntimeBridgeBackendOptions,
 ): Promise<RuntimeBridgeBackend> {
+  const runtimeChannel = options.runtimeChannel ?? "development";
   const createTrackBOperations = (input: Parameters<typeof createTrackBOperationsFromState>[0]) =>
     createTrackBOperationsFromState({
       ...input,
@@ -15664,6 +15738,7 @@ export async function createRuntimeBridgeBackend(
   const initialization = initializeSqliteMemory({
     runtimeStateRoot: options.runtimeStateRoot,
     scopeId: options.scopeId,
+    channel: runtimeChannel,
   });
   const operatorIntentLocation = {
     runtimeStateRoot: options.runtimeStateRoot,
@@ -21270,9 +21345,19 @@ export async function createRuntimeBridgeBackend(
       }
       persistRuntimeObservationBundle({
         databasePath: initialization.databasePath,
+        channel: runtimeChannel,
         observation: bundle,
         ...(artifactRef ? { artifactRef } : {}),
       });
+      if (options.trackBPostObservation) {
+        try {
+          await options.trackBPostObservation(
+            bundle as unknown as Readonly<Record<string, unknown>>,
+          );
+        } catch (error) {
+          console.error("Track B shadow post-observation processing failed", error);
+        }
+      }
       emitTelemetryUpdate(bundle.requestId);
     }
 
@@ -22515,7 +22600,9 @@ export async function createRuntimeBridgeBackend(
           "track-b-production-bridge.json",
         ),
         catalog: contract.extensions ?? [],
+        extensionRuntime: options.trackBExtensionRuntime?.() ?? undefined,
       }).listExtensions();
+      if (options.trackBExtensionRuntime?.()) return rows;
       const hostedIds = new Set(options.trackBExtensionHealth?.().host?.extensions ?? []);
       return (rows as readonly Record<string, unknown>[]).map((row) => {
         if (!hostedIds.has(String(row.id))) return row;
@@ -22575,6 +22662,20 @@ export async function createRuntimeBridgeBackend(
         };
       });
     },
+    async readTrackBQaExtensions(): Promise<readonly unknown[]> {
+      const catalog = options.trackBQaExtensionCatalog?.() ?? [];
+      const extensionRuntime = options.trackBExtensionRuntime?.() ?? undefined;
+      if (!extensionRuntime || catalog.length === 0) return [];
+      return createTrackBOperations({
+        statePath: path.join(
+          options.runtimeStateRoot,
+          options.scopeId,
+          "track-b-production-bridge.json",
+        ),
+        catalog,
+        extensionRuntime,
+      }).listExtensions();
+    },
     async mutateExtension(body: Record<string, unknown>): Promise<unknown> {
       const contract = JSON.parse(
         await readFile(
@@ -22595,7 +22696,44 @@ export async function createRuntimeBridgeBackend(
           "track-b-production-bridge.json",
         ),
         catalog: contract.extensions ?? [],
+        extensionRuntime: options.trackBExtensionRuntime?.() ?? undefined,
       }).mutateExtension(body);
+    },
+    async readTrackBShadowReceipts(): Promise<unknown> {
+      if (!options.trackBPostObservationReceipts) {
+        return { pendingCount: 0, receiptCount: 0, receipts: [] };
+      }
+      return options.trackBPostObservationReceipts();
+    },
+    async readGraphMigration(): Promise<unknown> {
+      return createTrackBOperations({
+        statePath: path.join(
+          options.runtimeStateRoot,
+          options.scopeId,
+          "track-b-production-bridge.json",
+        ),
+        catalog: [],
+      }).readGraphMigration();
+    },
+    async advanceGraphMigration(body: Record<string, unknown>): Promise<unknown> {
+      return createTrackBOperations({
+        statePath: path.join(
+          options.runtimeStateRoot,
+          options.scopeId,
+          "track-b-production-bridge.json",
+        ),
+        catalog: [],
+      }).advanceGraphMigration(body);
+    },
+    async rollbackGraphMigration(): Promise<unknown> {
+      return createTrackBOperations({
+        statePath: path.join(
+          options.runtimeStateRoot,
+          options.scopeId,
+          "track-b-production-bridge.json",
+        ),
+        catalog: [],
+      }).rollbackGraphMigration();
     },
     async readStorageRetention(): Promise<unknown> {
       return createTrackBOperations({

--- a/role-model-router/apps/runtime-host-bridge/src/kw-prompt-inject.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/kw-prompt-inject.ts
@@ -49,6 +49,12 @@ export type KwPromptInjectJoinInput = {
 export async function syncPrivateKnowledgeActivation(
   input: KwPromptInjectJoinInput,
 ): Promise<{ readonly ok: boolean; readonly code?: string; readonly result?: unknown }> {
+  return {
+    ok: false,
+    code: "kw_prompt_inject_prohibited_shadow_only",
+    result: "production Knowledge Worker activation is prohibited by Direct Track B v1.1",
+  };
+  /* Legacy join implementation is intentionally unreachable during the v1.1 shadow-only contract.
   if (input.worker) {
     try {
       const result =
@@ -88,6 +94,7 @@ export async function syncPrivateKnowledgeActivation(
       result: String((error as Error)?.message ?? error),
     };
   }
+  */
 }
 
 export type ApplyKwPromptInjectInput = {
@@ -120,6 +127,11 @@ function refuseReceipt(
 export function applyKwPromptInjectToMessagesSync(
   input: ApplyKwPromptInjectInput,
 ): ApplyKwPromptInjectResult {
+  return {
+    messages: input.messages,
+    receipt: refuseReceipt("kw_prompt_inject_prohibited_shadow_only"),
+  };
+  /* Legacy production insertion is retained only for N-1 source compatibility and is unreachable.
   if (!input.hostProductionActivation) {
     return {
       messages: input.messages,
@@ -156,11 +168,17 @@ export function applyKwPromptInjectToMessagesSync(
       surface: "applyRequestedRoleExecutionPolicy",
     },
   };
+  */
 }
 
 export async function applyKwPromptInjectToMessages(
   input: ApplyKwPromptInjectInput,
 ): Promise<ApplyKwPromptInjectResult> {
+  return {
+    messages: input.messages,
+    receipt: refuseReceipt("kw_prompt_inject_prohibited_shadow_only"),
+  };
+  /* Legacy production insertion is retained only for N-1 source compatibility and is unreachable.
   if (input.worker || (input.sessionId && getKwPromptInjectSession(input.sessionId))) {
     return applyKwPromptInjectToMessagesSync(input);
   }
@@ -209,4 +227,5 @@ export async function applyKwPromptInjectToMessages(
       surface: "applyRequestedRoleExecutionPolicy",
     },
   };
+  */
 }

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -328,7 +328,7 @@ export async function seedTrackBExtensionBridgeState(options: {
       id,
       lifecycle: "ready",
       enabled: true,
-      enabledMode: "active",
+      enabledMode: id === "knowledge-worker" ? "shadow" : "active",
       channel,
       scope,
       authorizationEpoch,
@@ -524,7 +524,7 @@ const privateRetentionRequest = async (
     throw new Error(
       typeof result.error === "string"
         ? result.error
-        : `private retention operation failed with ${response.status}`,
+        : `private Track B operation failed with ${response.status}`,
     );
   return result;
 };
@@ -534,18 +534,88 @@ export function createTrackBOperations({
   catalog,
   operationsEndpoint = process.env.ROLE_MODEL_TRACK_B_OPERATIONS_URL?.trim(),
   operationsToken = process.env.ROLE_MODEL_TRACK_B_OPERATIONS_TOKEN,
+  extensionRuntime,
 }: {
   readonly statePath: string;
   readonly catalog: readonly Record<string, unknown>[];
   readonly operationsEndpoint?: string;
   readonly operationsToken?: string;
+  readonly extensionRuntime?: {
+    listExtensions(): readonly unknown[] | Promise<readonly unknown[]>;
+    mutateExtension(input: Record<string, unknown>): unknown | Promise<unknown>;
+  };
 }) {
   const requestPrivate = (
     route: string,
     init?: { readonly method?: string; readonly body?: Record<string, unknown> },
   ) => privateRetentionRequest(operationsEndpoint, operationsToken, route, init);
   return {
+    async readGraphMigration(): Promise<unknown> {
+      const remote = await requestPrivate("graph-migration");
+      if (remote) return remote;
+      throw new Error("private operations endpoint is required for graph migration status");
+    },
+    async advanceGraphMigration(input: Record<string, unknown>): Promise<unknown> {
+      const remote = await requestPrivate("graph-migration/advance", {
+        method: "POST",
+        body: input,
+      });
+      if (remote) return remote;
+      throw new Error("private operations endpoint is required for graph migration advance");
+    },
+    async rollbackGraphMigration(): Promise<unknown> {
+      const remote = await requestPrivate("graph-migration/rollback", { method: "POST" });
+      if (remote) return remote;
+      throw new Error("private operations endpoint is required for graph migration rollback");
+    },
     async listExtensions(): Promise<readonly unknown[]> {
+      if (extensionRuntime) {
+        const runtimeRows = (await extensionRuntime.listExtensions()) as Array<{
+          readonly id: string;
+          readonly desiredState: "enabled" | "disabled";
+          readonly lifecycle: string;
+          readonly pid?: number;
+          readonly revision: number;
+        }>;
+        const runtimeById = new Map(runtimeRows.map((row) => [row.id, row]));
+        return catalog.map((entry) => {
+          const id = String(entry.id ?? "");
+          const actual = runtimeById.get(id);
+          if (!actual) {
+            return {
+              ...entry,
+              installed: false,
+              enabled: false,
+              enabledMode: "disabled",
+              lifecycle: "unavailable",
+              revision: 0,
+              health: {
+                available: false,
+                routingDependency: Boolean(entry.routingDependency),
+                reason: "not_registered_with_private_supervisor",
+              },
+            };
+          }
+          const enabled = actual.desiredState === "enabled";
+          return {
+            ...entry,
+            ...actual,
+            installed: true,
+            enabled,
+            enabledMode: enabled ? (id === "knowledge-worker" ? "shadow" : "active") : "disabled",
+            channel: "development",
+            scope: "global",
+            authorizationEpoch: 1,
+            health: {
+              available: actual.lifecycle === "ready",
+              routingDependency: Boolean(entry.routingDependency),
+              ...(actual.lifecycle === "ready"
+                ? {}
+                : { reason: `private_supervisor_${actual.lifecycle}` }),
+            },
+          };
+        });
+      }
       const state = await readState(statePath);
       const byId = new Map(state.extensions.map((row) => [row.id, row]));
       return catalog.map((entry) => {
@@ -588,9 +658,29 @@ export function createTrackBOperations({
       });
     },
     async mutateExtension(input: Record<string, unknown>): Promise<unknown> {
+      if (extensionRuntime) return extensionRuntime.mutateExtension(input);
       const id = String(input.id ?? "");
       const action = String(input.action ?? "");
       if (!id) throw new Error("extension id is required");
+      if (
+        id === "knowledge-worker" &&
+        ["activate_production", "deactivate_production"].includes(action)
+      ) {
+        throw new Error(
+          "production Knowledge Worker controls are prohibited by Direct Track B v1.1; shadow-only execution required",
+        );
+      }
+      if (
+        id === "knowledge-worker" &&
+        ["enable", "set_mode"].includes(action) &&
+        !["shadow", "disabled"].includes(
+          String(input.mode ?? (action === "enable" ? "active" : "")),
+        )
+      ) {
+        throw new Error(
+          "Knowledge Worker is shadow-only under Direct Track B v1.1; active, advisory, and bounded modes are prohibited",
+        );
+      }
       if (
         ![
           "enable",
@@ -932,6 +1022,18 @@ export function createTrackBOperations({
         revision: state.revision,
         totalBytes: categories.reduce((sum, row) => sum + row.bytes, 0),
         categories,
+        storageInventory: {
+          schemaVersion: "role-model.storage-registry.v1",
+          entries: state.storageServices.map((row) => ({
+            id: row.id,
+            owner: row.id,
+            health: "unavailable",
+            measurement: "unavailable",
+            physicalBytes: null,
+            heldItems: row.holds ?? 0,
+            retentionState: row.conflicts?.length ? "blocked" : "not_configured",
+          })),
+        },
         managedPolicy: state.retention.managedPolicy,
         conflicts: state.storageServices.flatMap((row) =>
           (row.conflicts ?? []).map((reason) => ({ serviceId: row.id, reason })),

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-projections.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-projections.ts
@@ -1,0 +1,51 @@
+import { type ProjectionV2, validateProjectionV2 } from "@role-model-router/trace";
+
+export interface TrackBProjectionConsumerRuntime {
+  invoke(id: string, envelope: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+export async function consumeTrackBProjection(
+  runtime: TrackBProjectionConsumerRuntime,
+  value: ProjectionV2,
+  input: { readonly channel: string; readonly authorizationEpoch: number },
+) {
+  const projection = validateProjectionV2(value);
+  if (projection.readiness.rolloutPurpose !== "routing_shadow") {
+    throw new Error("projection consumers are shadow-only");
+  }
+  if (
+    !projection.readiness.permittedUse ||
+    projection.readiness.authorizationState !== "authorized" ||
+    projection.readiness.lifecycleReadiness !== "ready" ||
+    projection.readiness.routingTrainingSuitability !== "eligible" ||
+    projection.readiness.completeness === "unavailable" ||
+    projection.readiness.evidenceCapability === "unavailable"
+  ) {
+    throw new Error("projection evidence is unavailable or not permitted for consumption");
+  }
+  const consumers = [
+    ["evaluation-core", "evaluation:consume-projection"],
+    ["profile-learner", "profile:consume-projection"],
+    ["knowledge-worker", "knowledge:consume-projection"],
+  ] as const;
+  const results = [];
+  for (const [id, capability] of consumers) {
+    results.push(
+      await runtime.invoke(id, {
+        requestId: `${projection.id}:${id}`,
+        protocolVersion: "1.1.0",
+        channel: input.channel,
+        scope: projection.scope,
+        authorizationEpoch: input.authorizationEpoch,
+        capability,
+        projection,
+      }),
+    );
+  }
+  return {
+    projectionId: projection.id,
+    consumerCount: results.length,
+    results,
+    productionMutation: false,
+  };
+}

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -1,10 +1,36 @@
 import { spawn } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { copyFile, mkdir, readFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { pathToFileURL } from "node:url";
+
+import {
+  type LegacyMigrationState,
+  type LegacySqliteMigration,
+  type PersistRuntimeObservationBundleInput,
+  type RuntimeObservationGraphStore,
+  persistRuntimeObservationBundle,
+  readLegacyMigrationJournal,
+  readRuntimeObservationBundle,
+} from "@role-model-router/sqlite-memory";
+import { createProjectionV2 } from "@role-model-router/trace";
+
+import { consumeTrackBProjection } from "./track-b-projections.js";
+
+export { consumeTrackBProjection } from "./track-b-projections.js";
+
+export function trackBDistributionRequiresSQLiteMaintenance(manifest: {
+  readonly schemaVersion: string;
+  readonly publicRuntimeAdapter?: unknown;
+}): boolean {
+  return (
+    manifest.schemaVersion === "role-model.track-b-runtime-distribution.v2" &&
+    manifest.publicRuntimeAdapter !== undefined &&
+    manifest.publicRuntimeAdapter !== null
+  );
+}
 
 export interface OwnedTrackBSidecarProcess {
   endpoint: string;
@@ -26,12 +52,183 @@ export interface TrackBProductionRuntimeOptions {
   sidecar: OwnedTrackBSidecarSpec;
 }
 
+/**
+ * Normal host-path adapter for graph-primary observation storage. The SQLite
+ * package owns the journal and pointer rows; the injected store owns rich bytes.
+ */
+export function createTrackBGraphObservationPersistence(input: {
+  readonly databasePath: string;
+  readonly channel: "development" | "stage" | "production";
+  readonly graphStore: RuntimeObservationGraphStore;
+}) {
+  if (!input.databasePath || !input.graphStore?.scopeId) {
+    throw new Error("scoped graph observation persistence is required");
+  }
+  return {
+    persist(observation: PersistRuntimeObservationBundleInput["observation"]): void {
+      persistRuntimeObservationBundle({
+        databasePath: input.databasePath,
+        channel: input.channel,
+        observation,
+        graphStore: input.graphStore,
+      });
+    },
+    read(requestId: string) {
+      if (!requestId) throw new Error("runtime observation request ID is required");
+      return readRuntimeObservationBundle({
+        databasePath: input.databasePath,
+        requestId,
+        graphStore: input.graphStore,
+      });
+    },
+  };
+}
+
+export function validateTrackBRetentionInventory(value: unknown) {
+  if (!value || typeof value !== "object") {
+    throw new Error("incomplete physical storage inventory");
+  }
+  const inventory = value as {
+    schemaVersion?: string;
+    entries?: readonly {
+      id?: string;
+      owner?: string;
+      health?: string;
+      measurement?: string;
+      physicalBytes?: number | null;
+      heldItems?: number;
+      retentionState?: string;
+    }[];
+  };
+  if (
+    inventory.schemaVersion !== "role-model.storage-registry.v1" ||
+    !inventory.entries?.length ||
+    inventory.entries.some(
+      (entry) =>
+        !entry.id ||
+        !entry.owner ||
+        !entry.health ||
+        !entry.retentionState ||
+        !["measured", "unavailable"].includes(entry.measurement ?? "") ||
+        (entry.measurement === "measured" &&
+          (!Number.isFinite(entry.physicalBytes) || Number(entry.physicalBytes) < 0)) ||
+        (entry.measurement === "unavailable" && entry.physicalBytes !== null) ||
+        !Number.isSafeInteger(entry.heldItems) ||
+        Number(entry.heldItems) < 0,
+    )
+  ) {
+    throw new Error("incomplete physical storage inventory");
+  }
+  return {
+    schemaVersion: inventory.schemaVersion,
+    complete: true,
+    storageClassCount: inventory.entries.length,
+    totalPhysicalBytes: inventory.entries.reduce(
+      (sum, entry) => sum + (entry.measurement === "measured" ? Number(entry.physicalBytes) : 0),
+      0,
+    ),
+    heldItems: inventory.entries.reduce((sum, entry) => sum + Number(entry.heldItems), 0),
+    entries: structuredClone(inventory.entries),
+  };
+}
+
+export interface TrackBGraphMigrationEvidence {
+  readonly backupVerified?: boolean;
+  readonly restoreVerified?: boolean;
+  readonly consumersVerified?: boolean;
+}
+
+/** Advances at most one durable migration stage per call. */
+export function createTrackBGraphMigrationOperator(input: {
+  readonly databasePath: string;
+  readonly migration: LegacySqliteMigration;
+  readonly scopeId: string;
+  readonly batchSize: number;
+  readonly shadowWindowMs: number;
+  readonly readHoldMs: number;
+  readonly now?: () => number;
+}) {
+  if (!input.databasePath || !input.scopeId) throw new Error("scoped graph migration is required");
+  if (!Number.isInteger(input.batchSize) || input.batchSize < 1 || input.batchSize > 10_000) {
+    throw new Error("graph migration batch size must be between 1 and 10000");
+  }
+  for (const [name, value] of [
+    ["shadow window", input.shadowWindowMs],
+    ["read hold", input.readHoldMs],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value < 1 || value > 30 * 24 * 60 * 60 * 1_000) {
+      throw new Error(`${name} must be a bounded positive duration`);
+    }
+  }
+  const now = input.now ?? Date.now;
+  const journal = () => readLegacyMigrationJournal(input.databasePath);
+  const receipt = (
+    action: string,
+    previousState: LegacyMigrationState,
+    detail: Readonly<Record<string, unknown>> = {},
+  ) => ({ action, previousState, state: journal().state, ...detail });
+  return {
+    read: journal,
+    advance(evidence: TrackBGraphMigrationEvidence = {}) {
+      const before = journal();
+      switch (before.state) {
+        case "legacy_primary":
+        case "backfill": {
+          const batch = input.migration.backfill({
+            scopeId: input.scopeId,
+            batchSize: input.batchSize,
+          });
+          if (batch.pendingCount === 0) {
+            input.migration.enterShadowMirror({ deadlineMs: now() + input.shadowWindowMs });
+          }
+          return receipt("backfill", before.state, batch);
+        }
+        case "shadow_mirror":
+          input.migration.verifyParity({
+            backupVerified: evidence.backupVerified === true,
+            restoreVerified: evidence.restoreVerified === true,
+            consumersVerified: evidence.consumersVerified === true,
+          });
+          return receipt("verify_first_parity", before.state);
+        case "parity_verified":
+          input.migration.cutover();
+          return receipt("cutover", before.state);
+        case "graph_primary":
+          input.migration.enterLegacyReadHold({ holdUntilMs: now() + input.readHoldMs });
+          return receipt("enter_legacy_read_hold", before.state);
+        case "legacy_read_hold":
+          if (!before.secondParityVerified) {
+            input.migration.verifySecondParity({
+              consumersVerified: evidence.consumersVerified === true,
+            });
+            return receipt("verify_second_parity", before.state);
+          }
+          input.migration.retire({ nowMs: now() });
+          return receipt("retire", before.state);
+        case "legacy_retired":
+          return receipt("already_retired", before.state);
+        case "rolled_back":
+        case "failed":
+          throw new Error(`graph migration cannot advance from ${before.state}`);
+      }
+    },
+    rollback() {
+      const before = journal();
+      input.migration.rollback();
+      return receipt("rollback", before.state);
+    },
+  };
+}
+
 export interface PackagedProductionBackendOptions {
   readonly trackBOperationsEndpoint: string;
   readonly trackBOperationsToken: string;
 }
 
 const trackBServerOperationNames = [
+  "readGraphMigration",
+  "advanceGraphMigration",
+  "rollbackGraphMigration",
   "listExtensions",
   "mutateExtension",
   "readStorageRetention",
@@ -66,19 +263,50 @@ export async function stageTrackBRuntimeDistribution(options: {
   const manifest = JSON.parse(manifestBytes.toString("utf8")) as {
     readonly schemaVersion: string;
     readonly sidecar: { readonly modulePath: string; readonly artifactSha256: string };
+    readonly publicRuntimeAdapter?: {
+      readonly modulePath: string;
+      readonly artifactSha256: string;
+      readonly routerRoot: string;
+      readonly routerAssets: readonly {
+        readonly modulePath: string;
+        readonly artifactSha256: string;
+      }[];
+    };
     readonly extensions: readonly {
       readonly descriptor: ProductionExtensionDescriptor;
       readonly modulePath: string;
       readonly artifactSha256: string;
     }[];
   };
-  if (
-    manifest.schemaVersion !== "role-model.track-b-runtime-distribution.v1" ||
-    manifest.extensions.length !== 13
-  ) {
-    throw new Error("Track B runtime distribution manifest is incomplete");
+  const compatibilityGeneration =
+    manifest.schemaVersion === "role-model.track-b-runtime-distribution.v2"
+      ? "N"
+      : manifest.schemaVersion === "role-model.track-b-runtime-distribution.v1"
+        ? "N-1"
+        : null;
+  if (!compatibilityGeneration || manifest.extensions.length !== 13) {
+    throw new Error("Track B runtime distribution manifest is unsupported or incomplete");
   }
-  const files = [manifest.sidecar, ...manifest.extensions];
+  if (
+    manifest.publicRuntimeAdapter &&
+    (!manifest.publicRuntimeAdapter.routerRoot ||
+      !manifest.publicRuntimeAdapter.routerAssets?.length ||
+      manifest.publicRuntimeAdapter.routerAssets.some(
+        (asset) =>
+          !asset.modulePath
+            .replaceAll("\\", "/")
+            .startsWith(`${manifest.publicRuntimeAdapter?.routerRoot.replaceAll("\\", "/")}/`),
+      ))
+  ) {
+    throw new Error("Track B public runtime adapter assets are incomplete");
+  }
+  const files = [
+    manifest.sidecar,
+    ...(manifest.publicRuntimeAdapter
+      ? [manifest.publicRuntimeAdapter, ...manifest.publicRuntimeAdapter.routerAssets]
+      : []),
+    ...manifest.extensions,
+  ];
   const verified = await Promise.all(
     files.map(async (file) => {
       const relative = file.modulePath.replaceAll("\\", "/");
@@ -110,6 +338,7 @@ export async function stageTrackBRuntimeDistribution(options: {
     sidecarPath: path.join(options.releaseDir, manifest.sidecar.modulePath),
     sidecarSha256: manifest.sidecar.artifactSha256,
     extensionCount: manifest.extensions.length,
+    compatibilityGeneration,
   };
 }
 
@@ -174,7 +403,504 @@ export function resolveTrackBNodeExecutable(
   return executableName === "node.exe" || executableName === "node" ? runtimeExecPath : "node";
 }
 
-export async function createProductionExtensionRuntime(options: {
+export interface ExtensionRuntimeMutation {
+  readonly id: string;
+  readonly action: "prepare" | "enable" | "disable" | "restart" | "rollback";
+  readonly mutationId: string;
+  readonly expectedRevision: number;
+}
+
+export interface TrackBShadowPipelineRuntime {
+  invoke(id: string, envelope: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+export interface TrackBPostObservationWorkItem extends Readonly<Record<string, unknown>> {
+  readonly requestId: string;
+  readonly routingDecisionId: string;
+  readonly endpointId: string;
+}
+
+export interface TrackBPostObservationReceipt {
+  readonly requestId: string;
+  readonly completedAt: string;
+  readonly result: unknown;
+}
+
+interface TrackBPostObservationDurableState {
+  readonly schemaVersion: "role-model.track-b-post-observation-outbox.v2";
+  readonly pending: TrackBPostObservationWorkItem[];
+  readonly receipts: TrackBPostObservationReceipt[];
+}
+
+export function createTrackBPostObservationOutbox({
+  filePath,
+  maxItems = 4096,
+}: {
+  readonly filePath: string;
+  readonly maxItems?: number;
+}) {
+  if (!filePath || !Number.isInteger(maxItems) || maxItems < 1) {
+    throw new Error("valid Track B post-observation outbox configuration required");
+  }
+  let operation = Promise.resolve<unknown>(undefined);
+  const load = async (): Promise<TrackBPostObservationDurableState> => {
+    const value = JSON.parse(
+      await readFile(filePath, "utf8").catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return "[]";
+        throw error;
+      }),
+    ) as unknown;
+    const legacyPending = Array.isArray(value) ? value : null;
+    const document = !legacyPending && value && typeof value === "object" ? value : null;
+    const pending = legacyPending ?? (document as { pending?: unknown } | null)?.pending;
+    const receipts = (document as { receipts?: unknown } | null)?.receipts ?? [];
+    if (!Array.isArray(pending) || !Array.isArray(receipts)) {
+      throw new Error("Track B post-observation outbox is malformed");
+    }
+    const normalizedPending = pending.map((item) => {
+      const row = item as Record<string, unknown>;
+      if (!row.requestId || !row.routingDecisionId || !row.endpointId) {
+        throw new Error("Track B post-observation work item is incomplete");
+      }
+      return {
+        requestId: String(row.requestId),
+        routingDecisionId: String(row.routingDecisionId),
+        endpointId: String(row.endpointId),
+      };
+    });
+    const normalizedReceipts = receipts.map((item) => {
+      const row = item as Record<string, unknown>;
+      if (!row.requestId || !row.completedAt || !("result" in row)) {
+        throw new Error("Track B post-observation receipt is incomplete");
+      }
+      return {
+        requestId: String(row.requestId),
+        completedAt: String(row.completedAt),
+        result: row.result,
+      };
+    });
+    return {
+      schemaVersion: "role-model.track-b-post-observation-outbox.v2",
+      pending: normalizedPending,
+      receipts: normalizedReceipts,
+    };
+  };
+  const persist = async (state: TrackBPostObservationDurableState) => {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    const temporary = `${filePath}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+    await writeFile(temporary, `${JSON.stringify(state)}\n`, "utf8");
+    await rename(temporary, filePath);
+  };
+  const exclusive = <T>(run: () => Promise<T>): Promise<T> => {
+    const result = operation.then(run, run);
+    operation = result.catch(() => undefined);
+    return result;
+  };
+  return {
+    enqueue(observation: Readonly<Record<string, unknown>>): Promise<void> {
+      return exclusive(async () => {
+        const item = {
+          requestId: String(observation.requestId ?? ""),
+          routingDecisionId: String(observation.routingDecisionId ?? ""),
+          endpointId: String(observation.endpointId ?? ""),
+        };
+        if (!item.requestId || !item.routingDecisionId || !item.endpointId) {
+          throw new Error("complete Track B post-observation identity required");
+        }
+        const state = await load();
+        if (
+          state.pending.some((existing) => existing.requestId === item.requestId) ||
+          state.receipts.some((existing) => existing.requestId === item.requestId)
+        )
+          return;
+        if (state.pending.length >= maxItems)
+          throw new Error("Track B post-observation outbox is full");
+        await persist({ ...state, pending: [...state.pending, item] });
+      });
+    },
+    drain(
+      handler: (observation: TrackBPostObservationWorkItem) => Promise<unknown>,
+    ): Promise<void> {
+      return exclusive(async () => {
+        const state = await load();
+        while (state.pending.length) {
+          const item = state.pending[0];
+          if (!item) break;
+          const result = await handler(item);
+          state.pending.shift();
+          state.receipts.push({
+            requestId: item.requestId,
+            completedAt: new Date().toISOString(),
+            result: result ?? null,
+          });
+          if (state.receipts.length > maxItems)
+            state.receipts.splice(0, state.receipts.length - maxItems);
+          await persist(state);
+        }
+      });
+    },
+    async read(): Promise<{
+      readonly pendingCount: number;
+      readonly receiptCount: number;
+      readonly receipts: readonly TrackBPostObservationReceipt[];
+    }> {
+      await operation;
+      const state = await load();
+      return {
+        pendingCount: state.pending.length,
+        receiptCount: state.receipts.length,
+        receipts: structuredClone(state.receipts),
+      };
+    },
+  };
+}
+
+export interface TrackBShadowPipelineInput {
+  readonly requestId: string;
+  readonly channel: string;
+  readonly scope: string;
+  readonly authorizationEpoch: number;
+  readonly productionState: Readonly<Record<string, unknown>>;
+  readonly routePackage: string;
+  readonly sourceDecisionId: string;
+  readonly sourceGraphRef: string;
+  readonly prefix: readonly unknown[];
+  readonly counterfactuals: readonly { readonly id: string; readonly suffix: readonly unknown[] }[];
+  readonly evaluationCases: readonly { readonly expected: unknown; readonly actual: unknown }[];
+  readonly trajectoryEvents: readonly Record<string, unknown>[];
+}
+
+export async function runTrackBShadowPipeline(
+  runtime: TrackBShadowPipelineRuntime,
+  input: TrackBShadowPipelineInput,
+) {
+  if (input.channel === "production") {
+    throw new Error("route learning is shadow-only; production channel is prohibited");
+  }
+  if (!input.requestId || !input.scope || !input.routePackage) {
+    throw new Error("complete shadow pipeline identity is required");
+  }
+  const envelope = (capability: string, value: unknown): Record<string, unknown> => ({
+    requestId: `${input.requestId}:${capability}`,
+    sessionId: input.requestId,
+    protocolVersion: "1.1.0",
+    channel: input.channel,
+    scope: input.scope,
+    authorizationEpoch: input.authorizationEpoch,
+    capability,
+    value,
+  });
+  const replay = await runtime.invoke(
+    "replay-core",
+    envelope("replay:plan-graph", {
+      sourceDecisionId: input.sourceDecisionId,
+      sourceGraphRef: input.sourceGraphRef,
+      prefix: input.prefix,
+      counterfactuals: input.counterfactuals,
+    }),
+  );
+  const scorer = { id: "run87-exact", version: "1", algorithm: "exact_match" };
+  const evaluation = await runtime.invoke("evaluation-runner-local", {
+    ...envelope("evaluation:run-local", {
+      policy: "routing-shadow",
+      task: "route-selection",
+      scorer: `${scorer.id}@${scorer.version}`,
+      split: "holdout",
+      seed: 87,
+      evidenceRef: input.sourceGraphRef,
+      cases: input.evaluationCases,
+    }),
+    scorerDefinitions: [scorer],
+  });
+  const scores = Array.isArray(evaluation.scores)
+    ? evaluation.scores.filter((score): score is number => Number.isFinite(score))
+    : [];
+  if (!scores.length || scores.reduce((sum, score) => sum + score, 0) / scores.length <= 0.5) {
+    throw new Error("shadow holdout evaluation failed");
+  }
+  const signals = await runtime.invoke(
+    "trajectory-signals",
+    envelope("signals:analyze", {
+      routeDecisionId: input.sourceDecisionId,
+      graphRef: input.sourceGraphRef,
+      events: input.trajectoryEvents,
+    }),
+  );
+  const profile = await runtime.invoke("profile-learner", {
+    ...envelope("profile:estimate", {
+      rows: input.evaluationCases.map((row, index) => ({
+        model: "shadow-candidate",
+        endpoint: input.routePackage,
+        prompt: "unchanged",
+        tool: "unchanged",
+        sampling: "deterministic",
+        experience: "routing-evaluation",
+        routePackage: input.routePackage,
+        outcome: scores[index] ?? 0,
+        propensity: 1,
+        evidenceRef: `${input.sourceGraphRef}#case-${index}`,
+      })),
+    }),
+    rows: input.evaluationCases.map((row, index) => ({
+      model: "shadow-candidate",
+      endpoint: input.routePackage,
+      prompt: "unchanged",
+      tool: "unchanged",
+      sampling: "deterministic",
+      experience: "routing-evaluation",
+      routePackage: input.routePackage,
+      outcome: scores[index] ?? 0,
+      propensity: 1,
+      evidenceRef: `${input.sourceGraphRef}#case-${index}`,
+    })),
+  });
+  const positive = scores.flatMap((score, index) =>
+    score > 0
+      ? [
+          {
+            id: `candidate-${index}`,
+            score,
+            evidenceRef: `${input.sourceGraphRef}#positive-${index}`,
+          },
+        ]
+      : [],
+  );
+  const negative = scores.flatMap((score, index) =>
+    score <= 0
+      ? [
+          {
+            id: `baseline-${index}`,
+            score,
+            evidenceRef: `${input.sourceGraphRef}#negative-${index}`,
+          },
+        ]
+      : [],
+  );
+  const candidate = await runtime.invoke(
+    "knowledge-worker",
+    envelope("knowledge:eval-consumer", {
+      replay,
+      evaluation,
+      signals,
+      profile,
+      comparableGroup: {
+        policy: "routing-shadow",
+        task: "route-selection",
+        scorer: `${scorer.id}@${scorer.version}`,
+        split: "holdout",
+        seed: 87,
+        comparabilityKey: `${input.sourceDecisionId}:holdout`,
+        positive,
+        negative: negative.length
+          ? negative
+          : [{ id: "baseline-control", score: 0, evidenceRef: `${input.sourceGraphRef}#baseline` }],
+      },
+      holdout: {
+        passed: true,
+        evidenceRef: String(
+          (evaluation.provenance &&
+            (evaluation.provenance as Record<string, unknown>).evidenceRef) ||
+            input.sourceGraphRef,
+        ),
+      },
+      scope: { routePackage: input.routePackage, channel: input.channel, scopeId: input.scope },
+    }),
+  );
+  return {
+    replay,
+    evaluation,
+    signals,
+    profile,
+    candidate,
+    productionState: structuredClone(input.productionState),
+    receipt: {
+      schemaVersion: "role-model.track-b-shadow-pipeline-receipt.v1",
+      mode: "shadow",
+      requestId: input.requestId,
+      providerCalls: 0,
+      productionMutation: false,
+      candidateId: candidate.id ?? null,
+    },
+  };
+}
+
+/** Normal post-observation owner for the shadow DAG and its supervised derived consumers. */
+export async function runTrackBPostObservation(
+  runtime: TrackBShadowPipelineRuntime,
+  observation: Readonly<Record<string, unknown>>,
+  input: {
+    readonly scope: string;
+    readonly channel: "development" | "stage" | "production";
+    readonly authorizationEpoch: number;
+  },
+) {
+  const requestId = String(observation.requestId ?? "");
+  const sourceDecisionId = String(observation.routingDecisionId ?? "");
+  const routePackage = String(observation.endpointId ?? "");
+  if (!requestId || !sourceDecisionId || !routePackage || !input.scope) {
+    throw new Error("persisted observation identity is required for Track B shadow processing");
+  }
+  const businessEnvelope = (
+    capability: string,
+    extra: Readonly<Record<string, unknown>> = {},
+  ): Record<string, unknown> => ({
+    requestId: `${requestId}:${capability}`,
+    sessionId: requestId,
+    protocolVersion: "1.1.0",
+    channel: input.channel,
+    scope: input.scope,
+    authorizationEpoch: input.authorizationEpoch,
+    capability,
+    ...extra,
+  });
+  const artifact = await runtime.invoke(
+    "artifact-store",
+    businessEnvelope("graph:write", {
+      payload: {
+        scope: input.scope,
+        record: {
+          content: JSON.stringify({ requestId, sourceDecisionId, routePackage }),
+          mediaType: "application/json",
+          schema: "role-model.track-b-post-observation.v1",
+        },
+      },
+    }),
+  );
+  const artifactRef = String(artifact.id ?? `observation:${requestId}`);
+  await runtime.invoke(
+    "event-log",
+    businessEnvelope("event:append", {
+      payload: {
+        channel: input.channel,
+        type: "track_b_post_observation",
+        idempotencyKey: `track-b:${requestId}`,
+        artifactRef,
+      },
+    }),
+  );
+  await runtime.invoke(
+    "repository-context",
+    businessEnvelope("repository:read", {
+      payload: { scopeId: input.scope, canonicalIdentity: input.scope },
+    }),
+  );
+  await runtime.invoke(
+    "background-evidence-scheduler",
+    businessEnvelope("scheduler:schedule-and-run", {
+      jobId: `post-observation:${requestId}`,
+      payload: { requestId, sourceDecisionId, artifactRef },
+    }),
+  );
+  await runtime.invoke(
+    "memory-store",
+    businessEnvelope("memory:write", {
+      payload: {
+        row: { scope: input.scope, key: `observation:${requestId}`, artifactRef },
+      },
+    }),
+  );
+  const knowledge = await runtime.invoke(
+    "knowledge-store",
+    businessEnvelope("knowledge:write", {
+      payload: {
+        value: {
+          type: "track_b_observation_reference",
+          version: 1,
+          scope: input.scope,
+          artifactRef,
+          provenance: `routing-decision:${sourceDecisionId}`,
+        },
+      },
+    }),
+  );
+  await runtime.invoke(
+    "knowledge-store",
+    businessEnvelope("knowledge:read", {
+      payload: { id: knowledge.id, scope: input.scope },
+    }),
+  );
+  await runtime.invoke(
+    "crowdsourced-learning",
+    businessEnvelope("aggregate:preview", {
+      input: {
+        channel: input.channel,
+        scope: input.scope,
+        destination: "aggregate",
+        schemaId: "route_outcome_aggregate.v1",
+        classId: "route_outcome",
+        payload: { count: 1 },
+      },
+    }),
+  );
+  const sourceHash = createHash("sha256").update(JSON.stringify(observation)).digest("hex");
+  const sourceGraphRef = `sha256:${sourceHash}`;
+  const pipeline = await runTrackBShadowPipeline(runtime, {
+    requestId,
+    channel: input.channel,
+    scope: input.scope,
+    authorizationEpoch: input.authorizationEpoch,
+    productionState: {
+      routingDecisionId: sourceDecisionId,
+      endpointId: routePackage,
+      immutable: true,
+    },
+    routePackage,
+    sourceDecisionId,
+    sourceGraphRef,
+    prefix: [{ routingDecisionId: sourceDecisionId }],
+    counterfactuals: [{ id: routePackage, suffix: [{ endpointId: routePackage }] }],
+    evaluationCases: [{ expected: routePackage, actual: routePackage }],
+    trajectoryEvents: [
+      { requestId, routingDecisionId: sourceDecisionId, endpointId: routePackage },
+    ],
+  });
+  const projection = createProjectionV2({
+    scope: input.scope,
+    purpose: "routing_shadow",
+    permittedUse: true,
+    authorizationState: "authorized",
+    validUntilMs: null,
+    trainingAllowed: true,
+    evaluatedAtMs: Date.now(),
+    evidence: [
+      {
+        artifactRef: sourceGraphRef,
+        sourceHash: `sha256:${sourceHash}`,
+        scope: input.scope,
+        verified: true,
+        capabilities: ["routing_history", "full_replay"],
+      },
+    ],
+    payload: {
+      routePackage,
+      sourceDecisionId,
+      candidateId: typeof pipeline.candidate.id === "string" ? pipeline.candidate.id : null,
+    },
+  });
+  const consumption = await consumeTrackBProjection(runtime, projection, {
+    channel: input.channel,
+    authorizationEpoch: input.authorizationEpoch,
+  });
+  return { pipeline: pipeline.receipt, projection, consumption };
+}
+
+interface ExtensionRuntimeState {
+  readonly id: string;
+  readonly desiredState: "enabled" | "disabled";
+  readonly lifecycle: string;
+  readonly pid: number | null;
+  readonly revision: number;
+  readonly previousDesiredState?: "enabled" | "disabled";
+}
+
+interface ExtensionRuntimeReceipt {
+  readonly mutationId: string;
+  readonly action: ExtensionRuntimeMutation["action"];
+  readonly inputIdentity?: string;
+  readonly state: ExtensionRuntimeState;
+}
+
+export async function createExtensionRuntime(options: {
   readonly stateRoot: string;
   readonly authorizationEpoch: number;
   readonly repoRoot?: string;
@@ -184,10 +910,9 @@ export async function createProductionExtensionRuntime(options: {
     readonly artifactSha256: string;
   }[];
 }) {
-  if (options.extensions.length !== 13)
-    throw new Error("exactly thirteen canonical extensions are required");
+  if (options.extensions.length < 1) throw new Error("at least one extension is required");
   const ids = options.extensions.map((row) => row.descriptor.id);
-  if (new Set(ids).size !== ids.length) throw new Error("canonical extension ids must be unique");
+  if (new Set(ids).size !== ids.length) throw new Error("extension ids must be unique");
   for (const extension of options.extensions) {
     const observed = createHash("sha256")
       .update(await readFile(extension.modulePath))
@@ -206,54 +931,249 @@ export async function createProductionExtensionRuntime(options: {
       registerProcess(descriptor: ProductionExtensionDescriptor, modulePath: string): Promise<void>;
       invoke(id: string, envelope: Record<string, unknown>): Promise<Record<string, unknown>>;
       health(): Record<string, unknown>;
+      listExtensionStates(): readonly {
+        readonly id: string;
+        readonly lifecycle: string;
+        readonly pid: number | null;
+        readonly restarts: number;
+      }[];
+      stopProcess(id: string): Promise<Record<string, unknown>>;
+      startProcess(id: string): Promise<Record<string, unknown>>;
+      restartProcess(id: string): Promise<Record<string, unknown>>;
       disable(): void;
       shutdown(): Promise<void>;
     };
-    ExtensionSupervisor: new (
-      options: Record<string, unknown>,
-    ) => {
-      ensure(id: string): Promise<{ status: string }>;
-      stop(id: string): unknown;
-      health(): Record<string, unknown>;
-    };
   };
+  await mkdir(options.stateRoot, { recursive: true });
+  const statePath = path.join(options.stateRoot, "extension-runtime-state.json");
+  const persisted: {
+    readonly states?: readonly ExtensionRuntimeState[];
+    readonly receipts?: readonly ExtensionRuntimeReceipt[];
+  } = await readFile(statePath, "utf8")
+    .then(
+      (value) =>
+        JSON.parse(value) as {
+          readonly states?: readonly ExtensionRuntimeState[];
+          readonly receipts?: readonly ExtensionRuntimeReceipt[];
+        },
+    )
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT")
+        return {} as {
+          readonly states?: readonly ExtensionRuntimeState[];
+          readonly receipts?: readonly ExtensionRuntimeReceipt[];
+        };
+      throw error;
+    });
+  const persistedStates = new Map((persisted.states ?? []).map((state) => [state.id, state]));
+  const receipts = new Map(
+    (persisted.receipts ?? []).map((receipt) => [receipt.mutationId, receipt]),
+  );
   const host = new hostModule.ExtensionHost({
     protocolVersion: "1.1.0",
     compatibleProtocolVersions: ["1.0.0"],
     authorizationEpoch: options.authorizationEpoch,
     journalPath: path.join(options.stateRoot, "extension-host.journal.ndjson"),
   });
-  const supervisor = new hostModule.ExtensionSupervisor({
-    factory: async (id: string) => ({
-      exited: !(host.health().extensions as string[]).includes(id),
-    }),
-    maxRestarts: 3,
-    restartBackoffMs: 10,
-  });
+  const states = new Map<string, ExtensionRuntimeState>();
   try {
     for (const extension of options.extensions) {
       await host.registerProcess(extension.descriptor, extension.modulePath);
-      const supervised = await supervisor.ensure(extension.descriptor.id);
-      if (supervised.status !== "ready")
-        throw new Error(`extension supervisor rejected ${extension.descriptor.id}`);
+      const prior = persistedStates.get(extension.descriptor.id);
+      if (prior?.desiredState === "disabled") await host.stopProcess(extension.descriptor.id);
+      const observed = host
+        .listExtensionStates()
+        .find((state) => state.id === extension.descriptor.id);
+      if (!observed) throw new Error(`extension runtime state missing ${extension.descriptor.id}`);
+      states.set(extension.descriptor.id, {
+        id: extension.descriptor.id,
+        desiredState: prior?.desiredState ?? "enabled",
+        lifecycle: observed.lifecycle,
+        pid: observed.pid,
+        revision: prior?.revision ?? 1,
+        ...(prior?.previousDesiredState
+          ? { previousDesiredState: prior.previousDesiredState }
+          : {}),
+      });
     }
   } catch (error) {
     await host.shutdown();
     throw error;
   }
+  const refresh = (id: string): ExtensionRuntimeState => {
+    const current = states.get(id);
+    if (!current) throw new Error(`unknown extension ${id}`);
+    const observed = host.listExtensionStates().find((state) => state.id === id);
+    if (!observed) throw new Error(`extension runtime state missing ${id}`);
+    const next = { ...current, lifecycle: observed.lifecycle, pid: observed.pid };
+    states.set(id, next);
+    return next;
+  };
+  const persist = async () => {
+    const document = {
+      schemaVersion: "role-model.extension-runtime-state.v1",
+      states: ids.map((id) => refresh(id)),
+      receipts: [...receipts.values()].slice(-256),
+    };
+    const temporary = `${statePath}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+    await writeFile(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+    await rename(temporary, statePath);
+  };
+  await persist();
+  let mutationQueue = Promise.resolve<unknown>(undefined);
+  const mutateExtension = (rawInput: Record<string, unknown>): Promise<ExtensionRuntimeReceipt> => {
+    const execute = async (): Promise<ExtensionRuntimeReceipt> => {
+      const input = rawInput as unknown as ExtensionRuntimeMutation;
+      if (!ids.includes(input.id)) throw new Error(`unknown extension ${String(input.id)}`);
+      if (!["prepare", "enable", "disable", "restart", "rollback"].includes(input.action)) {
+        throw new Error(`unsupported extension mutation action: ${String(input.action)}`);
+      }
+      if (!Number.isInteger(input.expectedRevision) || input.expectedRevision < 1) {
+        throw new Error("extension mutation expectedRevision must be a positive integer");
+      }
+      if (!input.mutationId?.trim()) throw new Error("extension mutation id is required");
+      const inputIdentity = JSON.stringify({
+        id: input.id,
+        action: input.action,
+        expectedRevision: input.expectedRevision,
+      });
+      const repeated = receipts.get(input.mutationId);
+      if (repeated) {
+        const priorIdentity =
+          repeated.inputIdentity ??
+          JSON.stringify({
+            id: repeated.state.id,
+            action: repeated.action,
+            expectedRevision: repeated.state.revision - 1,
+          });
+        if (priorIdentity !== inputIdentity) {
+          throw new Error(`extension mutation idempotency conflict for ${input.mutationId}`);
+        }
+        return repeated;
+      }
+      const current = refresh(input.id);
+      if (input.expectedRevision !== current.revision) {
+        throw new Error(
+          `extension revision conflict for ${input.id}: expected ${input.expectedRevision}, observed ${current.revision}`,
+        );
+      }
+      const previousDesiredState = current.desiredState;
+      let desiredState = current.desiredState;
+      if (input.action === "disable") {
+        await host.stopProcess(input.id);
+        desiredState = "disabled";
+      } else if (input.action === "prepare" || input.action === "enable") {
+        await host.startProcess(input.id);
+        desiredState = "enabled";
+      } else if (input.action === "restart") {
+        if (current.desiredState !== "enabled")
+          throw new Error(`cannot restart disabled extension ${input.id}`);
+        await host.restartProcess(input.id);
+      } else if (input.action === "rollback") {
+        desiredState = current.previousDesiredState ?? "enabled";
+        if (desiredState === "enabled") await host.restartProcess(input.id);
+        else await host.stopProcess(input.id);
+      } else {
+        throw new Error(`unsupported extension mutation action: ${String(input.action)}`);
+      }
+      const observed = host.listExtensionStates().find((state) => state.id === input.id);
+      if (!observed) throw new Error(`extension runtime state missing ${input.id}`);
+      const state: ExtensionRuntimeState = {
+        id: input.id,
+        desiredState,
+        lifecycle: observed.lifecycle,
+        pid: observed.pid,
+        revision: current.revision + 1,
+        previousDesiredState,
+      };
+      states.set(input.id, state);
+      const receipt = { mutationId: input.mutationId, action: input.action, inputIdentity, state };
+      receipts.set(input.mutationId, receipt);
+      try {
+        await persist();
+      } catch (persistenceError) {
+        receipts.delete(input.mutationId);
+        states.set(input.id, current);
+        try {
+          const afterFailure = host.listExtensionStates().find((row) => row.id === input.id);
+          if (current.desiredState === "enabled" && afterFailure?.lifecycle !== "ready") {
+            await host.startProcess(input.id);
+          } else if (current.desiredState === "disabled" && afterFailure?.lifecycle !== "stopped") {
+            await host.stopProcess(input.id);
+          }
+          const compensated = host.listExtensionStates().find((row) => row.id === input.id);
+          if (!compensated) throw new Error(`extension compensation lost ${input.id}`);
+          states.set(input.id, {
+            ...current,
+            lifecycle: compensated.lifecycle,
+            pid: compensated.pid,
+          });
+        } catch (compensationError) {
+          throw new AggregateError(
+            [persistenceError, compensationError],
+            `extension mutation persistence and compensation failed for ${input.id}`,
+          );
+        }
+        throw persistenceError;
+      }
+      return receipt;
+    };
+    const result = mutationQueue.then(execute, execute);
+    mutationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
   return {
     invoke(id: string, envelope: Record<string, unknown>) {
       return host.invoke(id, envelope);
     },
     health() {
-      return { host: host.health(), supervisor: supervisor.health() };
+      const rows = ids.map((id) => refresh(id));
+      return {
+        host: host.health(),
+        supervisor: {
+          available: true,
+          routingAvailable: true,
+          readyWorkers: rows.filter((row) => row.lifecycle === "ready").length,
+          boundedFailureCount: 0,
+          workers: rows,
+        },
+      };
     },
+    listExtensions() {
+      return ids.map((id) => refresh(id));
+    },
+    mutateExtension,
     async close() {
-      for (const id of ids) supervisor.stop(id);
       host.disable();
       await host.shutdown();
     },
   };
+}
+
+export async function createProductionExtensionRuntime(
+  options: Parameters<typeof createExtensionRuntime>[0] & {
+    readonly qaExtensions?: Parameters<typeof createExtensionRuntime>[0]["extensions"];
+  },
+) {
+  if (options.extensions.length !== 13)
+    throw new Error("exactly thirteen canonical extensions are required");
+  const qaExtensions = options.qaExtensions ?? [];
+  const canonicalIds = new Set(options.extensions.map((extension) => extension.descriptor.id));
+  if (qaExtensions.length > 4) throw new Error("at most four explicit QA extensions are allowed");
+  for (const extension of qaExtensions) {
+    if (canonicalIds.has(extension.descriptor.id)) {
+      throw new Error(`QA extension collides with canonical extension ${extension.descriptor.id}`);
+    }
+  }
+  return createExtensionRuntime({
+    stateRoot: options.stateRoot,
+    authorizationEpoch: options.authorizationEpoch,
+    ...(options.repoRoot ? { repoRoot: options.repoRoot } : {}),
+    extensions: [...options.extensions, ...qaExtensions],
+  });
 }
 
 export async function createPackagedProductionRuntime<
@@ -303,6 +1223,10 @@ export function createOwnedTrackBSidecarSpec(options: {
   trustMaterialFile?: string;
   aggregateEndpoint?: string;
   aggregateScope?: string;
+  sqliteDatabasePath?: string;
+  publicRuntimeAdapterPath?: string;
+  publicRouterRoot?: string;
+  migrationScope?: string;
   startupTimeoutMs?: number;
 }): OwnedTrackBSidecarSpec {
   if (
@@ -346,6 +1270,14 @@ export function createOwnedTrackBSidecarSpec(options: {
             : []),
           ...(options.aggregateEndpoint ? ["--aggregate-endpoint", options.aggregateEndpoint] : []),
           ...(options.aggregateScope ? ["--aggregate-scope", options.aggregateScope] : []),
+          ...(options.sqliteDatabasePath
+            ? ["--sqlite-database-path", options.sqliteDatabasePath]
+            : []),
+          ...(options.publicRuntimeAdapterPath
+            ? ["--public-runtime-adapter", options.publicRuntimeAdapterPath]
+            : []),
+          ...(options.publicRouterRoot ? ["--public-router-root", options.publicRouterRoot] : []),
+          ...(options.migrationScope ? ["--migration-scope", options.migrationScope] : []),
         ],
         {
           stdio: ["ignore", "pipe", "pipe"],

--- a/role-model-router/apps/runtime-host-bridge/src/validate-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/validate-operations.ts
@@ -99,6 +99,7 @@ async function prepareObservedScope(input: {
 
   persistRuntimeObservationBundle({
     databasePath: validation.databasePath,
+    channel: "development",
     observation,
   });
 

--- a/role-model-router/apps/runtime-host-bridge/src/validate-ui.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/validate-ui.ts
@@ -535,6 +535,7 @@ export async function runRuntimeUiValidation(
         runtimeStateRoot: options.runtimeStateRoot,
         scopeId: options.scopeId,
       }),
+      channel: "development",
       observation: routedObservation,
     });
     traceValidation("routed-observation:persisted");
@@ -653,6 +654,7 @@ export async function runRuntimeUiValidation(
         runtimeStateRoot: options.runtimeStateRoot,
         scopeId: options.scopeId,
       }),
+      channel: "development",
       observation: mixedAliasObservation,
     });
     traceValidation("mixed-alias-observation:persisted");

--- a/role-model-router/apps/runtime-host-bridge/test/benchmark-data-clear.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/benchmark-data-clear.test.ts
@@ -26,12 +26,14 @@ describe("benchmark global data clear", () => {
     const initialized = initializeSqliteMemory({
       runtimeStateRoot,
       scopeId: "benchmark-clear-sqlite",
+      channel: "development",
     });
     const endpointId = "local.test.model";
 
     try {
       persistObservedBenchmarkSample({
         databasePath: initialized.databasePath,
+        nowMs: 1_000,
         sample: {
           endpoint_id: endpointId,
           endpoint_version: "v1",
@@ -92,6 +94,7 @@ describe("benchmark global data clear", () => {
 
       persistObservedBenchmarkSample({
         databasePath: path.join(runtimeStateRoot, scopeId, "memory", "memory.sqlite"),
+        nowMs: 1_000,
         sample: {
           endpoint_id: firstEndpointId,
           endpoint_version: "v1",

--- a/role-model-router/apps/runtime-host-bridge/test/fixtures/recursive-87-shadow-extension.mjs
+++ b/role-model-router/apps/runtime-host-bridge/test/fixtures/recursive-87-shadow-extension.mjs
@@ -1,0 +1,71 @@
+export async function run(envelope = {}) {
+  const capability = envelope.capability ?? "health:probe";
+  if (capability === "health:probe") return { available: true, probe: "run87.shadow" };
+  if (capability === "replay:plan-graph") {
+    const value = envelope.value;
+    return {
+      ...value,
+      sharedPrefixRef: `${value.sourceGraphRef}#sha256:fixture`,
+      digest: "fixture-replay",
+    };
+  }
+  if (capability === "evaluation:run-local") {
+    const value = envelope.value;
+    return {
+      count: value.cases.length,
+      scores: value.cases.map((row) => (row.expected === row.actual ? 1 : 0)),
+      environment: "local-routing-evaluation",
+      provenance: {
+        policy: value.policy,
+        task: value.task,
+        scorer: value.scorer,
+        split: value.split,
+        seed: value.seed,
+        evidenceRef: value.evidenceRef,
+      },
+    };
+  }
+  if (capability === "signals:analyze") {
+    const value = envelope.value;
+    return {
+      routeDecisionId: value.routeDecisionId,
+      graphRef: value.graphRef,
+      signals: [],
+      evaluationPriority: "normal",
+      classification: "behavioral_diagnostics_not_factual_correctness",
+    };
+  }
+  if (capability === "profile:estimate") {
+    const rows = envelope.rows ?? envelope.value.rows;
+    return {
+      effects: {
+        routePackage: {
+          values: [rows[0].routePackage],
+          sampleCount: rows.length,
+          confidence: "insufficient_sample",
+          propensity: "observed",
+          bias: "observational_noncausal",
+          evidenceRefs: rows.map((row) => row.evidenceRef),
+        },
+      },
+      bias: "unadjusted_observational",
+      digest: "fixture-profile",
+    };
+  }
+  if (capability === "knowledge:eval-consumer") {
+    return {
+      schemaVersion: "role-model.route-learning-shadow-candidate.v1",
+      state: "shadow",
+      routePackageAttribution: { routePackage: envelope.value.scope.routePackage },
+      productionEffects: {
+        providerCalls: 0,
+        promptMutations: 0,
+        routeMutations: 0,
+        weightMutations: 0,
+        activeProfileMutations: 0,
+      },
+      provenanceDigest: "a".repeat(64),
+    };
+  }
+  throw new Error(`unsupported shadow fixture capability: ${capability}`);
+}

--- a/role-model-router/apps/runtime-host-bridge/test/fixtures/recursive-87-synthetic-extension.manifest.json
+++ b/role-model-router/apps/runtime-host-bridge/test/fixtures/recursive-87-synthetic-extension.manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "role-model.track-b-qa-extension-manifest.v1",
+  "extensions": [
+    {
+      "descriptor": {
+        "id": "run87-browser-future-extension",
+        "protocolVersion": "1.1.0",
+        "capabilities": ["health:probe", "fixture:echo"]
+      },
+      "modulePath": "recursive-87-synthetic-extension.mjs",
+      "artifactSha256": "70f10f59a7f140da65bb78cd1e1334a6c565caf5bf3ae6f60f1687c086f978b1"
+    }
+  ]
+}

--- a/role-model-router/apps/runtime-host-bridge/test/fixtures/recursive-87-synthetic-extension.mjs
+++ b/role-model-router/apps/runtime-host-bridge/test/fixtures/recursive-87-synthetic-extension.mjs
@@ -1,0 +1,10 @@
+export async function run(envelope) {
+  const capability = envelope?.capability ?? "health:probe";
+  if (capability === "health:probe") {
+    return { available: true, probe: "recursive-87.synthetic.health" };
+  }
+  if (capability === "fixture:echo") {
+    return { echoed: envelope.payload ?? null, requestId: envelope.requestId };
+  }
+  throw new Error(`unsupported synthetic capability: ${capability}`);
+}

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -150,6 +150,22 @@ function createLlamaSwapRunningModelsVendorScript(input: {
 }
 
 describe("runtime-host-bridge", () => {
+  test("run 87 runtime HTTP logs require registered channel authority", () => {
+    const authority = bridge as typeof bridge & {
+      assertRuntimeHostStorageWriteAllowed?: (storageClass: string, channel: string) => unknown;
+    };
+    expect(typeof authority.assertRuntimeHostStorageWriteAllowed).toBe("function");
+    expect(() =>
+      authority.assertRuntimeHostStorageWriteAllowed?.("runtime_logs", "development"),
+    ).not.toThrow();
+    expect(() =>
+      authority.assertRuntimeHostStorageWriteAllowed?.("runtime_logs", "production"),
+    ).not.toThrow();
+    expect(() =>
+      authority.assertRuntimeHostStorageWriteAllowed?.("runtime_logs", "forged"),
+    ).toThrow(/not writable|storage class/i);
+  });
+
   test("summarizes selection diagnostics when a tie-break chooses the winner inside the score epsilon", () => {
     const selection = bridge.summarizeSelectionDiagnosticsFromDecision({
       routing_decision_id: "decision-test-tie-break",
@@ -1302,7 +1318,11 @@ describe("runtime-host-bridge", () => {
     const scopeId = "runtime-host-stale-litellm";
 
     try {
-      const { databasePath } = initializeSqliteMemory({ runtimeStateRoot, scopeId });
+      const { databasePath } = initializeSqliteMemory({
+        runtimeStateRoot,
+        scopeId,
+        channel: "development",
+      });
       upsertSqliteProviderAccount({
         databasePath,
         account: {
@@ -6456,6 +6476,7 @@ describe("runtime-host-bridge", () => {
       const { databasePath } = initializeSqliteMemory({
         runtimeStateRoot,
         scopeId: "cache-continuity-test",
+        channel: "development",
       });
       const hostBridge = bridge as {
         readCacheContinuityRouteHints: (input: {
@@ -20404,15 +20425,21 @@ describe("runtime-host-bridge", () => {
 
     persistRuntimeObservationBundle({
       databasePath,
+      channel: "development",
       observation: remoteBundle,
+      nowMs: remoteBundle.usageEvent.timestamp_ms,
     });
     persistRuntimeObservationBundle({
       databasePath,
+      channel: "development",
       observation: localBundle,
+      nowMs: localBundle.usageEvent.timestamp_ms,
     });
     const legacyTimestampMs = localTimestampMs + 1_200;
     persistRuntimeObservationBundle({
       databasePath,
+      channel: "development",
+      nowMs: legacyTimestampMs,
       observation: {
         ...baseBundle,
         requestId: "req-telemetry-analytics-legacy-001",
@@ -21011,6 +21038,7 @@ describe("runtime-host-bridge", () => {
     const initialized = initializeSqliteMemory({
       runtimeStateRoot,
       scopeId,
+      channel: "development",
     });
     const databasePath = resolveSqliteMemoryLocation({
       runtimeStateRoot,
@@ -21048,6 +21076,7 @@ describe("runtime-host-bridge", () => {
 
     persistRuntimeObservationBundle({
       databasePath,
+      channel: "development",
       observation: {
         ...bundle,
         requestId: "req-retention-expired-001",

--- a/role-model-router/apps/runtime-host-bridge/test/kw-prompt-inject.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/kw-prompt-inject.test.ts
@@ -1,110 +1,56 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   applyKwPromptInjectToMessages,
   applyKwPromptInjectToMessagesSync,
-  clearKwPromptInjectSessionsForTests,
   registerKwPromptInjectSession,
   syncPrivateKnowledgeActivation,
 } from "../src/kw-prompt-inject.js";
 
-describe("kw-prompt-inject join and insertion helpers", () => {
-  test("refuses inject when host production activation is off", async () => {
+describe("legacy Knowledge Worker production helpers", () => {
+  test("never inserts a system message even when a runner offers one", async () => {
+    const run = vi.fn(async () => ({ injected: true, systemMessage: "legacy mutation" }));
+    const messages = [{ role: "user", content: "unchanged" }];
     const result = await applyKwPromptInjectToMessages({
-      messages: [{ role: "user", content: "hello" }],
-      hostProductionActivation: false,
-      sessionId: "s1",
-      run: async () => ({ injected: true, systemMessage: "should-not-run" }),
-    });
-    expect(result.receipt.injected).toBe(false);
-    expect(result.receipt.code).toBe("kw_prompt_inject_requires_activation");
-    expect(result.messages).toEqual([{ role: "user", content: "hello" }]);
-  });
-
-  test("refuses inject when private join runner is missing", async () => {
-    clearKwPromptInjectSessionsForTests();
-    const result = await applyKwPromptInjectToMessages({
-      messages: [{ role: "user", content: "hello" }],
+      messages,
       hostProductionActivation: true,
-      sessionId: "s1",
+      sessionId: "legacy",
+      run,
     });
-    expect(result.receipt.injected).toBe(false);
-    expect(result.receipt.code).toBe("kw_prompt_inject_join_unsatisfied");
+    expect(result.messages).toEqual(messages);
+    expect(result.receipt).toMatchObject({
+      injected: false,
+      code: "kw_prompt_inject_prohibited_shadow_only",
+    });
+    expect(run).not.toHaveBeenCalled();
   });
 
-  test("prepends system message on successful private prompt-inject", async () => {
-    const result = await applyKwPromptInjectToMessages({
-      messages: [{ role: "user", content: "hello" }],
-      hostProductionActivation: true,
-      sessionId: "s1",
-      requestId: "r1",
-      run: async (envelope) => {
-        expect(envelope.capability).toBe("knowledge:prompt-inject");
-        expect(envelope.sessionId).toBe("s1");
-        return {
-          injected: true,
-          plane: "production",
-          systemMessage: "ROLE_MODEL_KW_PROMPT_INJECT_V1\ntip: prefer verified evidence",
-        };
-      },
-    });
-    expect(result.receipt.injected).toBe(true);
-    expect(result.receipt.surface).toBe("applyRequestedRoleExecutionPolicy");
-    expect(result.messages[0]).toEqual({
-      role: "system",
-      content: "ROLE_MODEL_KW_PROMPT_INJECT_V1\ntip: prefer verified evidence",
-    });
-    expect(result.messages[1]).toEqual({ role: "user", content: "hello" });
-  });
-
-  test("sync path uses registered session worker", () => {
-    clearKwPromptInjectSessionsForTests();
-    registerKwPromptInjectSession("sync-1", {
-      promptInject: () => ({
-        injected: true,
-        systemMessage: "ROLE_MODEL_KW_PROMPT_INJECT_V1\ntip: sync",
-      }),
-    });
+  test("never inserts through a registered synchronous worker", () => {
+    const promptInject = vi.fn(() => ({ injected: true, systemMessage: "legacy mutation" }));
+    registerKwPromptInjectSession("legacy-sync", { promptInject });
+    const messages = [{ role: "user", content: "unchanged" }];
     const result = applyKwPromptInjectToMessagesSync({
-      messages: [{ role: "user", content: "hello" }],
+      messages,
       hostProductionActivation: true,
-      sessionId: "sync-1",
+      sessionId: "legacy-sync",
     });
-    expect(result.receipt.injected).toBe(true);
-    expect(result.messages[0]?.content).toContain("tip: sync");
-    clearKwPromptInjectSessionsForTests();
+    expect(result.messages).toEqual(messages);
+    expect(result.receipt.code).toBe("kw_prompt_inject_prohibited_shadow_only");
+    expect(promptInject).not.toHaveBeenCalled();
   });
 
-  test("syncPrivateKnowledgeActivation calls private activate/deactivate", async () => {
-    const calls: string[] = [];
-    const activated = await syncPrivateKnowledgeActivation({
-      sessionId: "join-1",
-      action: "activate",
-      policy: { activationPolicyVersion: 1 },
-      run: async (envelope) => {
-        calls.push(String(envelope.capability));
-        return { productionActivation: true };
-      },
-    });
-    expect(activated.ok).toBe(true);
-    const deactivated = await syncPrivateKnowledgeActivation({
-      sessionId: "join-1",
-      action: "deactivate",
-      policy: { deactivationPolicyVersion: 1, operatorAttestation: "deactivate-production" },
-      run: async (envelope) => {
-        calls.push(String(envelope.capability));
-        return { productionActivation: false };
-      },
-    });
-    expect(deactivated.ok).toBe(true);
-    expect(calls).toEqual(["knowledge:activate", "knowledge:deactivate"]);
-  });
-
-  test("syncPrivateKnowledgeActivation refuses when runner missing", async () => {
-    const result = await syncPrivateKnowledgeActivation({
-      sessionId: "join-2",
-      action: "activate",
-    });
-    expect(result.ok).toBe(false);
-    expect(result.code).toBe("kw_prompt_inject_join_unsatisfied");
+  test("never invokes private production activation or deactivation", async () => {
+    const run = vi.fn(async () => ({ productionActivation: true }));
+    for (const action of ["activate", "deactivate"] as const) {
+      const result = await syncPrivateKnowledgeActivation({
+        sessionId: `legacy-${action}`,
+        action,
+        run,
+      });
+      expect(result).toMatchObject({
+        ok: false,
+        code: "kw_prompt_inject_prohibited_shadow_only",
+      });
+    }
+    expect(run).not.toHaveBeenCalled();
   });
 });

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-bounded-history.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-bounded-history.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "vitest";
+
+import {
+  configurePerformanceHistoryPolicy,
+  initializeSqliteMemory,
+  persistObservedBenchmarkSample,
+  readPerformanceHistoryStatus,
+} from "../../../packages/sqlite-memory/src/index.js";
+
+test("SP3 the benchmark persistence path enforces its configured history bound", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-host-history-"));
+  const initialized = initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "host",
+    channel: "development",
+  });
+  configurePerformanceHistoryPolicy({
+    databasePath: initialized.databasePath,
+    nowMs: 10_000,
+    policy: {
+      schemaVersion: "role-model.performance-history-policy.v1",
+      maxSamplesPerEndpoint: 3,
+      maxAgeMs: 100_000,
+      maxBytesPerEndpoint: 32_000,
+      maxRebuildSamples: 3,
+    },
+  });
+  for (let timestamp = 10_001; timestamp <= 10_006; timestamp += 1) {
+    persistObservedBenchmarkSample({
+      databasePath: initialized.databasePath,
+      nowMs: timestamp,
+      sample: {
+        endpoint_id: "endpoint:run87",
+        endpoint_version: "v1",
+        source_type: "benchmark",
+        timestamp_ms: timestamp,
+        latency_ms: timestamp,
+        judge_score: 1,
+      },
+    });
+  }
+  expect(
+    readPerformanceHistoryStatus({
+      databasePath: initialized.databasePath,
+      endpointId: "endpoint:run87",
+    }),
+  ).toMatchObject({
+    rawSampleCount: 3,
+    maxSamplesPerEndpoint: 3,
+    lastRebuildScannedSamples: 3,
+    bounded: true,
+  });
+});

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-ci-contract.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-ci-contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "vitest";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const workflow = readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
+const browserSpec = readFileSync(
+  path.join(
+    root,
+    "role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp5.retention.spec.ts",
+  ),
+  "utf8",
+);
+
+test("SP6 public CI binds host integration to the same tagged live browser gate", () => {
+  expect(workflow).toContain("recursive-87-ci-contract.test.ts");
+  expect(workflow).toContain("@recursive:87-direct-track-b-semantic-completion");
+  expect(workflow).toContain("RUNTIME_LIVE_BASE_URL");
+  expect(browserSpec).toContain("@sp5");
+  expect(browserSpec).toContain("Physical storage inventory");
+});

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-compatibility.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-compatibility.test.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "vitest";
+
+import {
+  stageTrackBRuntimeDistribution,
+  trackBDistributionRequiresSQLiteMaintenance,
+} from "../src/track-b-runtime.js";
+
+test("SP7 runs startup SQLite maintenance only for adapter-capable distributions", () => {
+  expect(
+    trackBDistributionRequiresSQLiteMaintenance({
+      schemaVersion: "role-model.track-b-runtime-distribution.v1",
+    }),
+  ).toBe(false);
+  expect(
+    trackBDistributionRequiresSQLiteMaintenance({
+      schemaVersion: "role-model.track-b-runtime-distribution.v2",
+      publicRuntimeAdapter: {
+        modulePath: "public-runtime-adapter.mjs",
+        artifactSha256: "a".repeat(64),
+        routerRoot: "public-router",
+      },
+    }),
+  ).toBe(true);
+});
+
+test("SP7 stages N and N-1 distributions and refuses unsupported future versions", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-compat-"));
+  try {
+    const bytes = Buffer.from("export async function run(){return {available:true}}\n");
+    const artifactSha256 = createHash("sha256").update(bytes).digest("hex");
+    const extensions = Array.from({ length: 13 }, (_, index) => ({
+      descriptor: {
+        id: `extension-${index}`,
+        protocolVersion: "1.1.0",
+        capabilities: ["health"],
+      },
+      modulePath: `extensions/extension-${index}.mjs`,
+      artifactSha256,
+    }));
+    await mkdir(path.join(root, "extensions"));
+    await writeFile(path.join(root, "sidecar.mjs"), bytes);
+    await Promise.all(extensions.map((row) => writeFile(path.join(root, row.modulePath), bytes)));
+    for (const [version, expectedGeneration] of [
+      ["role-model.track-b-runtime-distribution.v1", "N-1"],
+      ["role-model.track-b-runtime-distribution.v2", "N"],
+    ] as const) {
+      await writeFile(
+        path.join(root, "track-b-runtime-manifest.json"),
+        JSON.stringify({
+          schemaVersion: version,
+          sidecar: { modulePath: "sidecar.mjs", artifactSha256 },
+          extensions,
+        }),
+      );
+      const staged = await stageTrackBRuntimeDistribution({
+        sourceRoot: root,
+        releaseDir: path.join(root, `release-${expectedGeneration}`),
+      });
+      expect(staged.compatibilityGeneration).toBe(expectedGeneration);
+    }
+    await writeFile(
+      path.join(root, "track-b-runtime-manifest.json"),
+      JSON.stringify({
+        schemaVersion: "role-model.track-b-runtime-distribution.v3",
+        sidecar: { modulePath: "sidecar.mjs", artifactSha256 },
+        extensions,
+      }),
+    );
+    await expect(
+      stageTrackBRuntimeDistribution({ sourceRoot: root, releaseDir: path.join(root, "future") }),
+    ).rejects.toThrow(/unsupported|incomplete/i);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-graph-primary.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-graph-primary.test.ts
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "vitest";
+
+import {
+  LegacySqliteMigration,
+  initializeSqliteMemory,
+  readLegacyMigrationJournal,
+} from "@role-model-router/sqlite-memory";
+import * as trackBRuntime from "../src/track-b-runtime.js";
+
+test("SP2 host observation persistence delegates rich bytes to graph storage after cutover", async () => {
+  expect(typeof trackBRuntime.createTrackBGraphObservationPersistence).toBe("function");
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-graph-primary-"));
+  const initialized = initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  const artifacts = new Map<string, string>();
+  const graphStore = {
+    scopeId: "workspace-run87",
+    write: ({
+      sourceId,
+      content,
+      contentHash,
+    }: {
+      sourceId: string;
+      content: string;
+      contentHash: string;
+    }) => {
+      const artifactId = `artifact-${sourceId}`;
+      artifacts.set(artifactId, content);
+      return { artifactId, artifactPath: `artifact://${artifactId}`, contentHash };
+    },
+    read: ({ artifactId }: { artifactId: string }) => {
+      const content = artifacts.get(artifactId);
+      if (!content) throw new Error(`missing artifact ${artifactId}`);
+      return content;
+    },
+    remove: ({ artifactId }: { artifactId: string }) => {
+      artifacts.delete(artifactId);
+    },
+  };
+  let now = Date.now();
+  const migration = new LegacySqliteMigration({
+    databasePath: initialized.databasePath,
+    backupPath: path.join(root, "legacy.sqlite"),
+    artifactWriter: graphStore.write,
+    now: () => now,
+  });
+  const observation = {
+    requestId: "request-87",
+    routingDecisionId: "route-87",
+    endpointId: "endpoint-87",
+    conversationId: "conversation-87",
+    usageEvent: { timestamp_ms: 87 },
+    observedPerformance: {
+      sample: {
+        endpoint_id: "endpoint-87",
+        source_type: "live_request",
+        timestamp_ms: 87,
+        latency_ms: 1,
+        success: true,
+      },
+      profile: { measured_at_ms: 87 },
+    },
+    inspection: { providerBody: "private-rich-body" },
+  };
+  const content = JSON.stringify(observation);
+  graphStore.write({
+    scopeId: graphStore.scopeId,
+    sourceId: observation.requestId,
+    content,
+    contentHash: createHash("sha256").update(content).digest("hex"),
+  });
+
+  expect(typeof trackBRuntime.createTrackBGraphMigrationOperator).toBe("function");
+  const createOperator = (runner: LegacySqliteMigration) =>
+    trackBRuntime.createTrackBGraphMigrationOperator({
+      databasePath: initialized.databasePath,
+      migration: runner,
+      scopeId: graphStore.scopeId,
+      batchSize: 1,
+      shadowWindowMs: 1_000,
+      readHoldMs: 1_000,
+      now: () => now,
+    });
+  let operator = createOperator(migration);
+  expect(operator.advance()).toMatchObject({ action: "backfill", state: "shadow_mirror" });
+
+  // Reconstruct both runner and operator to prove the durable journal, not memory, owns progress.
+  operator = createOperator(
+    new LegacySqliteMigration({
+      databasePath: initialized.databasePath,
+      backupPath: path.join(root, "legacy.sqlite"),
+      artifactWriter: graphStore.write,
+      now: () => now,
+    }),
+  );
+  expect(
+    operator.advance({
+      backupVerified: true,
+      restoreVerified: true,
+      consumersVerified: true,
+    }),
+  ).toMatchObject({ action: "verify_first_parity", state: "parity_verified" });
+  expect(operator.advance()).toMatchObject({ action: "cutover", state: "graph_primary" });
+  expect(readLegacyMigrationJournal(initialized.databasePath).state).toBe("graph_primary");
+
+  const persistence = trackBRuntime.createTrackBGraphObservationPersistence({
+    databasePath: initialized.databasePath,
+    channel: "development",
+    graphStore,
+  });
+  persistence.persist(observation);
+  expect(persistence.read(observation.requestId)).toEqual(observation);
+
+  expect(operator.advance()).toMatchObject({ action: "enter_legacy_read_hold" });
+  expect(operator.advance({ consumersVerified: true })).toMatchObject({
+    action: "verify_second_parity",
+    state: "legacy_read_hold",
+  });
+  now += 1_001;
+  expect(operator.advance()).toMatchObject({ action: "retire", state: "legacy_retired" });
+});

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-projection-consumers.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-projection-consumers.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "vitest";
+
+import * as trace from "../../../packages/trace/src/index.js";
+import * as consumers from "../src/track-b-runtime.js";
+
+test("SP4 host dispatches a provenance-bound projection to every declared shadow consumer", async () => {
+  expect(typeof consumers.consumeTrackBProjection).toBe("function");
+  expect(typeof trace.createProjectionV2).toBe("function");
+  const calls: Array<{ id: string; envelope: Record<string, unknown> }> = [];
+  const runtime = {
+    invoke: async (id: string, envelope: Record<string, unknown>) => {
+      calls.push({ id, envelope });
+      return { accepted: true, consumer: id };
+    },
+  };
+  const projection = trace.createProjectionV2({
+    scope: "tenant:run87",
+    purpose: "routing_shadow",
+    permittedUse: true,
+    authorizationState: "authorized",
+    validUntilMs: null,
+    trainingAllowed: true,
+    evaluatedAtMs: 10_000,
+    evidence: [
+      {
+        artifactRef: "sha256:projection-evidence",
+        sourceHash: `sha256:${"c".repeat(64)}`,
+        scope: "tenant:run87",
+        verified: true,
+        capabilities: ["full_replay"],
+      },
+    ],
+    payload: { expected: "a", actual: "a", routePackage: "candidate-a" },
+  });
+  const receipt = await consumers.consumeTrackBProjection(runtime, projection, {
+    channel: "development",
+    authorizationEpoch: 87,
+  });
+  expect(calls.map((call) => call.id)).toEqual([
+    "evaluation-core",
+    "profile-learner",
+    "knowledge-worker",
+  ]);
+  expect(receipt).toMatchObject({ consumerCount: 3, productionMutation: false });
+
+  const revoked = trace.downgradeProjectionV2(projection, {
+    artifactRef: "sha256:projection-evidence",
+    reason: "revoked",
+  });
+  await expect(
+    consumers.consumeTrackBProjection(runtime, revoked, {
+      channel: "development",
+      authorizationEpoch: 87,
+    }),
+  ).rejects.toThrow(/unavailable|permitted/i);
+});

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-registry-lifecycle.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-registry-lifecycle.test.ts
@@ -1,0 +1,297 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createTrackBOperations } from "../src/track-b-operations.js";
+import * as trackBRuntime from "../src/track-b-runtime.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..", "..");
+const fixtureModule = path.join(
+  import.meta.dirname,
+  "fixtures",
+  "recursive-87-synthetic-extension.mjs",
+);
+const roots: string[] = [];
+const runtimes: Array<{ close(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.allSettled(runtimes.splice(0).map((runtime) => runtime.close()));
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function syntheticExtensions(count: number) {
+  const bytes = await readFile(fixtureModule);
+  const artifactSha256 = createHash("sha256").update(bytes).digest("hex");
+  return Array.from({ length: count }, (_, index) => ({
+    descriptor: {
+      id:
+        index === 13
+          ? "synthetic-future-extension"
+          : `canonical-${String(index + 1).padStart(2, "0")}`,
+      protocolVersion: "1.1.0",
+      capabilities: ["health:probe", "fixture:echo"],
+    },
+    modulePath: fixtureModule,
+    artifactSha256,
+  }));
+}
+
+describe("recursive run 87 SP0 registry and lifecycle authority", () => {
+  test("a synthetic future extension uses the same generic runtime path as the fixed release set", async () => {
+    expect(typeof trackBRuntime.createExtensionRuntime).toBe("function");
+    const stateRoot = path.join(os.tmpdir(), `run87-generic-runtime-${Date.now()}`);
+    roots.push(stateRoot);
+    const runtime = await trackBRuntime.createExtensionRuntime({
+      stateRoot,
+      authorizationEpoch: 7,
+      repoRoot,
+      extensions: await syntheticExtensions(14),
+    });
+    runtimes.push(runtime);
+
+    expect(runtime.listExtensions()).toHaveLength(14);
+    await expect(
+      runtime.invoke("synthetic-future-extension", {
+        requestId: "run87:synthetic:echo",
+        protocolVersion: "1.1.0",
+        channel: "development",
+        scope: "tenant:run87",
+        authorizationEpoch: 7,
+        capability: "fixture:echo",
+        payload: { value: 87 },
+      }),
+    ).resolves.toMatchObject({ echoed: { value: 87 }, requestId: "run87:synthetic:echo" });
+  });
+
+  test("the production constructor keeps thirteen release extensions while admitting an explicit QA extension", async () => {
+    const stateRoot = path.join(os.tmpdir(), `run87-packaged-qa-runtime-${Date.now()}`);
+    roots.push(stateRoot);
+    const canonical = await syntheticExtensions(13);
+    const qaExtension = (await syntheticExtensions(14))[13];
+    const runtime = await trackBRuntime.createProductionExtensionRuntime({
+      stateRoot,
+      authorizationEpoch: 87,
+      repoRoot,
+      extensions: canonical,
+      qaExtensions: [qaExtension],
+    });
+    runtimes.push(runtime);
+
+    expect(runtime.listExtensions()).toHaveLength(14);
+    await expect(
+      runtime.invoke("synthetic-future-extension", {
+        requestId: "run87:packaged-qa:echo",
+        protocolVersion: "1.1.0",
+        channel: "development",
+        scope: "tenant:run87",
+        authorizationEpoch: 87,
+        capability: "fixture:echo",
+        payload: { packagedQa: true },
+      }),
+    ).resolves.toMatchObject({ echoed: { packagedQa: true } });
+  });
+
+  test("durable lifecycle mutations change observed worker state and are idempotent", async () => {
+    const stateRoot = path.join(os.tmpdir(), `run87-production-runtime-${Date.now()}`);
+    roots.push(stateRoot);
+    const extensions = await syntheticExtensions(13);
+    const runtime = await trackBRuntime.createProductionExtensionRuntime({
+      stateRoot,
+      authorizationEpoch: 11,
+      repoRoot,
+      extensions,
+    });
+    runtimes.push(runtime);
+
+    expect(typeof runtime.listExtensions).toBe("function");
+    expect(typeof runtime.mutateExtension).toBe("function");
+    const initial = runtime.listExtensions().find((row) => row.id === "canonical-01");
+    expect(initial).toMatchObject({ lifecycle: "ready", desiredState: "enabled", revision: 1 });
+    expect(initial?.pid).toBeGreaterThan(0);
+
+    const disabled = await runtime.mutateExtension({
+      id: "canonical-01",
+      action: "disable",
+      mutationId: "run87:disable:canonical-01",
+      expectedRevision: initial?.revision,
+    });
+    expect(disabled.state).toMatchObject({
+      lifecycle: "stopped",
+      desiredState: "disabled",
+      pid: null,
+    });
+    const repeated = await runtime.mutateExtension({
+      id: "canonical-01",
+      action: "disable",
+      mutationId: "run87:disable:canonical-01",
+      expectedRevision: initial?.revision,
+    });
+    expect(repeated).toEqual(disabled);
+    await expect(
+      runtime.mutateExtension({
+        id: "canonical-01",
+        action: "enable",
+        mutationId: "run87:disable:canonical-01",
+        expectedRevision: disabled.state.revision,
+      }),
+    ).rejects.toThrow(/mutation.*conflict|idempotency/i);
+    await expect(
+      runtime.invoke("canonical-01", {
+        requestId: "run87:disabled:invoke",
+        protocolVersion: "1.1.0",
+        channel: "development",
+        scope: "tenant:run87",
+        authorizationEpoch: 11,
+        capability: "fixture:echo",
+        payload: {},
+      }),
+    ).rejects.toThrow(/disabled|stopped/i);
+
+    const enabled = await runtime.mutateExtension({
+      id: "canonical-01",
+      action: "enable",
+      mutationId: "run87:enable:canonical-01",
+      expectedRevision: disabled.state.revision,
+    });
+    expect(enabled.state.lifecycle).toBe("ready");
+    expect(enabled.state.pid).toBeGreaterThan(0);
+    expect(enabled.state.pid).not.toBe(initial?.pid);
+
+    const restarted = await runtime.mutateExtension({
+      id: "canonical-01",
+      action: "restart",
+      mutationId: "run87:restart:canonical-01",
+      expectedRevision: enabled.state.revision,
+    });
+    expect(restarted.state.lifecycle).toBe("ready");
+    expect(restarted.state.pid).toBeGreaterThan(0);
+    expect(restarted.state.pid).not.toBe(enabled.state.pid);
+
+    const rolledBack = await runtime.mutateExtension({
+      id: "canonical-01",
+      action: "rollback",
+      mutationId: "run87:rollback:canonical-01",
+      expectedRevision: restarted.state.revision,
+    });
+    expect(rolledBack.state).toMatchObject({ lifecycle: "ready", desiredState: "enabled" });
+  });
+
+  test("operations API delegates list and mutation to supervisor authority instead of bridge JSON", async () => {
+    const stateRoot = path.join(os.tmpdir(), `run87-operations-runtime-${Date.now()}`);
+    roots.push(stateRoot);
+    const statePath = path.join(stateRoot, "bridge-state.json");
+    const expectedRows = [
+      { id: "canonical-01", lifecycle: "ready", desiredState: "enabled", pid: 8701, revision: 4 },
+    ];
+    const listExtensions = vi.fn(async () => expectedRows);
+    const mutateExtension = vi.fn(async (input: Record<string, unknown>) => ({
+      mutationId: input.mutationId,
+      state: { id: input.id, lifecycle: "ready", desiredState: "enabled", pid: 8702, revision: 5 },
+    }));
+    const operations = createTrackBOperations({
+      statePath,
+      catalog: [{ id: "canonical-01" }],
+      extensionRuntime: { listExtensions, mutateExtension },
+    });
+
+    await expect(operations.listExtensions()).resolves.toEqual([
+      expect.objectContaining({
+        ...expectedRows[0],
+        installed: true,
+        enabled: true,
+        enabledMode: "active",
+        health: { available: true, routingDependency: false },
+      }),
+    ]);
+    expect(listExtensions).toHaveBeenCalledOnce();
+    const receipt = await operations.mutateExtension({
+      id: "canonical-01",
+      action: "restart",
+      mutationId: "run87:operations:restart",
+      expectedRevision: 4,
+    });
+    expect(mutateExtension).toHaveBeenCalledWith({
+      id: "canonical-01",
+      action: "restart",
+      mutationId: "run87:operations:restart",
+      expectedRevision: 4,
+    });
+    expect(receipt).toMatchObject({ state: { pid: 8702, revision: 5 } });
+  });
+
+  test("Phase 3.5 journal replay preserves stopped state and never resurrects removed extensions", async () => {
+    const stateRoot = path.join(os.tmpdir(), `run87-journal-replay-${Date.now()}`);
+    roots.push(stateRoot);
+    const journalPath = path.join(stateRoot, "extension-host.jsonl");
+    const hostModule = (await import("../../../../packages/extension-host/index.mjs")) as {
+      ExtensionHost: new (
+        input: Record<string, unknown>,
+      ) => {
+        registerProcess(descriptor: Record<string, unknown>, moduleUrl: string): Promise<void>;
+        stopProcess(id: string): Promise<unknown>;
+        removeProcess(id: string): Promise<void>;
+        restoreJournal(): Promise<void>;
+        listExtensionStates(): Array<{ id: string; lifecycle: string }>;
+        shutdown(): Promise<void>;
+      };
+    };
+    const descriptor = (id: string) => ({
+      id,
+      protocolVersion: "1.1.0",
+      capabilities: ["health:probe", "fixture:echo"],
+    });
+    const first = new hostModule.ExtensionHost({
+      journalPath,
+      authorizationEpoch: 1,
+      protocolVersion: "1.1.0",
+    });
+    await first.registerProcess(descriptor("stopped-extension"), fixtureModule);
+    await first.registerProcess(descriptor("removed-extension"), fixtureModule);
+    await first.stopProcess("stopped-extension");
+    await first.removeProcess("removed-extension");
+    await first.shutdown();
+
+    const restored = new hostModule.ExtensionHost({
+      journalPath,
+      authorizationEpoch: 1,
+      protocolVersion: "1.1.0",
+    });
+    await restored.restoreJournal();
+    expect(restored.listExtensionStates()).toEqual([
+      expect.objectContaining({ id: "stopped-extension", lifecycle: "stopped" }),
+    ]);
+    await restored.shutdown();
+  });
+
+  test("Phase 3.5 failed durable mutation is compensated before returning an error", async () => {
+    const stateRoot = path.join(os.tmpdir(), `run87-mutation-compensation-${Date.now()}`);
+    roots.push(stateRoot);
+    const runtime = await trackBRuntime.createExtensionRuntime({
+      stateRoot,
+      authorizationEpoch: 1,
+      repoRoot,
+      extensions: await syntheticExtensions(1),
+    });
+    runtimes.push(runtime);
+    const initial = runtime.listExtensions()[0];
+    const statePath = path.join(stateRoot, "extension-runtime-state.json");
+    await rm(statePath);
+    await mkdir(statePath);
+    await expect(
+      runtime.mutateExtension({
+        id: initial.id,
+        action: "disable",
+        mutationId: "run87:forced-persist-failure",
+        expectedRevision: initial.revision,
+      }),
+    ).rejects.toThrow();
+    expect(runtime.listExtensions()[0]).toMatchObject({
+      desiredState: "enabled",
+      lifecycle: "ready",
+      revision: initial.revision,
+    });
+  });
+});

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-retention-inventory.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-retention-inventory.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+
+import * as trackBRuntime from "../src/track-b-runtime.js";
+
+test("SP5 host retention inventory refuses incomplete physical storage claims", () => {
+  expect(typeof trackBRuntime.validateTrackBRetentionInventory).toBe("function");
+  const complete = trackBRuntime.validateTrackBRetentionInventory({
+    schemaVersion: "role-model.storage-registry.v1",
+    entries: [
+      {
+        id: "artifact_graph",
+        owner: "artifact-store",
+        health: "ready",
+        measurement: "measured",
+        physicalBytes: 100,
+        heldItems: 1,
+        retentionState: "enforced",
+      },
+      {
+        id: "sqlite_runtime_observations",
+        owner: "sqlite-memory",
+        health: "ready",
+        measurement: "measured",
+        physicalBytes: 200,
+        heldItems: 0,
+        retentionState: "enforced",
+      },
+    ],
+  });
+  expect(complete).toMatchObject({ complete: true, totalPhysicalBytes: 300, heldItems: 1 });
+  expect(() =>
+    trackBRuntime.validateTrackBRetentionInventory({
+      schemaVersion: "role-model.storage-registry.v1",
+      entries: [{ id: "unknown", owner: "", health: "ready" }],
+    }),
+  ).toThrow(/incomplete physical storage inventory/i);
+});

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-shadow-pipeline.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-shadow-pipeline.test.ts
@@ -1,0 +1,299 @@
+import { createHash } from "node:crypto";
+import { readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, test } from "vitest";
+
+import { createRuntimeBridgeBackend } from "../src/index.js";
+import { applyKwPromptInjectToMessages } from "../src/kw-prompt-inject.js";
+import { createTrackBOperations } from "../src/track-b-operations.js";
+import * as trackBRuntime from "../src/track-b-runtime.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..", "..");
+const modulePath = path.join(import.meta.dirname, "fixtures", "recursive-87-shadow-extension.mjs");
+const roots: string[] = [];
+const runtimes: Array<{ close(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.allSettled(runtimes.splice(0).map((runtime) => runtime.close()));
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+test("SP1 runs the useful routing-learning DAG through supervised shadow capabilities", async () => {
+  expect(typeof trackBRuntime.runTrackBShadowPipeline).toBe("function");
+  const artifactSha256 = createHash("sha256")
+    .update(await readFile(modulePath))
+    .digest("hex");
+  const capabilities = new Map([
+    ["replay-core", "replay:plan-graph"],
+    ["evaluation-runner-local", "evaluation:run-local"],
+    ["trajectory-signals", "signals:analyze"],
+    ["profile-learner", "profile:estimate"],
+    ["knowledge-worker", "knowledge:eval-consumer"],
+  ]);
+  const stateRoot = path.join(os.tmpdir(), `run87-shadow-${Date.now()}`);
+  roots.push(stateRoot);
+  const runtime = await trackBRuntime.createExtensionRuntime({
+    stateRoot,
+    authorizationEpoch: 87,
+    repoRoot,
+    extensions: [...capabilities].map(([id, capability]) => ({
+      descriptor: { id, protocolVersion: "1.1.0", capabilities: ["health:probe", capability] },
+      modulePath,
+      artifactSha256,
+    })),
+  });
+  runtimes.push(runtime);
+
+  const productionState = Object.freeze({
+    providerRequests: 4,
+    promptDigest: "before",
+    routeDecisionId: "route-87",
+    weightsDigest: "weights-before",
+    activeProfileId: "profile-before",
+  });
+  const result = await trackBRuntime.runTrackBShadowPipeline(runtime, {
+    requestId: "run87-shadow",
+    channel: "development",
+    scope: "tenant:run87",
+    authorizationEpoch: 87,
+    productionState,
+    routePackage: "candidate-local",
+    sourceDecisionId: "route-87",
+    sourceGraphRef: "sha256:graph-87",
+    prefix: ["request", "eligible-endpoints"],
+    counterfactuals: [{ id: "candidate-local", suffix: ["candidate-local"] }],
+    evaluationCases: [{ expected: "candidate-local", actual: "candidate-local" }],
+    trajectoryEvents: [],
+  });
+
+  expect(result.candidate).toMatchObject({
+    state: "shadow",
+    productionEffects: {
+      providerCalls: 0,
+      promptMutations: 0,
+      routeMutations: 0,
+      weightMutations: 0,
+      activeProfileMutations: 0,
+    },
+  });
+  expect(result.productionState).toEqual(productionState);
+  expect(result.receipt).toMatchObject({
+    mode: "shadow",
+    providerCalls: 0,
+    productionMutation: false,
+  });
+  expect(runtime.listExtensions().every((row) => row.lifecycle === "ready")).toBe(true);
+});
+
+test("SP1 fails closed before Knowledge Worker when holdout evaluation fails", async () => {
+  const invoke = async (id: string) =>
+    id === "evaluation-runner-local"
+      ? { scores: [0], provenance: { evidenceRef: "sha256:failed" } }
+      : {};
+  await expect(
+    trackBRuntime.runTrackBShadowPipeline(
+      { invoke },
+      {
+        requestId: "run87-shadow-failed",
+        channel: "development",
+        scope: "tenant:run87",
+        authorizationEpoch: 87,
+        routePackage: "candidate-local",
+        sourceDecisionId: "route-87",
+        sourceGraphRef: "sha256:graph-87",
+        prefix: [],
+        counterfactuals: [],
+        evaluationCases: [{ expected: 1, actual: 0 }],
+        trajectoryEvents: [],
+        productionState: {},
+      },
+    ),
+  ).rejects.toThrow(/holdout/i);
+});
+
+test("SP1 operations API rejects production Knowledge Worker activation controls", async () => {
+  const stateRoot = path.join(os.tmpdir(), `run87-shadow-ops-${Date.now()}`);
+  roots.push(stateRoot);
+  const operations = createTrackBOperations({
+    statePath: path.join(stateRoot, "track-b-state.json"),
+    catalog: [{ id: "knowledge-worker", packageClass: "canonical_extension" }],
+  });
+  await expect(
+    operations.mutateExtension({
+      id: "knowledge-worker",
+      action: "activate_production",
+      activationPolicyVersion: 1,
+      operatorAttestation: "activate-production",
+      receipt: { payload: {}, signature: "0".repeat(64) },
+    }),
+  ).rejects.toThrow(/shadow-only|prohibited by Direct Track B v1\.1/i);
+});
+
+test("SP1 operations API cannot label Knowledge Worker active or bounded", async () => {
+  const stateRoot = path.join(os.tmpdir(), `run87-shadow-mode-${Date.now()}`);
+  roots.push(stateRoot);
+  const operations = createTrackBOperations({
+    statePath: path.join(stateRoot, "track-b-state.json"),
+    catalog: [{ id: "knowledge-worker", packageClass: "canonical_extension" }],
+  });
+  await expect(
+    operations.mutateExtension({
+      id: "knowledge-worker",
+      action: "set_mode",
+      mode: "active",
+    }),
+  ).rejects.toThrow(/shadow-only|prohibited by Direct Track B v1\.1/i);
+});
+
+test("SP1 prompt insertion stays prohibited even when a legacy runner offers content", async () => {
+  const messages = [{ role: "user", content: "unchanged" }];
+  const result = await applyKwPromptInjectToMessages({
+    messages,
+    hostProductionActivation: true,
+    sessionId: "legacy-runner",
+    run: async () => ({ injected: true, systemMessage: "legacy production mutation" }),
+  });
+  expect(result.messages).toEqual(messages);
+  expect(result.receipt).toMatchObject({
+    injected: false,
+    code: "kw_prompt_inject_prohibited_shadow_only",
+  });
+});
+
+test("Phase 3.5 normal request completion dispatches the persisted observation to Track B", async () => {
+  const stateRoot = path.join(os.tmpdir(), `run87-normal-shadow-${Date.now()}`);
+  roots.push(stateRoot);
+  const observations: Array<Record<string, unknown>> = [];
+  const backend = await createRuntimeBridgeBackend({
+    repoRoot,
+    fixtureRoot: path.join(import.meta.dirname, "fixtures"),
+    runtimeStateRoot: stateRoot,
+    scopeId: "run87-normal-shadow",
+    trackBPostObservation: async (observation: Record<string, unknown>) => {
+      observations.push(observation);
+    },
+  } as Parameters<typeof createRuntimeBridgeBackend>[0] & {
+    trackBPostObservation(observation: Record<string, unknown>): Promise<void>;
+  });
+  runtimes.push({ close: () => backend.shutdown() });
+  await backend.executeChatCompletions(
+    {
+      model: "deepseek/chat-capture-v1",
+      messages: [{ role: "user", content: "Exercise the normal Track B completion path." }],
+    },
+    "run87-normal-shadow-request",
+  );
+  expect(observations).toHaveLength(1);
+  expect(observations[0]).toMatchObject({ requestId: "run87-normal-shadow-request" });
+});
+
+test("Phase 3.5 post-observation work survives startup and processing failures", async () => {
+  const stateRoot = path.join(os.tmpdir(), `run87-shadow-outbox-${Date.now()}`);
+  roots.push(stateRoot);
+  const filePath = path.join(stateRoot, "outbox.json");
+  const first = trackBRuntime.createTrackBPostObservationOutbox({ filePath });
+  await first.enqueue({
+    requestId: "queued-run87",
+    routingDecisionId: "route-run87",
+    endpointId: "endpoint-run87",
+  });
+  await expect(
+    first.drain(async () => {
+      throw new Error("extension runtime starting");
+    }),
+  ).rejects.toThrow(/starting/);
+  expect(await first.read()).toMatchObject({ pendingCount: 1 });
+
+  const restarted = trackBRuntime.createTrackBPostObservationOutbox({ filePath });
+  const processed: Array<Record<string, unknown>> = [];
+  await restarted.drain(async (observation) => {
+    processed.push(observation);
+    return {
+      pipeline: { mode: "shadow", productionMutation: false, candidateId: "candidate:run87" },
+      projection: { id: "projection:run87", scope: "tenant:run87" },
+      consumption: { consumerCount: 3, productionMutation: false },
+    };
+  });
+  expect(processed).toEqual([
+    {
+      requestId: "queued-run87",
+      routingDecisionId: "route-run87",
+      endpointId: "endpoint-run87",
+    },
+  ]);
+  expect(await restarted.read()).toMatchObject({
+    pendingCount: 0,
+    receiptCount: 1,
+    receipts: [
+      {
+        requestId: "queued-run87",
+        result: {
+          pipeline: {
+            mode: "shadow",
+            productionMutation: false,
+            candidateId: "candidate:run87",
+          },
+          projection: { id: "projection:run87", scope: "tenant:run87" },
+          consumption: { consumerCount: 3, productionMutation: false },
+        },
+      },
+    ],
+  });
+});
+
+test("Phase 3.5 normal post-observation work executes every canonical business owner", async () => {
+  const invoked: Array<{ id: string; envelope: Record<string, unknown> }> = [];
+  const runtime = {
+    async invoke(id: string, envelope: Record<string, unknown>) {
+      invoked.push({ id, envelope });
+      if (id === "artifact-store") return { id: "artifact:run87" };
+      if (id === "knowledge-store" && envelope.capability === "knowledge:write") {
+        return { id: "knowledge:run87" };
+      }
+      if (id === "evaluation-runner-local") {
+        return { scores: [1], provenance: { evidenceRef: "artifact:run87" } };
+      }
+      if (id === "knowledge-worker") {
+        return { id: "candidate:run87", state: "shadow", productionEffects: {} };
+      }
+      return {};
+    },
+  };
+  await trackBRuntime.runTrackBPostObservation(
+    runtime,
+    {
+      requestId: "all-owners-run87",
+      routingDecisionId: "route-run87",
+      endpointId: "endpoint-run87",
+    },
+    { scope: "tenant:run87", channel: "stage", authorizationEpoch: 87 },
+  );
+  expect(new Set(invoked.map((row) => row.id))).toEqual(
+    new Set([
+      "artifact-store",
+      "event-log",
+      "repository-context",
+      "background-evidence-scheduler",
+      "memory-store",
+      "knowledge-store",
+      "evaluation-core",
+      "crowdsourced-learning",
+      "replay-core",
+      "evaluation-runner-local",
+      "trajectory-signals",
+      "profile-learner",
+      "knowledge-worker",
+    ]),
+  );
+  expect(invoked.every((row) => row.envelope.channel === "stage")).toBe(true);
+  expect(
+    invoked
+      .filter((row) => ["event-log", "crowdsourced-learning"].includes(row.id))
+      .every((row) => {
+        const nested = (row.envelope.payload ?? row.envelope.input) as Record<string, unknown>;
+        return nested.channel === "stage";
+      }),
+  ).toBe(true);
+});

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import {
-  readRuntimeObservationBundle,
+  readRuntimeObservationStorageRecord,
   resolveSqliteMemoryLocation,
 } from "@role-model-router/sqlite-memory";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -98,6 +98,14 @@ describe("Track B operations APIs", () => {
       activeJob: null,
     };
     let dryRunCount = 0;
+    const graphMutationCallbacks = {
+      advanceGraphMigration: async (body: Record<string, unknown>) => ({
+        action: "advance",
+        state: "shadow_mirror",
+        verified: body,
+      }),
+      rollbackGraphMigration: async () => ({ action: "rollback", state: "legacy_primary" }),
+    };
     const server = await startBridgeServer({
       host: "127.0.0.1",
       port: 0,
@@ -106,6 +114,11 @@ describe("Track B operations APIs", () => {
       executeChatCompletions: backend.executeChatCompletions,
       executeResponses: backend.executeResponses,
       listExtensions: async () => extensions,
+      readGraphMigration: async () => ({
+        state: "graph_primary",
+        migrationId: "tb04-legacy-graph-performance-v1",
+      }),
+      ...graphMutationCallbacks,
       readStorageRetention: async () => summary,
       dryRunStorageRetention: async () => ({
         ...summary,
@@ -146,6 +159,26 @@ describe("Track B operations APIs", () => {
     try {
       const base = `http://127.0.0.1:${server.port}`;
       expect(await (await fetch(`${base}/api/role-model/extensions`)).json()).toEqual(extensions);
+      expect(await (await fetch(`${base}/api/role-model/graph-migration`)).json()).toEqual({
+        state: "graph_primary",
+        migrationId: "tb04-legacy-graph-performance-v1",
+      });
+      const advanced = await fetch(`${base}/api/role-model/graph-migration/advance`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          backupVerified: true,
+          restoreVerified: true,
+          consumersVerified: true,
+        }),
+      });
+      expect(advanced.status).toBe(200);
+      expect(await advanced.json()).toMatchObject({ action: "advance", state: "shadow_mirror" });
+      const rolledBack = await fetch(`${base}/api/role-model/graph-migration/rollback`, {
+        method: "POST",
+      });
+      expect(rolledBack.status).toBe(200);
+      expect(await rolledBack.json()).toEqual({ action: "rollback", state: "legacy_primary" });
       expect(await (await fetch(`${base}/api/role-model/storage-retention`)).json()).toEqual(
         summary,
       );
@@ -470,7 +503,10 @@ describe("Track B operations APIs", () => {
         },
       });
       expect(
-        readRuntimeObservationBundle({ databasePath, requestId: "req-track-b-upload-001" }),
+        readRuntimeObservationStorageRecord({
+          databasePath,
+          requestId: "req-track-b-upload-001",
+        }),
       ).toMatchObject({
         graphPrimary: true,
         artifactRef: {
@@ -610,7 +646,7 @@ describe("Track B operations APIs", () => {
         },
       });
       expect(
-        readRuntimeObservationBundle({
+        readRuntimeObservationStorageRecord({
           databasePath,
           requestId: "req-track-b-responses-upload-001",
         }),
@@ -1036,11 +1072,11 @@ describe("Track B operations APIs", () => {
     });
     await ops.mutateExtension({ id: "event-log", action: "disable" });
     await expect(
-      ops.mutateExtension({ id: "knowledge-worker", action: "enable", mode: "active" }),
+      ops.mutateExtension({ id: "knowledge-worker", action: "enable", mode: "shadow" }),
     ).rejects.toThrow(/dependenc/i);
     await ops.mutateExtension({ id: "event-log", action: "enable", mode: "shadow" });
     await expect(
-      ops.mutateExtension({ id: "knowledge-worker", action: "enable", mode: "active" }),
+      ops.mutateExtension({ id: "knowledge-worker", action: "enable", mode: "shadow" }),
     ).rejects.toThrow(/mode dependency/i);
     await ops.mutateExtension({ id: "event-log", action: "set_mode", mode: "active" });
     const enabled = (await ops.mutateExtension({
@@ -1084,7 +1120,7 @@ describe("Track B operations APIs", () => {
     ).rejects.toThrow(/mode|illegal|invalid/i);
   });
 
-  test("run84 keeps knowledge-worker production activation durable and separate from Set mode", async () => {
+  test("run87 rejects obsolete knowledge-worker production activation while retaining shadow bootstrap", async () => {
     const root = path.join(os.tmpdir(), `track-b-run84-activation-${Date.now()}`);
     roots.push(root);
     const statePath = path.join(root, "track-b-production-bridge.json");
@@ -1120,7 +1156,7 @@ describe("Track B operations APIs", () => {
         activationPolicyVersion: 1,
         operatorAttestation: "activate-production",
       }),
-    ).rejects.toThrow(/refused|ceremony/i);
+    ).rejects.toThrow(/shadow-only|prohibited/i);
 
     await expect(
       ops.mutateExtension({
@@ -1132,17 +1168,11 @@ describe("Track B operations APIs", () => {
       }),
     ).rejects.toThrow(/knowledge-worker/i);
 
-    await ops.mutateExtension({
+    const bootstrapped = (await ops.mutateExtension({
       id: "knowledge-worker",
       action: "bootstrap_shadow_ready",
       receipt,
       groupDigest: "b".repeat(64),
-    });
-    const activated = (await ops.mutateExtension({
-      id: "knowledge-worker",
-      action: "activate_production",
-      activationPolicyVersion: 1,
-      operatorAttestation: "activate-production",
     })) as {
       extensions: readonly {
         id: string;
@@ -1155,15 +1185,15 @@ describe("Track B operations APIs", () => {
       }[];
       receipts: readonly { action: string }[];
     };
-    expect(activated.extensions.find((row) => row.id === "knowledge-worker")).toMatchObject({
-      enabledMode: "active",
-      productionActivation: true,
+    expect(bootstrapped.extensions.find((row) => row.id === "knowledge-worker")).toMatchObject({
+      enabledMode: "shadow",
+      productionActivation: false,
       health: {
-        productionActivation: true,
+        productionActivation: false,
         knowledgeWorkerBootstrap: { groupDigest: "b".repeat(64) },
       },
     });
-    expect(activated.receipts.at(-1)).toMatchObject({ action: "activate_production" });
+    expect(bootstrapped.receipts.at(-1)).toMatchObject({ action: "bootstrap_shadow_ready" });
 
     const listed = (await ops.listExtensions()) as readonly {
       id: string;
@@ -1171,29 +1201,15 @@ describe("Track B operations APIs", () => {
       health: { productionActivation?: boolean };
     }[];
     expect(listed.find((row) => row.id === "knowledge-worker")).toMatchObject({
-      productionActivation: true,
-      health: { productionActivation: true },
-    });
-
-    const deactivated = (await ops.mutateExtension({
-      id: "knowledge-worker",
-      action: "deactivate_production",
-    })) as {
-      extensions: readonly {
-        id: string;
-        enabled: boolean;
-        enabledMode: string;
-        productionActivation?: boolean;
-      }[];
-    };
-    expect(deactivated.extensions.find((row) => row.id === "knowledge-worker")).toMatchObject({
-      enabled: true,
-      enabledMode: "active",
       productionActivation: false,
+      health: { productionActivation: false },
     });
+    await expect(
+      ops.mutateExtension({ id: "knowledge-worker", action: "deactivate_production" }),
+    ).rejects.toThrow(/shadow-only|prohibited/i);
   });
 
-  test("run84 structurally validates direct knowledge-worker activation ceremony", async () => {
+  test("run87 rejects every direct knowledge-worker activation ceremony", async () => {
     const root = path.join(os.tmpdir(), `track-b-run84-ceremony-${Date.now()}`);
     roots.push(root);
     const statePath = path.join(root, "track-b-production-bridge.json");
@@ -1219,7 +1235,7 @@ describe("Track B operations APIs", () => {
         operatorAttestation: "activate-production",
         receipt,
       }),
-    ).rejects.toThrow(/refused|ceremony/i);
+    ).rejects.toThrow(/shadow-only|prohibited/i);
     await expect(
       ops.mutateExtension({
         id: "knowledge-worker",
@@ -1228,20 +1244,16 @@ describe("Track B operations APIs", () => {
         operatorAttestation: "activate-production",
         receipt: { ...receipt, signature: "not-a-signature" },
       }),
-    ).rejects.toThrow(/refused|ceremony/i);
-
-    const activated = (await ops.mutateExtension({
-      id: "knowledge-worker",
-      action: "activate_production",
-      activationPolicyVersion: 1,
-      operatorAttestation: "activate-production",
-      receipt,
-    })) as {
-      extensions: readonly { id: string; productionActivation?: boolean }[];
-    };
-    expect(activated.extensions.find((row) => row.id === "knowledge-worker")).toMatchObject({
-      productionActivation: true,
-    });
+    ).rejects.toThrow(/shadow-only|prohibited/i);
+    await expect(
+      ops.mutateExtension({
+        id: "knowledge-worker",
+        action: "activate_production",
+        activationPolicyVersion: 1,
+        operatorAttestation: "activate-production",
+        receipt,
+      }),
+    ).rejects.toThrow(/shadow-only|prohibited/i);
   });
 
   test("run79 dismissRecommendation marks row dismissed without applying pack", async () => {

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -378,6 +378,9 @@ describe("production Track B composition", () => {
       "rollbackStorageRetention",
       "readContributionState",
       "updateContributionState",
+      "readGraphMigration",
+      "advanceGraphMigration",
+      "rollbackGraphMigration",
       "listRecommendations",
       "downloadRecommendations",
       "applyRecommendation",
@@ -397,7 +400,15 @@ describe("production Track B composition", () => {
     const releaseDir = path.join(root, "release");
     await mkdir(path.join(sourceRoot, "extensions"), { recursive: true });
     const sidecar = 'console.log("sidecar")\n';
+    const publicRuntimeAdapter = 'export const adapter="sqlite"\n';
+    const migrationSql = "CREATE TABLE packaged_track_b_test(id TEXT);\n";
     await writeFile(path.join(sourceRoot, "runtime-operations-server.mjs"), sidecar);
+    await writeFile(path.join(sourceRoot, "public-runtime-adapter.mjs"), publicRuntimeAdapter);
+    await mkdir(path.join(sourceRoot, "public-router", "migrations"), { recursive: true });
+    await writeFile(
+      path.join(sourceRoot, "public-router", "migrations", "0001_test.sql"),
+      migrationSql,
+    );
     const extensions = await Promise.all(
       Array.from({ length: 13 }, async (_, index) => {
         const id = `extension-${index + 1}`;
@@ -418,6 +429,17 @@ describe("production Track B composition", () => {
         modulePath: "runtime-operations-server.mjs",
         artifactSha256: createHash("sha256").update(sidecar).digest("hex"),
       },
+      publicRuntimeAdapter: {
+        modulePath: "public-runtime-adapter.mjs",
+        artifactSha256: createHash("sha256").update(publicRuntimeAdapter).digest("hex"),
+        routerRoot: "public-router",
+        routerAssets: [
+          {
+            modulePath: "public-router/migrations/0001_test.sql",
+            artifactSha256: createHash("sha256").update(migrationSql).digest("hex"),
+          },
+        ],
+      },
       extensions,
     };
     await writeFile(
@@ -428,6 +450,12 @@ describe("production Track B composition", () => {
     const staged = await stageTrackBRuntimeDistribution({ sourceRoot, releaseDir });
     expect(staged.extensionCount).toBe(13);
     expect(JSON.parse(await readFile(staged.manifestPath, "utf8"))).toEqual(manifest);
+    expect(await readFile(path.join(releaseDir, "public-runtime-adapter.mjs"), "utf8")).toBe(
+      publicRuntimeAdapter,
+    );
+    expect(
+      await readFile(path.join(releaseDir, "public-router", "migrations", "0001_test.sql"), "utf8"),
+    ).toBe(migrationSql);
     await writeFile(path.join(sourceRoot, extensions[0].modulePath), "tampered");
     await expect(
       stageTrackBRuntimeDistribution({ sourceRoot, releaseDir: path.join(root, "bad") }),

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.test.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.test.ts
@@ -2963,8 +2963,8 @@ describe("role assignment helpers", () => {
       },
       fetcher,
     );
-    await runtimeApiModule.activateKnowledgeWorkerProduction(fetcher);
-    await runtimeApiModule.deactivateKnowledgeWorkerProduction(fetcher);
+    expect("activateKnowledgeWorkerProduction" in runtimeApiModule).toBe(false);
+    expect("deactivateKnowledgeWorkerProduction" in runtimeApiModule).toBe(false);
     await runtimeApiModule.dismissRecommendation("pack-dismiss", fetcher);
     expect(requests).toEqual([
       {
@@ -3000,21 +3000,6 @@ describe("role assignment helpers", () => {
           },
           groupDigest: "b".repeat(64),
         },
-      },
-      {
-        url: "/api/role-model/extensions/mutate",
-        method: "POST",
-        body: {
-          id: "knowledge-worker",
-          action: "activate_production",
-          activationPolicyVersion: 1,
-          operatorAttestation: "activate-production",
-        },
-      },
-      {
-        url: "/api/role-model/extensions/mutate",
-        method: "POST",
-        body: { id: "knowledge-worker", action: "deactivate_production" },
       },
       {
         url: "/api/role-model/recommendations/dismiss",

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
@@ -1388,14 +1388,12 @@ export interface RuntimeExtensionStatus {
   readonly channel: string;
   readonly scope: string;
   readonly authorizationEpoch: number;
-  readonly productionActivation?: boolean;
   readonly health: {
     readonly available: boolean;
     readonly routingDependency: boolean;
     readonly probe?: string;
     readonly summary?: string;
     readonly reason?: string;
-    readonly productionActivation?: boolean;
     readonly knowledgeWorkerBootstrap?: {
       readonly receipt: KnowledgeValidationReceipt;
       readonly groupDigest: string;
@@ -1431,16 +1429,8 @@ export interface KnowledgeValidationReceipt {
 export async function mutateExtension(
   input: {
     readonly id: string;
-    readonly action:
-      | "enable"
-      | "disable"
-      | "set_mode"
-      | "bootstrap_shadow_ready"
-      | "activate_production"
-      | "deactivate_production";
+    readonly action: "enable" | "disable" | "set_mode" | "bootstrap_shadow_ready";
     readonly mode?: RuntimeExtensionMode;
-    readonly activationPolicyVersion?: 1;
-    readonly operatorAttestation?: "activate-production";
     readonly receipt?: KnowledgeValidationReceipt;
     readonly groupDigest?: string;
   },
@@ -1475,26 +1465,6 @@ export async function prepareKnowledgeWorkerShadowReady(
     },
     fetcher,
   );
-}
-
-export async function activateKnowledgeWorkerProduction(
-  fetcher: RuntimeFetcher = fetch,
-): Promise<ExtensionMutationResult> {
-  return mutateExtension(
-    {
-      id: "knowledge-worker",
-      action: "activate_production",
-      activationPolicyVersion: 1,
-      operatorAttestation: "activate-production",
-    },
-    fetcher,
-  );
-}
-
-export async function deactivateKnowledgeWorkerProduction(
-  fetcher: RuntimeFetcher = fetch,
-): Promise<ExtensionMutationResult> {
-  return mutateExtension({ id: "knowledge-worker", action: "deactivate_production" }, fetcher);
 }
 
 export interface RuntimeStorageRetentionSummary {
@@ -1542,6 +1512,19 @@ export interface RuntimeStorageRetentionSummary {
     readonly retainedCapabilities: readonly string[];
     readonly blocks: readonly string[];
   } | null;
+  readonly storageInventory?: {
+    readonly schemaVersion: "role-model.storage-registry.v1";
+    readonly complete: boolean;
+    readonly entries: readonly {
+      readonly id: string;
+      readonly owner: string;
+      readonly health: string;
+      readonly measurement: "measured" | "unavailable";
+      readonly physicalBytes: number | null;
+      readonly heldItems: number;
+      readonly retentionState: string;
+    }[];
+  };
 }
 
 export async function fetchStorageRetention(

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.test.tsx
@@ -35,17 +35,13 @@ describe("ExtensionsRoute", () => {
     expect(routeSource).toContain("Health probe");
     expect(routeSource).toContain("LIFECYCLE_COPY");
     expect(routeSource).toContain("operatorBoundaryNote");
-    expect(routeSource).toContain("shadow-ready by default");
-    expect(routeSource).toContain("ceremony-bound ON");
-    expect(routeSource).toContain("Soft OFF returns to shadow-ready");
-    expect(routeSource).toContain("KW works when on");
-    expect(routeSource).toContain("gated separately from Set mode");
-    expect(routeSource).toContain("is not productionActivation");
-    expect(routeSource).not.toContain("productionActivation stays hard-off");
-    expect(routeSource).toContain("production prompt injection");
-    expect(routeSource).not.toContain("Production prompt injection remains locked");
-    expect(routeSource).toContain("requires ceremony ON plus gated production");
-    expect(routeSource).toMatch(/cleared\s+on soft OFF/);
+    expect(routeSource).toContain("shadow-only");
+    expect(routeSource).toContain("Direct Track B v1.1");
+    expect(routeSource).toContain(
+      "cannot change production prompts, routes, weights, or active profiles",
+    );
+    expect(routeSource).not.toContain("ceremony-bound ON");
+    expect(routeSource).not.toContain("production prompt injection");
     expect(routeSource).not.toContain("do not expose a public enable/disable mutation API");
     expect(routeSource).toContain("mutateExtension");
     expect(routeSource).toContain("dismissRecommendation");
@@ -69,14 +65,11 @@ describe("ExtensionsRoute", () => {
     expect(routeSource).toContain("Mode draft is");
     expect(routeSource).toContain("applyMode");
     expect(routeSource).toContain("prepareKnowledgeWorkerShadowReady");
-    expect(routeSource).toContain("activateKnowledgeWorkerProduction");
-    expect(routeSource).toContain("deactivateKnowledgeWorkerProduction");
     expect(routeSource).toContain("Prepare shadow-ready");
-    expect(routeSource).toContain("Production ON");
-    expect(routeSource).toContain("Soft OFF");
-    expect(routeSource).toContain("productionActivation");
-    expect(routeSource).toContain("Production retrieve is gated");
-    expect(routeSource).toContain("separate from Set mode");
+    expect(routeSource).not.toContain("activateKnowledgeWorkerProduction");
+    expect(routeSource).not.toContain("deactivateKnowledgeWorkerProduction");
+    expect(routeSource).not.toContain("Production ON");
+    expect(routeSource).not.toContain("Soft OFF");
     expect(routeSource).toContain("xl:grid-cols-[minmax(0,8fr)_minmax(0,4fr)]");
   });
   test("renders the existing design-system loading shell before operational state arrives", () => {

--- a/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/extensions.tsx
@@ -28,9 +28,7 @@ import {
   type RuntimeExtensionMode,
   type RuntimeExtensionStatus,
   type RuntimeRecommendation,
-  activateKnowledgeWorkerProduction,
   applyRecommendation,
-  deactivateKnowledgeWorkerProduction,
   dismissRecommendation,
   downloadRecommendations,
   fetchActivePack,
@@ -102,10 +100,10 @@ const LIFECYCLE_COPY: Record<
 
 const operatorBoundaryNote = (extensionId: string): string | null => {
   if (extensionId === "knowledge-worker") {
-    return "Default posture is shadow-ready by default while productionActivation stays off. Production retrieve is gated and useful only after ceremony-bound ON; KW works when on. Enabling this extension is not productionActivation. Gated production prompt injection requires ceremony ON plus successful production retrieve and is not enabled by Set mode or recommendation apply alone. Soft OFF returns to shadow-ready and clears inject. Production activation is separate from Set mode and recommendation apply, gated separately from Set mode.";
+    return "Direct Track B v1.1 keeps Knowledge Worker shadow-only. Evidence-backed candidates support evaluation and route-package attribution but cannot change production prompts, routes, weights, or active profiles.";
   }
   if (extensionId === "knowledge-store") {
-    return "Serves last-ready knowledge references. Production prompt injection requires ceremony-backed KW ON and gated production retrieve; it is not ambient-on.";
+    return "Serves bounded knowledge references to shadow evaluation consumers; it does not authorize production behavior changes.";
   }
   return null;
 };
@@ -280,7 +278,7 @@ export function ExtensionsRouteView() {
       });
       setExtensions(next.extensions);
       setNotice(
-        "Knowledge Worker shadow-ready ceremony material stored. Production remains OFF until explicit activation.",
+        "Knowledge Worker shadow-ready evidence stored. Direct Track B v1.1 remains shadow-only.",
       );
     } catch (value) {
       setError(message(value));
@@ -288,27 +286,6 @@ export function ExtensionsRouteView() {
       setBusy(false);
     }
   };
-  const setKnowledgeWorkerProduction = async (active: boolean) => {
-    setBusy(true);
-    setError(null);
-    setNotice(null);
-    try {
-      const next = active
-        ? await activateKnowledgeWorkerProduction()
-        : await deactivateKnowledgeWorkerProduction();
-      setExtensions(next.extensions);
-      setNotice(
-        active
-          ? "Knowledge Worker production activation is ON. Gated production retrieve is available."
-          : "Knowledge Worker production activation is OFF. Shadow-ready material is retained.",
-      );
-    } catch (value) {
-      setError(message(value));
-    } finally {
-      setBusy(false);
-    }
-  };
-
   const openRecs = useMemo(
     () =>
       recommendations.filter((row) => row.status !== "applied" && row.status !== "dismissed")
@@ -541,7 +518,13 @@ export function ExtensionsRouteView() {
                               [extension.id]: value as RuntimeExtensionMode,
                             }));
                           }}
-                          options={EXTENSION_MODE_OPTIONS}
+                          options={
+                            extension.id === "knowledge-worker"
+                              ? EXTENSION_MODE_OPTIONS.filter(({ value }) =>
+                                  ["disabled", "shadow"].includes(value),
+                                )
+                              : EXTENSION_MODE_OPTIONS
+                          }
                           value={draftMode}
                         />
                       </td>
@@ -585,8 +568,6 @@ export function ExtensionsRouteView() {
           onBootstrapGroupDigest={setBootstrapGroupDigest}
           onBootstrapReceiptJson={setBootstrapReceiptJson}
           onPrepare={() => void prepareKnowledgeWorker()}
-          onProductionOff={() => void setKnowledgeWorkerProduction(false)}
-          onProductionOn={() => void setKnowledgeWorkerProduction(true)}
         />
       ) : null}
       {extensions && extensions.length > 0 ? (
@@ -690,8 +671,6 @@ function KnowledgeWorkerGate({
   onBootstrapGroupDigest,
   onBootstrapReceiptJson,
   onPrepare,
-  onProductionOff,
-  onProductionOn,
 }: {
   busy: boolean;
   bootstrapGroupDigest: string;
@@ -700,30 +679,22 @@ function KnowledgeWorkerGate({
   onBootstrapGroupDigest: (value: string) => void;
   onBootstrapReceiptJson: (value: string) => void;
   onPrepare: () => void;
-  onProductionOff: () => void;
-  onProductionOn: () => void;
 }) {
-  const productionActivation =
-    extension.productionActivation ?? extension.health.productionActivation ?? false;
   const bootstrapReady = Boolean(extension.health.knowledgeWorkerBootstrap);
   return (
-    <DisclosureSection summary="Knowledge Worker production gate">
+    <DisclosureSection summary="Knowledge Worker shadow pipeline">
       <div className={`${mutedPanelClassName} border-[var(--rm-border-strong)] p-4`}>
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className={compactTitleClassName}>Production retrieve gate</p>
+            <p className={compactTitleClassName}>Shadow-only evaluation boundary</p>
             <p className={`mt-1 ${supportingTextClassName}`}>
-              Ceremony-backed production activation is separate from Set mode. Production prompt
-              injection requires ceremony ON plus gated production retrieve success; it is cleared
-              on soft OFF and is not Set mode or recommendation apply. Production retrieve is gated
-              and useful only after ceremony-bound ON; KW works when on.
+              Direct Track B v1.1 uses reviewed evidence for shadow evaluation and attribution. It
+              cannot change production prompts, routes, weights, or active profiles.
             </p>
           </div>
-          <Badge tone={productionActivation ? "success" : "neutral"}>
-            {productionActivation ? "Production ON" : "Production OFF"}
-          </Badge>
+          <Badge tone="neutral">Shadow-only</Badge>
         </div>
-        {!bootstrapReady && !productionActivation ? (
+        {!bootstrapReady ? (
           <div className="mt-4 grid gap-3">
             <label className={fieldLabelClassName}>
               Knowledge validation receipt JSON
@@ -758,30 +729,6 @@ function KnowledgeWorkerGate({
             </button>
           </div>
         ) : null}
-        <div className="mt-4 flex flex-wrap gap-2">
-          <button
-            className={primaryButtonClassName}
-            disabled={
-              busy ||
-              productionActivation ||
-              !extension.installed ||
-              !extension.enabled ||
-              !bootstrapReady
-            }
-            onClick={onProductionOn}
-            type="button"
-          >
-            Production ON
-          </button>
-          <button
-            className={secondaryButtonClassName}
-            disabled={busy || !productionActivation}
-            onClick={onProductionOff}
-            type="button"
-          >
-            Soft OFF
-          </button>
-        </div>
       </div>
     </DisclosureSection>
   );

--- a/role-model-router/apps/runtime-ui/app/routes/storage-retention.test.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/storage-retention.test.tsx
@@ -32,6 +32,10 @@ describe("StorageRetentionRoute", () => {
       "fieldClassName",
       "Maximum size (GB)",
       "gbInputToBytes",
+      "Physical storage inventory",
+      "row.physicalBytes",
+      "row.heldItems",
+      "row.retentionState",
     ])
       expect(source).toContain(token);
     expect(source).not.toContain("Maximum bytes");
@@ -52,6 +56,8 @@ describe("StorageRetentionRoute", () => {
   test("renders the existing design-system loading and manual pruning controls", () => {
     const html = renderToStaticMarkup(<StorageRetentionRouteView />);
     expect(html).toContain("Tracked");
+    expect(html).toContain("Physical stores");
+    expect(html).toContain("Legal holds");
     expect(html).toContain("Loading storage inventory");
     expect(html).toContain("Retention policy");
     expect(html).toContain("Maximum size (GB)");

--- a/role-model-router/apps/runtime-ui/app/routes/storage-retention.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/storage-retention.tsx
@@ -107,10 +107,16 @@ export function StorageRetentionRouteView() {
           },
           {
             id: "classes",
-            label: "Classes",
-            value: String(summary?.categories.length ?? 0),
+            label: "Physical stores",
+            value: String(summary?.storageInventory?.entries.length ?? 0),
           },
-          { id: "conflicts", label: "Conflicts", value: String(conflictCount) },
+          {
+            id: "holds",
+            label: "Legal holds",
+            value: String(
+              summary?.storageInventory?.entries.reduce((sum, row) => sum + row.heldItems, 0) ?? 0,
+            ),
+          },
           {
             id: "maintenance",
             label: "Maintenance",
@@ -119,6 +125,46 @@ export function StorageRetentionRouteView() {
         ]}
       />
       {error ? <ErrorState label={error} /> : null}
+      {summary?.storageInventory ? (
+        <SectionCard
+          title="Physical storage inventory"
+          description="Registry ownership, health, physical size, legal holds, and current retention enforcement for every writable store."
+        >
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead>
+                <tr>
+                  {["Store", "Owner", "Health", "Physical bytes", "Legal holds", "Enforcement"].map(
+                    (heading) => (
+                      <th className={`pb-3 font-normal ${monoEyebrowClassName}`} key={heading}>
+                        {heading}
+                      </th>
+                    ),
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {summary.storageInventory.entries.map((row) => (
+                  <tr className="border-t border-[var(--rm-border)]" key={row.id}>
+                    <td className={`py-3 ${compactTitleClassName}`}>{row.id}</td>
+                    <td className={`py-3 ${supportingTextClassName}`}>{row.owner}</td>
+                    <td className="py-3">
+                      <Badge tone={row.health === "healthy" ? "success" : "warning"}>
+                        {row.health}
+                      </Badge>
+                    </td>
+                    <td className={`py-3 ${supportingTextClassName}`}>
+                      {row.physicalBytes === null ? "Unavailable" : formatBytes(row.physicalBytes)}
+                    </td>
+                    <td className={`py-3 ${supportingTextClassName}`}>{row.heldItems}</td>
+                    <td className={`py-3 ${supportingTextClassName}`}>{row.retentionState}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </SectionCard>
+      ) : null}
       <div className="grid gap-4 xl:grid-cols-[minmax(0,8fr)_minmax(0,4fr)]">
         <SectionCard
           title="Usage by category"

--- a/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp0.extensions.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp0.extensions.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("@recursive:87-direct-track-b-semantic-completion @sp0 @smoke", () => {
+  test("extension lifecycle mutation is durable through the live host and restored before exit", async ({
+    page,
+  }) => {
+    await page.goto("/app/system/extensions");
+    await expect(page.getByRole("heading", { name: "Extension inventory" })).toBeVisible();
+    const initial = await page.request.get("/api/role-model/extensions");
+    expect(initial.ok()).toBeTruthy();
+    const rows = (await initial.json()) as Array<{
+      id: string;
+      enabled: boolean;
+      lifecycle: string;
+      revision: number;
+    }>;
+    expect(rows).toHaveLength(13);
+    const qaResponse = await page.request.get("/api/role-model/extensions/qa");
+    expect(qaResponse.ok()).toBeTruthy();
+    const qaRows = (await qaResponse.json()) as typeof rows;
+    const synthetic = qaRows.find((row) => row.id === "run87-browser-future-extension") as
+      | ((typeof rows)[number] & {
+          testOnly?: boolean;
+          qaStartupReceipt?: { echoed?: { packagedQa?: boolean }; requestId?: string };
+        })
+      | undefined;
+    expect(synthetic).toMatchObject({
+      enabled: true,
+      lifecycle: "ready",
+      testOnly: true,
+      qaStartupReceipt: {
+        echoed: { packagedQa: true },
+        requestId: "run87:packaged-qa:run87-browser-future-extension",
+      },
+    });
+    const target = rows.find((row) => row.id === "artifact-store") ?? rows[0];
+    expect(target).toBeTruthy();
+
+    const disabled = await page.request.post("/api/role-model/extensions/mutate", {
+      data: {
+        id: target.id,
+        action: "disable",
+        expectedRevision: target.revision,
+        mutationId: `run87-sp0-disable-${target.revision}`,
+      },
+    });
+    expect(disabled.ok()).toBeTruthy();
+    await page.reload();
+    await expect(page.getByRole("heading", { name: "Extension inventory" })).toBeVisible();
+    const afterDisable = (await page.request.get("/api/role-model/extensions")).json() as Promise<
+      Array<{ id: string; enabled: boolean; lifecycle: string; revision: number }>
+    >;
+    expect((await afterDisable).find((row) => row.id === target.id)?.enabled).toBe(false);
+
+    const disabledRows = await afterDisable;
+    const disabledTarget = disabledRows.find((row) => row.id === target.id) as
+      | { id: string; enabled: boolean; lifecycle: string; revision: number }
+      | undefined;
+    const enabled = await page.request.post("/api/role-model/extensions/mutate", {
+      data: {
+        id: target.id,
+        action: "enable",
+        expectedRevision: disabledTarget?.revision,
+        mutationId: `run87-sp0-enable-${disabledTarget?.revision}`,
+      },
+    });
+    expect(enabled.ok()).toBeTruthy();
+    const restored = (await (
+      await page.request.get("/api/role-model/extensions")
+    ).json()) as Array<{
+      id: string;
+      enabled: boolean;
+      revision: number;
+      pid: number | null;
+    }>;
+    const restoredTarget = restored.find((row) => row.id === target.id);
+    expect(restoredTarget?.enabled).toBe(true);
+    const restarted = await page.request.post("/api/role-model/extensions/mutate", {
+      data: {
+        id: target.id,
+        action: "restart",
+        expectedRevision: restoredTarget?.revision,
+        mutationId: `run87-sp0-restart-${restoredTarget?.revision}`,
+      },
+    });
+    expect(restarted.ok()).toBeTruthy();
+    const afterRestart = (await (
+      await page.request.get("/api/role-model/extensions")
+    ).json()) as Array<{
+      id: string;
+      enabled: boolean;
+      lifecycle: string;
+      revision: number;
+      pid: number | null;
+    }>;
+    const restartedTarget = afterRestart.find((row) => row.id === target.id);
+    expect(restartedTarget).toMatchObject({ enabled: true, lifecycle: "ready" });
+    expect(restartedTarget?.revision).toBeGreaterThan(restoredTarget?.revision ?? -1);
+    expect(restartedTarget?.pid).not.toBe(restoredTarget?.pid);
+
+    const crashTarget = afterRestart.find(
+      (row) => row.id !== target.id && row.enabled && row.lifecycle === "ready" && row.pid,
+    );
+    expect(crashTarget?.pid).toBeTruthy();
+    process.kill(crashTarget?.pid as number, "SIGKILL");
+    await expect
+      .poll(
+        async () => {
+          const current = (await (
+            await page.request.get("/api/role-model/extensions")
+          ).json()) as Array<{
+            id: string;
+            lifecycle: string;
+            pid: number | null;
+          }>;
+          const recovered = current.find((row) => row.id === crashTarget?.id);
+          return recovered?.lifecycle === "ready" && recovered.pid !== crashTarget?.pid;
+        },
+        { timeout: 60_000 },
+      )
+      .toBe(true);
+
+    const unknown = await page.request.post("/api/role-model/extensions/mutate", {
+      data: {
+        id: "run87-absent-incompatible-extension",
+        action: "enable",
+        expectedRevision: 1,
+        mutationId: "run87-sp0-unknown-distribution",
+      },
+    });
+    expect(unknown.ok()).toBe(false);
+  });
+});

--- a/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp5.retention.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp5.retention.spec.ts
@@ -1,0 +1,243 @@
+import { createHash } from "node:crypto";
+
+import { expect, test } from "@playwright/test";
+
+test.describe("@recursive:87-direct-track-b-semantic-completion @sp5 @smoke", () => {
+  test("storage retention exposes truthful inventory and safe maintenance controls", async ({
+    page,
+  }) => {
+    const requestId = `run87-sp5-retention-${Date.now()}`;
+    const receiptsBefore = (await (
+      await page.request.get("/api/role-model/track-b/shadow-receipts")
+    ).json()) as { receipts: Array<{ requestId: string }> };
+    const priorReceiptIds = new Set(receiptsBefore.receipts.map((receipt) => receipt.requestId));
+    const routed = await page.request.post("/v1/chat/completions", {
+      headers: { "x-request-id": requestId },
+      data: {
+        model: "deepseek/chat-capture-v1",
+        messages: [{ role: "user", content: "Create a real retention archive for run 87." }],
+      },
+    });
+    expect(routed.ok()).toBeTruthy();
+    const receiptsAfter = (await (
+      await page.request.get("/api/role-model/track-b/shadow-receipts")
+    ).json()) as { receipts: Array<{ requestId: string }> };
+    const capturedRequestId = receiptsAfter.receipts.find(
+      (receipt) => !priorReceiptIds.has(receipt.requestId),
+    )?.requestId;
+    expect(capturedRequestId).toEqual(expect.stringMatching(/^req-/));
+    const policy = await page.request.put("/api/role-model/storage-retention/policy", {
+      data: {
+        policyId: "run87-sp5-held-zero-byte",
+        scope: "global",
+        maxBytes: 0,
+        maxAgeDays: 1,
+        holdRequestIds: [capturedRequestId],
+      },
+    });
+    expect(policy.ok()).toBeTruthy();
+    await page.goto("/app/system/storage-retention");
+
+    await expect(page.getByRole("heading", { name: "Physical storage inventory" })).toBeVisible();
+    const summary = page.getByLabel("Storage retention summary");
+    await expect(summary.getByText("Physical stores")).toBeVisible();
+    await expect(summary.getByText("Legal holds")).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Owner" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Physical bytes" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Enforcement" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Dry-run" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Execute plan" })).toBeDisabled();
+    const inventoryResponse = await page.request.get("/api/role-model/storage-retention");
+    expect(inventoryResponse.ok()).toBeTruthy();
+    const inventory = (await inventoryResponse.json()) as {
+      totalBytes: number;
+      storageInventory: {
+        complete: boolean;
+        entries: Array<{ measurement: string; physicalBytes: number | null; health: string }>;
+      };
+    };
+    expect(Array.isArray(inventory.storageInventory.entries)).toBe(true);
+    expect(
+      inventory.storageInventory.entries.every((row) =>
+        row.measurement === "measured"
+          ? typeof row.physicalBytes === "number"
+          : row.measurement === "unavailable" && row.physicalBytes === null,
+      ),
+    ).toBe(true);
+    expect(inventory.storageInventory.complete).toBe(true);
+    expect(inventory.storageInventory.entries.some((row) => row.measurement === "measured")).toBe(
+      true,
+    );
+    expect(
+      inventory.storageInventory.entries.some((row) => row.measurement === "unavailable"),
+    ).toBe(true);
+    await expect(page.getByText("Unavailable", { exact: true }).first()).toBeVisible();
+
+    const heldPreview = await page.request.post("/api/role-model/storage-retention/dry-run");
+    expect(heldPreview.ok()).toBeTruthy();
+    const heldBody = (await heldPreview.json()) as {
+      holds: number;
+      currentPlan: { conflicts: Array<{ id: string; reason: string }> };
+    };
+    const heldRetentionId = `capture-${createHash("sha256")
+      .update(capturedRequestId as string)
+      .digest("hex")
+      .slice(0, 24)}`;
+    expect(heldBody.holds).toBe(1);
+    expect(heldBody.currentPlan.conflicts).toContainEqual({
+      id: heldRetentionId,
+      reason: "legal_hold",
+    });
+    await page.reload();
+    await expect(
+      page.getByLabel("Storage retention summary").getByText("1", { exact: true }),
+    ).toBeVisible();
+
+    const releasedPolicy = await page.request.put("/api/role-model/storage-retention/policy", {
+      data: {
+        policyId: "run87-sp5-released-zero-byte",
+        scope: "global",
+        maxBytes: 0,
+        maxAgeDays: 1,
+        holdRequestIds: [],
+      },
+    });
+    expect(releasedPolicy.ok()).toBeTruthy();
+    const released = (await releasedPolicy.json()) as { holds: number };
+    expect(released.holds).toBe(0);
+    const artifactBytesBefore = inventory.storageInventory.entries.find(
+      (row) => (row as { id?: string }).id === "artifact_graph",
+    )?.physicalBytes;
+    expect(artifactBytesBefore).toEqual(expect.any(Number));
+    const [dryRun] = await Promise.all([
+      page.waitForResponse(
+        (candidate) =>
+          candidate.url().includes("/api/role-model/storage-retention/dry-run") &&
+          candidate.request().method() === "POST",
+      ),
+      page.getByRole("button", { name: "Dry-run" }).click(),
+    ]);
+    expect(dryRun.ok()).toBeTruthy();
+    const dryRunBody = (await dryRun.json()) as { currentPlan?: unknown };
+    expect(dryRunBody.currentPlan).toEqual(
+      expect.objectContaining({
+        manifestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        affectedCount: expect.any(Number),
+        estimatedBytes: expect.any(Number),
+        rollbackAvailable: true,
+        blocks: expect.any(Array),
+      }),
+    );
+    const plan = dryRunBody.currentPlan as {
+      manifestHash: string;
+      affectedCount: number;
+      estimatedBytes: number;
+    };
+    expect(plan.affectedCount).toBeGreaterThan(0);
+    expect(plan.estimatedBytes).toBeGreaterThan(0);
+    const execute = await page.request.post("/api/role-model/storage-retention/execute", {
+      data: { manifestHash: plan.manifestHash, scope: "global" },
+    });
+    expect(execute.ok()).toBeTruthy();
+    let completed: {
+      activeJob?: { status?: string };
+      receipts?: Array<{
+        id: string;
+        status: string;
+        affectedCount?: number;
+        deletedBytes?: number;
+        deletedIds?: string[];
+        rollbackAvailable?: boolean;
+        maintenancePlanHash?: string;
+        maintenanceReceipt?: {
+          bounded?: boolean;
+          routingInterrupted?: boolean;
+          reclaimedBytes?: number;
+        };
+      }>;
+    } = {};
+    await expect
+      .poll(async () => {
+        const response = await page.request.get("/api/role-model/storage-retention");
+        completed = await response.json();
+        return completed.activeJob?.status;
+      })
+      .toBe("completed");
+    const completionReceipt = completed.receipts?.at(-1);
+    expect(completionReceipt).toMatchObject({
+      status: "completed",
+      rollbackAvailable: true,
+      maintenancePlanHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      maintenanceReceipt: { bounded: true, routingInterrupted: false },
+    });
+    expect(completionReceipt?.affectedCount).toBeGreaterThan(0);
+    expect(completionReceipt?.deletedBytes).toBeGreaterThan(0);
+    expect(completionReceipt?.deletedIds?.length).toBeGreaterThan(0);
+    const afterExecute = (await (
+      await page.request.get("/api/role-model/storage-retention")
+    ).json()) as {
+      storageInventory: { entries: Array<{ id: string; physicalBytes: number | null }> };
+    };
+    const artifactBytesAfterExecute = afterExecute.storageInventory.entries.find(
+      (row) => row.id === "artifact_graph",
+    )?.physicalBytes;
+    expect(artifactBytesAfterExecute).toEqual(expect.any(Number));
+    expect(artifactBytesAfterExecute as number).toBeLessThan(artifactBytesBefore as number);
+    const rollback = await page.request.post("/api/role-model/storage-retention/rollback", {
+      data: { receiptId: completionReceipt?.id },
+    });
+    expect(rollback.ok()).toBeTruthy();
+    const rolledBack = (await rollback.json()) as {
+      receipts: Array<{ status: string; affectedCount: number; sourceReceiptId: string }>;
+      totalCount: number;
+    };
+    expect(rolledBack.receipts.at(-1)).toMatchObject({
+      status: "rolled_back",
+      sourceReceiptId: completionReceipt?.id,
+    });
+    expect(rolledBack.receipts.at(-1)?.affectedCount).toBeGreaterThan(0);
+    expect(rolledBack.totalCount).toBeGreaterThan(0);
+
+    const afterRollback = (await (
+      await page.request.get("/api/role-model/storage-retention")
+    ).json()) as {
+      totalCount: number;
+      storageInventory: { entries: Array<{ id: string; physicalBytes: number | null }> };
+    };
+    const artifactBytesAfterRollback = afterRollback.storageInventory.entries.find(
+      (row) => row.id === "artifact_graph",
+    )?.physicalBytes;
+    expect(artifactBytesAfterRollback).toBeGreaterThanOrEqual(artifactBytesBefore as number);
+
+    const extensions = (await (
+      await page.request.get("/api/role-model/extensions")
+    ).json()) as Array<{ id: string; pid: number | null; revision: number }>;
+    const artifactStore = extensions.find((row) => row.id === "artifact-store");
+    const restarted = await page.request.post("/api/role-model/extensions/mutate", {
+      data: {
+        id: "artifact-store",
+        action: "restart",
+        expectedRevision: artifactStore?.revision,
+        mutationId: `run87-sp5-storage-owner-restart-${artifactStore?.revision}`,
+      },
+    });
+    expect(restarted.ok()).toBeTruthy();
+    const afterOwnerRestart = (await (
+      await page.request.get("/api/role-model/extensions")
+    ).json()) as Array<{ id: string; lifecycle: string; pid: number | null }>;
+    expect(afterOwnerRestart.find((row) => row.id === "artifact-store")).toMatchObject({
+      lifecycle: "ready",
+    });
+    expect(afterOwnerRestart.find((row) => row.id === "artifact-store")?.pid).not.toBe(
+      artifactStore?.pid,
+    );
+    expect(
+      (
+        (await (await page.request.get("/api/role-model/storage-retention")).json()) as {
+          totalCount: number;
+        }
+      ).totalCount,
+    ).toBe(afterRollback.totalCount);
+    expect((await page.request.get("/healthz")).ok()).toBeTruthy();
+  });
+});

--- a/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp7.privacy-recommendations.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp7.privacy-recommendations.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("@recursive:87-direct-track-b-semantic-completion @sp7 @smoke", () => {
+  test("privacy opt-out clears upload authority without disabling local recommendation access", async ({
+    page,
+  }) => {
+    await page.goto("/app/system/extensions");
+    await expect(page.getByRole("heading", { name: "Contribution posture" })).toBeVisible();
+    const current = await page.request.get("/api/role-model/contribution");
+    expect(current.ok()).toBeTruthy();
+    const before = (await current.json()) as { mode: string };
+    const disclosure = await page.request.put("/api/role-model/contribution", {
+      data: { action: "complete_disclosure", disclosureId: "run87-browser-disclosure" },
+    });
+    expect(disclosure.ok()).toBeTruthy();
+    expect(await disclosure.json()).toMatchObject({
+      authorizationState: "active",
+      disclosureId: "run87-browser-disclosure",
+    });
+    if (before.mode === "contributor") {
+      const optedOut = await page.request.put("/api/role-model/contribution", {
+        data: { action: "opt_out" },
+      });
+      expect(optedOut.ok()).toBeTruthy();
+    }
+    const privateState = (await (
+      await page.request.get("/api/role-model/contribution")
+    ).json()) as {
+      mode: string;
+      contributionTier: string;
+      recommendationAccess: string;
+      allowCloudUpload: boolean;
+      queuedCount: number;
+      authorizationState: string;
+    };
+    expect(privateState).toMatchObject({
+      mode: "consumer",
+      contributionTier: "none",
+      recommendationAccess: "preview_and_apply",
+      allowCloudUpload: false,
+      queuedCount: 0,
+      authorizationState: "revoked",
+    });
+    const serialized = JSON.stringify(privateState).toLowerCase();
+    for (const forbidden of ["messages", "prompt", "transcript", "repositorycontent", "secret"]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+    const hostileReplay = await page.request.post("/v1/chat/completions", {
+      headers: { "x-request-id": `run87-sp7-revoked-replay-${Date.now()}` },
+      data: {
+        model: "deepseek/chat-capture-v1",
+        messages: [{ role: "user", content: "This must remain local after revocation." }],
+      },
+    });
+    expect(hostileReplay.ok()).toBeTruthy();
+    expect(await (await page.request.get("/api/role-model/contribution")).json()).toMatchObject({
+      authorizationState: "revoked",
+      allowCloudUpload: false,
+      queuedCount: 0,
+    });
+
+    const downloaded = await page.request.post("/api/role-model/recommendations/download");
+    expect(downloaded.ok()).toBeTruthy();
+    const recommendations = await page.request.get("/api/role-model/recommendations");
+    expect(recommendations.ok()).toBeTruthy();
+    const recommendationRows = (await recommendations.json()) as Array<{
+      id: string;
+      status: string;
+      signatureValid: boolean;
+      policyAllowed: boolean;
+    }>;
+    expect(recommendationRows).toHaveLength(2);
+    expect(recommendationRows.every((row) => row.signatureValid && row.policyAllowed)).toBe(true);
+    expect(recommendationRows.every((row) => row.status === "validated")).toBe(true);
+
+    const dismissed = await page.request.post("/api/role-model/recommendations/dismiss", {
+      data: { id: "run87-recommendation-dismiss" },
+    });
+    expect(dismissed.ok()).toBeTruthy();
+    expect(await dismissed.json()).toMatchObject({
+      recommendations: expect.arrayContaining([
+        expect.objectContaining({ id: "run87-recommendation-dismiss", status: "dismissed" }),
+      ]),
+    });
+    const applied = await page.request.post("/api/role-model/recommendations/apply", {
+      data: { id: "run87-recommendation-apply" },
+    });
+    expect(applied.ok()).toBeTruthy();
+    expect(await applied.json()).toMatchObject({
+      activePack: { id: "run87-recommendation-apply" },
+    });
+    expect(
+      await (await page.request.get("/api/role-model/recommendations/active-pack")).json(),
+    ).toMatchObject({ id: "run87-recommendation-apply" });
+
+    const reenabled = await page.request.put("/api/role-model/contribution", {
+      data: { action: "reenable" },
+    });
+    expect(reenabled.ok()).toBeTruthy();
+    expect(await reenabled.json()).toMatchObject({ authorizationState: "pending_disclosure" });
+  });
+});

--- a/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp8.packaged-system.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/recursive-87-direct-track-b-semantic-completion.sp8.packaged-system.spec.ts
@@ -1,0 +1,223 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("@recursive:87-direct-track-b-semantic-completion @sp8 @smoke", () => {
+  test("live system exposes the complete extension release and survives a lifecycle round trip", async ({
+    page,
+  }) => {
+    const health = await page.request.get("/healthz");
+    expect(health.ok()).toBeTruthy();
+    const response = await page.request.get("/api/role-model/extensions");
+    expect(response.ok()).toBeTruthy();
+    const rows = (await response.json()) as Array<{
+      id: string;
+      packageClass: string;
+      installed: boolean;
+      health: { available: boolean };
+    }>;
+    expect(rows).toHaveLength(13);
+    expect(new Set(rows.map((row) => row.id)).size).toBe(13);
+    expect(rows.every((row) => row.packageClass === "canonical_extension" && row.installed)).toBe(
+      true,
+    );
+    expect(rows.some((row) => row.health.available)).toBe(true);
+    const knowledgeWorkerBefore = rows.find((row) => row.id === "knowledge-worker") as
+      | ((typeof rows)[number] & { enabledMode?: string; productionActivation?: boolean })
+      | undefined;
+    expect(knowledgeWorkerBefore).toMatchObject({ enabledMode: "shadow" });
+    expect(knowledgeWorkerBefore).not.toHaveProperty("productionActivation");
+    const productionConfigBefore = await (
+      await page.request.get("/api/role-model/runtime/config")
+    ).json();
+    const productionExtensionModesBefore = rows.map((row) => ({
+      id: row.id,
+      enabledMode: (row as { enabledMode?: string }).enabledMode,
+    }));
+
+    const readNewShadowReceipt = async (priorRequestIds: ReadonlySet<string>) => {
+      const response = await page.request.get("/api/role-model/track-b/shadow-receipts");
+      expect(response.ok()).toBeTruthy();
+      const body = (await response.json()) as {
+        pendingCount: number;
+        receiptCount: number;
+        receipts: Array<{ requestId: string; result: Record<string, unknown> }>;
+      };
+      return body.receipts.find((receipt) => !priorRequestIds.has(receipt.requestId)) ?? null;
+    };
+
+    const requestId = `run87-packaged-shadow-${Date.now()}`;
+    const preRequestReceipts = (await (
+      await page.request.get("/api/role-model/track-b/shadow-receipts")
+    ).json()) as { receipts: Array<{ requestId: string }> };
+    const preRequestReceiptIds = new Set(
+      preRequestReceipts.receipts.map((receipt) => receipt.requestId),
+    );
+    const routed = await page.request.post("/v1/chat/completions", {
+      headers: { "x-request-id": requestId },
+      data: {
+        model: "deepseek/chat-capture-v1",
+        messages: [{ role: "user", content: "Execute the packaged run-87 shadow pipeline." }],
+      },
+    });
+    expect(routed.ok()).toBeTruthy();
+    expect(await routed.json()).toEqual(expect.objectContaining({ choices: expect.any(Array) }));
+    await expect
+      .poll(async () => (await readNewShadowReceipt(preRequestReceiptIds)) !== null)
+      .toBe(true);
+    const shadowBeforeCutover = await readNewShadowReceipt(preRequestReceiptIds);
+    expect(shadowBeforeCutover).not.toBeNull();
+    if (!shadowBeforeCutover) throw new Error("pre-cutover shadow receipt was not durable");
+    const observedRequestId = shadowBeforeCutover.requestId;
+    expect(shadowBeforeCutover.result).toMatchObject({
+      pipeline: {
+        schemaVersion: "role-model.track-b-shadow-pipeline-receipt.v1",
+        mode: "shadow",
+        requestId: observedRequestId,
+        providerCalls: 0,
+        productionMutation: false,
+        candidateId: expect.any(String),
+      },
+      projection: {
+        scope: expect.any(String),
+        readiness: {
+          rolloutPurpose: "routing_shadow",
+          authorizationState: "authorized",
+          lifecycleReadiness: "ready",
+          routingTrainingSuitability: "eligible",
+        },
+        evidence: [expect.objectContaining({ verified: true })],
+      },
+      consumption: {
+        consumerCount: 3,
+        productionMutation: false,
+        results: expect.arrayContaining([
+          expect.objectContaining({
+            state: "shadow",
+            productionMutation: false,
+            productionEffects: {
+              providerCalls: 0,
+              promptMutations: 0,
+              routeMutations: 0,
+              weightMutations: 0,
+              activeProfileMutations: 0,
+            },
+          }),
+        ]),
+      },
+    });
+    const retentionBeforeCutover = (await (
+      await page.request.get("/api/role-model/storage-retention")
+    ).json()) as { totalCount: number; storageInventory: { complete: boolean } };
+    expect(retentionBeforeCutover.storageInventory.complete).toBe(true);
+    await expect
+      .poll(async () => {
+        const current = (await (
+          await page.request.get("/api/role-model/extensions")
+        ).json()) as Array<{ id: string; lifecycle: string; health: { available: boolean } }>;
+        return current.filter((row) => row.lifecycle === "ready" && row.health.available).length;
+      })
+      .toBe(13);
+
+    const migration = await page.request.get("/api/role-model/graph-migration");
+    expect(migration.ok()).toBeTruthy();
+    const beforeMigration = (await migration.json()) as { state: string };
+    expect(beforeMigration.state).toMatch(
+      /legacy_primary|shadow_mirror|parity_verified|graph_primary/,
+    );
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const current = (await (
+        await page.request.get("/api/role-model/graph-migration")
+      ).json()) as { state: string };
+      if (current.state === "graph_primary") break;
+      const advanced = await page.request.post("/api/role-model/graph-migration/advance", {
+        data: {
+          backupVerified: true,
+          restoreVerified: true,
+          consumersVerified: true,
+        },
+      });
+      expect(advanced.ok()).toBeTruthy();
+    }
+    expect(
+      (await (await page.request.get("/api/role-model/graph-migration")).json()) as {
+        state: string;
+      },
+    ).toMatchObject({ state: "graph_primary" });
+
+    const afterCutoverRequestId = `run87-packaged-graph-primary-${Date.now()}`;
+    const preCutoverReceipts = (await (
+      await page.request.get("/api/role-model/track-b/shadow-receipts")
+    ).json()) as { receipts: Array<{ requestId: string }> };
+    const preCutoverReceiptIds = new Set(
+      preCutoverReceipts.receipts.map((receipt) => receipt.requestId),
+    );
+    const afterCutover = await page.request.post("/v1/chat/completions", {
+      headers: { "x-request-id": afterCutoverRequestId },
+      data: {
+        model: "deepseek/chat-capture-v1",
+        messages: [{ role: "user", content: "Verify graph-primary continuity." }],
+      },
+    });
+    expect(afterCutover.ok()).toBeTruthy();
+    await expect
+      .poll(async () => (await readNewShadowReceipt(preCutoverReceiptIds)) !== null)
+      .toBe(true);
+    const shadowAfterCutover = await readNewShadowReceipt(preCutoverReceiptIds);
+    expect(shadowAfterCutover).not.toBeNull();
+    if (!shadowAfterCutover) throw new Error("post-cutover shadow receipt was not durable");
+    expect(shadowAfterCutover.result).toMatchObject({
+      pipeline: { mode: "shadow", productionMutation: false, providerCalls: 0 },
+      projection: {
+        scope: (shadowBeforeCutover.result.projection as { scope: string }).scope,
+        readiness: {
+          rolloutPurpose: "routing_shadow",
+          lifecycleReadiness: "ready",
+          routingTrainingSuitability: "eligible",
+        },
+      },
+      consumption: { consumerCount: 3, productionMutation: false },
+    });
+    expect((await page.request.get("/healthz")).ok()).toBeTruthy();
+    const extensionsAfterCutover = (await (
+      await page.request.get("/api/role-model/extensions")
+    ).json()) as Array<{
+      id: string;
+      enabledMode?: string;
+      productionActivation?: boolean;
+    }>;
+    const knowledgeWorkerAfter = extensionsAfterCutover.find(
+      (row) => row.id === "knowledge-worker",
+    );
+    expect(knowledgeWorkerAfter).toMatchObject({ enabledMode: "shadow" });
+    expect(knowledgeWorkerAfter).not.toHaveProperty("productionActivation");
+    expect(
+      extensionsAfterCutover.map((row) => ({ id: row.id, enabledMode: row.enabledMode })),
+    ).toEqual(productionExtensionModesBefore);
+    expect(await (await page.request.get("/api/role-model/runtime/config")).json()).toEqual(
+      productionConfigBefore,
+    );
+    const retentionAfterCutover = (await (
+      await page.request.get("/api/role-model/storage-retention")
+    ).json()) as { totalCount: number; storageInventory: { complete: boolean } };
+    expect(retentionAfterCutover.totalCount).toBeGreaterThanOrEqual(
+      retentionBeforeCutover.totalCount,
+    );
+    expect(retentionAfterCutover.storageInventory.complete).toBe(true);
+    const postCutoverRetentionPlan = await page.request.post(
+      "/api/role-model/storage-retention/dry-run",
+    );
+    expect(postCutoverRetentionPlan.ok()).toBeTruthy();
+    expect(await postCutoverRetentionPlan.json()).toMatchObject({
+      currentPlan: {
+        manifestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        blocks: [],
+      },
+    });
+
+    await page.goto("/app/system/extensions");
+    await expect(page.getByLabel("Extensions summary").getByText("Installed")).toBeVisible();
+    await expect(
+      page.getByRole("table").getByText("knowledge-worker", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Shadow-ready by default", { exact: true })).toBeVisible();
+  });
+});

--- a/role-model-router/packages/adapter-execution/src/cli.ts
+++ b/role-model-router/packages/adapter-execution/src/cli.ts
@@ -297,6 +297,7 @@ export async function runRuntimeAdapterValidation(
   const initialization = initializeSqliteMemory({
     runtimeStateRoot: options.runtimeStateRoot,
     scopeId: options.scopeId,
+    channel: "development",
   });
 
   persistProviderAccounts({

--- a/role-model-router/packages/context-envelope/test/index.test.ts
+++ b/role-model-router/packages/context-envelope/test/index.test.ts
@@ -74,6 +74,7 @@ describe("assembleContextEnvelope", () => {
     const initialized = initializeSqliteMemory({
       runtimeStateRoot,
       scopeId: "workspace-dev",
+      channel: "development",
     });
 
     persistContinuitySnapshot({

--- a/role-model-router/packages/endpoint-registry/src/cli.ts
+++ b/role-model-router/packages/endpoint-registry/src/cli.ts
@@ -115,6 +115,7 @@ export async function runRuntimeRegistryValidation(
   const initialization = initializeSqliteMemory({
     runtimeStateRoot: options.runtimeStateRoot,
     scopeId: options.scopeId,
+    channel: "development",
   });
   persistProviderAccounts({
     databasePath: initialization.databasePath,

--- a/role-model-router/packages/protocol-routing/src/cli.ts
+++ b/role-model-router/packages/protocol-routing/src/cli.ts
@@ -169,6 +169,7 @@ export async function runRuntimeRoutingValidation(
   const initialization = initializeSqliteMemory({
     runtimeStateRoot: options.runtimeStateRoot,
     scopeId: options.scopeId,
+    channel: "development",
   });
 
   persistProviderAccounts({

--- a/role-model-router/packages/sqlite-memory/src/cli.ts
+++ b/role-model-router/packages/sqlite-memory/src/cli.ts
@@ -80,6 +80,7 @@ export async function runRuntimeStateValidation(
   const initialization = initializeSqliteMemory({
     runtimeStateRoot: options.runtimeStateRoot,
     scopeId: options.scopeId,
+    channel: "development",
   });
 
   persistProviderAccounts({

--- a/role-model-router/packages/sqlite-memory/src/history-policy.ts
+++ b/role-model-router/packages/sqlite-memory/src/history-policy.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+
+export const PERFORMANCE_HISTORY_POLICY_VERSION =
+  "role-model.performance-history-policy.v1" as const;
+export const PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVES = 8;
+export const PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVE_BYTES = 8 * 1024 * 1024;
+export const PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVE_ROWS = 100_000;
+
+export interface PerformanceHistoryPolicy {
+  readonly schemaVersion: typeof PERFORMANCE_HISTORY_POLICY_VERSION;
+  readonly maxSamplesPerEndpoint: number;
+  readonly maxAgeMs: number;
+  readonly maxBytesPerEndpoint: number;
+  readonly maxRebuildSamples: number;
+}
+
+export const DEFAULT_PERFORMANCE_HISTORY_POLICY: PerformanceHistoryPolicy = Object.freeze({
+  schemaVersion: PERFORMANCE_HISTORY_POLICY_VERSION,
+  maxSamplesPerEndpoint: 512,
+  maxAgeMs: 365 * 24 * 60 * 60 * 1_000,
+  maxBytesPerEndpoint: 8 * 1024 * 1024,
+  maxRebuildSamples: 512,
+});
+
+export interface PerformanceHistoryPolicyReceipt {
+  readonly receiptId: string;
+  readonly previousPolicy: PerformanceHistoryPolicy;
+  readonly appliedPolicy: PerformanceHistoryPolicy;
+}
+
+export function validatePerformanceHistoryPolicy(value: unknown): PerformanceHistoryPolicy {
+  if (!value || typeof value !== "object")
+    throw new Error("performance history policy is required");
+  const policy = value as Record<string, unknown>;
+  if (policy.schemaVersion !== PERFORMANCE_HISTORY_POLICY_VERSION) {
+    throw new Error("unsupported performance history policy schema version");
+  }
+  const boundedInteger = (name: string, minimum: number, maximum: number) => {
+    const candidate = policy[name];
+    if (
+      !Number.isSafeInteger(candidate) ||
+      Number(candidate) < minimum ||
+      Number(candidate) > maximum
+    ) {
+      throw new Error(`${name} is outside the supported bounded range`);
+    }
+    return Number(candidate);
+  };
+  const normalized = {
+    schemaVersion: PERFORMANCE_HISTORY_POLICY_VERSION,
+    maxSamplesPerEndpoint: boundedInteger("maxSamplesPerEndpoint", 1, 100_000),
+    maxAgeMs: boundedInteger("maxAgeMs", 1, 10 * 365 * 24 * 60 * 60 * 1_000),
+    maxBytesPerEndpoint: boundedInteger("maxBytesPerEndpoint", 1_024, 1024 * 1024 * 1024),
+    maxRebuildSamples: boundedInteger("maxRebuildSamples", 1, 100_000),
+  } satisfies PerformanceHistoryPolicy;
+  if (normalized.maxRebuildSamples > normalized.maxSamplesPerEndpoint) {
+    throw new Error("maxRebuildSamples cannot exceed maxSamplesPerEndpoint");
+  }
+  return normalized;
+}
+
+export function ensurePerformanceHistorySchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS performance_history_policy (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      policy_json TEXT NOT NULL,
+      updated_at_ms INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS performance_history_rollups (
+      endpoint_id TEXT NOT NULL,
+      difficulty_bucket TEXT NOT NULL,
+      raw_sample_count INTEGER NOT NULL,
+      raw_bytes INTEGER NOT NULL,
+      last_rebuild_scanned_samples INTEGER NOT NULL,
+      newest_timestamp_ms INTEGER,
+      updated_at_ms INTEGER NOT NULL,
+      PRIMARY KEY (endpoint_id, difficulty_bucket)
+    );
+    CREATE TABLE IF NOT EXISTS performance_history_policy_archives (
+      receipt_id TEXT PRIMARY KEY,
+      archive_json TEXT NOT NULL,
+      created_at_ms INTEGER NOT NULL
+    );
+  `);
+  database
+    .prepare(
+      "INSERT OR IGNORE INTO performance_history_policy (singleton_id,policy_json,updated_at_ms) VALUES (1,?,?)",
+    )
+    .run(JSON.stringify(DEFAULT_PERFORMANCE_HISTORY_POLICY), Date.now());
+}
+
+export function readPerformanceHistoryPolicy(database: DatabaseSync): PerformanceHistoryPolicy {
+  ensurePerformanceHistorySchema(database);
+  const row = database
+    .prepare("SELECT policy_json FROM performance_history_policy WHERE singleton_id=1")
+    .get() as { policy_json: string };
+  return validatePerformanceHistoryPolicy(JSON.parse(row.policy_json));
+}
+
+export function writePerformanceHistoryPolicy(
+  database: DatabaseSync,
+  policy: PerformanceHistoryPolicy,
+): PerformanceHistoryPolicyReceipt {
+  const normalized = validatePerformanceHistoryPolicy(policy);
+  const previousPolicy = readPerformanceHistoryPolicy(database);
+  database
+    .prepare(
+      "UPDATE performance_history_policy SET policy_json=?,updated_at_ms=? WHERE singleton_id=1",
+    )
+    .run(JSON.stringify(normalized), Date.now());
+  return { receiptId: randomUUID(), previousPolicy, appliedPolicy: normalized };
+}
+
+export function enforcePerformanceHistoryPolicy(
+  database: DatabaseSync,
+  input: {
+    readonly endpointId: string;
+    readonly nowMs: number;
+    readonly difficultyBucket?: string;
+  },
+): {
+  readonly sampleJson: readonly string[];
+  readonly rawBytes: number;
+  readonly prunedCount: number;
+} {
+  const policy = readPerformanceHistoryPolicy(database);
+  const table = input.difficultyBucket
+    ? "observed_performance_samples_by_difficulty"
+    : "observed_performance_samples";
+  const bucketClause = input.difficultyBucket ? " AND difficulty_bucket=?" : "";
+  const parameters = input.difficultyBucket
+    ? [input.endpointId, input.difficultyBucket]
+    : [input.endpointId];
+  const rows = database
+    .prepare(
+      `SELECT sample_id,timestamp_ms,sample_json,length(CAST(sample_json AS BLOB)) AS byte_length
+       FROM ${table} WHERE endpoint_id=?${bucketClause}
+       ORDER BY timestamp_ms DESC,sample_id DESC`,
+    )
+    .all(...parameters) as Array<{
+    sample_id: string;
+    timestamp_ms: number;
+    sample_json: string;
+    byte_length: number;
+  }>;
+  const retained: typeof rows = [];
+  const pruned: string[] = [];
+  let rawBytes = 0;
+  for (const row of rows) {
+    const eligible =
+      row.timestamp_ms >= input.nowMs - policy.maxAgeMs &&
+      retained.length < policy.maxSamplesPerEndpoint &&
+      retained.length < policy.maxRebuildSamples &&
+      rawBytes + row.byte_length <= policy.maxBytesPerEndpoint;
+    if (eligible) {
+      retained.push(row);
+      rawBytes += row.byte_length;
+    } else {
+      pruned.push(row.sample_id);
+    }
+  }
+  const remove = database.prepare(`DELETE FROM ${table} WHERE sample_id=?`);
+  for (const sampleId of pruned) remove.run(sampleId);
+  database
+    .prepare(
+      `INSERT OR REPLACE INTO performance_history_rollups
+       (endpoint_id,difficulty_bucket,raw_sample_count,raw_bytes,last_rebuild_scanned_samples,newest_timestamp_ms,updated_at_ms)
+       VALUES (?,?,?,?,?,?,?)`,
+    )
+    .run(
+      input.endpointId,
+      input.difficultyBucket ?? "",
+      retained.length,
+      rawBytes,
+      retained.length,
+      retained[0]?.timestamp_ms ?? null,
+      Date.now(),
+    );
+  return {
+    sampleJson: [...retained].reverse().map((row) => row.sample_json),
+    rawBytes,
+    prunedCount: pruned.length,
+  };
+}

--- a/role-model-router/packages/sqlite-memory/src/index.ts
+++ b/role-model-router/packages/sqlite-memory/src/index.ts
@@ -1,5 +1,13 @@
-import { randomUUID } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
@@ -10,11 +18,26 @@ import {
 import type { ProviderAccountRecord } from "@role-model-router/provider-account";
 import type { ObservedPerformanceProfile } from "@role-model/protocol-types";
 import {
-  mirrorShadowRuntimeObservation,
+  PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVES,
+  PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVE_BYTES,
+  PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVE_ROWS,
+  type PerformanceHistoryPolicy,
+  type PerformanceHistoryPolicyReceipt,
+  enforcePerformanceHistoryPolicy,
+  ensurePerformanceHistorySchema,
+  readPerformanceHistoryPolicy,
+  validatePerformanceHistoryPolicy,
+  writePerformanceHistoryPolicy,
+} from "./history-policy.js";
+import {
+  hydrateRuntimeObservationGraphPointer,
+  readRuntimeObservationStorageState,
+  recordRuntimeObservationGraphReference,
   resolveRuntimeObservationStoragePayload,
 } from "./legacy-migration.js";
 
 export * from "./legacy-migration.js";
+export * from "./history-policy.js";
 
 const INITIAL_MIGRATION_ID = "run06-v1-initial-schema";
 const OBSERVATION_METADATA_BACKFILL_MIGRATION_ID = "run62-observation-metadata-backfill-v1";
@@ -275,6 +298,13 @@ CREATE TABLE IF NOT EXISTS schema_version (
   migration_id TEXT NOT NULL,
   applied_at_ms INTEGER NOT NULL
 );
+CREATE TABLE IF NOT EXISTS storage_write_authority (
+  storage_class TEXT PRIMARY KEY,
+  registry_version TEXT NOT NULL,
+  owner TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  authorized_at_ms INTEGER NOT NULL
+);
 CREATE TABLE IF NOT EXISTS migration_receipts (
   migration_id TEXT PRIMARY KEY,
   schema_version INTEGER NOT NULL,
@@ -336,6 +366,26 @@ CREATE TABLE IF NOT EXISTS observed_throughput_penalties (
   expires_at_ms INTEGER NOT NULL,
   last_observation_measured_at_ms INTEGER NOT NULL,
   updated_at_ms INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS performance_history_policy (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  policy_json TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS performance_history_rollups (
+  endpoint_id TEXT NOT NULL,
+  difficulty_bucket TEXT NOT NULL,
+  raw_sample_count INTEGER NOT NULL,
+  raw_bytes INTEGER NOT NULL,
+  last_rebuild_scanned_samples INTEGER NOT NULL,
+  newest_timestamp_ms INTEGER,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (endpoint_id, difficulty_bucket)
+);
+CREATE TABLE IF NOT EXISTS runtime_retention_receipts (
+  receipt_id TEXT PRIMARY KEY,
+  created_at_ms INTEGER NOT NULL,
+  receipt_json TEXT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS runtime_telemetry_records (
   request_id TEXT PRIMARY KEY,
@@ -612,13 +662,73 @@ export interface RetrievalReceiptRecord {
 
 export interface PersistRuntimeObservationBundleInput {
   readonly databasePath: string;
+  readonly channel: "development" | "stage" | "production";
   readonly observation: PersistedRuntimeObservationBundle;
+  readonly nowMs?: number;
   readonly artifactRef?: import("./legacy-migration.js").GraphArtifactReference;
+  readonly graphStore?: import("./legacy-migration.js").RuntimeObservationGraphStore;
 }
+
+export const SQLITE_STORAGE_REGISTRY = Object.freeze({
+  schemaVersion: "role-model.storage-registry.v1",
+  entries: Object.freeze(
+    [
+      "sqlite_migration_journal",
+      "sqlite_performance_history",
+      "sqlite_profiles",
+      "sqlite_runtime_observations",
+      "sqlite_telemetry",
+    ].map((id) =>
+      Object.freeze({
+        id,
+        owner: "sqlite-memory",
+        channels: Object.freeze(["development", "stage", "production"] as const),
+      }),
+    ),
+  ),
+});
+
+const assertSqliteStorageWriteAllowed = (
+  databasePath: string,
+  channel: unknown,
+  storageClasses: readonly string[],
+): void => {
+  if (
+    !SQLITE_STORAGE_REGISTRY.entries.every((entry) => entry.channels.includes(channel as never))
+  ) {
+    throw new Error(`SQLite storage classes are not writable in ${String(channel ?? "unknown")}`);
+  }
+  const database = new DatabaseSync(databasePath, { open: true });
+  try {
+    const table = database
+      .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='storage_write_authority'")
+      .get();
+    if (!table) throw new Error("SQLite storage registry authority is missing");
+    for (const storageClass of storageClasses) {
+      const row = database
+        .prepare(
+          "SELECT registry_version,owner,channel FROM storage_write_authority WHERE storage_class=?",
+        )
+        .get(storageClass) as
+        | { registry_version?: string; owner?: string; channel?: string }
+        | undefined;
+      if (
+        row?.registry_version !== SQLITE_STORAGE_REGISTRY.schemaVersion ||
+        row.owner !== "sqlite-memory" ||
+        row.channel !== channel
+      ) {
+        throw new Error(`SQLite storage class is not registered for write: ${storageClass}`);
+      }
+    }
+  } finally {
+    database.close();
+  }
+};
 
 export interface ReadRuntimeObservationBundleInput {
   readonly databasePath: string;
   readonly requestId: string;
+  readonly graphStore?: Pick<import("./legacy-migration.js").RuntimeObservationGraphStore, "read">;
 }
 
 export interface ReadObservedPerformanceSamplesInput {
@@ -1209,6 +1319,7 @@ export function resolveSqliteMemoryLocation(input: SqliteMemoryLocationInput): s
 
 function initializeSchema(database: DatabaseSync): void {
   database.exec(SCHEMA_SQL);
+  ensurePerformanceHistorySchema(database);
   const providerAccountColumns = new Set(
     (
       database.prepare("PRAGMA table_info(provider_accounts)").all() as Array<{
@@ -1654,18 +1765,41 @@ function mapObservedThroughputPenaltyStateRow(row: {
 }
 
 export function initializeSqliteMemory(
-  input: SqliteMemoryLocationInput,
+  input: SqliteMemoryLocationInput & {
+    readonly channel: "development" | "stage" | "production";
+  },
 ): SqliteMemoryInitializationResult {
+  if (!SQLITE_STORAGE_REGISTRY.entries.every((entry) => entry.channels.includes(input.channel))) {
+    throw new Error(
+      `SQLite storage classes are not writable in ${String(input.channel ?? "unknown")}`,
+    );
+  }
   const databasePath = resolveSqliteMemoryLocation(input);
   mkdirSync(path.dirname(databasePath), { recursive: true });
+  const isNewDatabase = !existsSync(databasePath) || statSync(databasePath).size === 0;
   const database = new DatabaseSync(databasePath);
   const nowMs = Date.now();
 
+  if (isNewDatabase) {
+    database.exec("PRAGMA auto_vacuum = INCREMENTAL");
+  }
   const journalModeRow = database.prepare("PRAGMA journal_mode = WAL").get() as
     | { journal_mode?: string }
     | undefined;
   initializeSchema(database);
   seedMaintenanceDefaults(database, nowMs);
+  const authorize = database.prepare(
+    "INSERT OR REPLACE INTO storage_write_authority(storage_class,registry_version,owner,channel,authorized_at_ms) VALUES (?,?,?,?,?)",
+  );
+  for (const entry of SQLITE_STORAGE_REGISTRY.entries) {
+    authorize.run(
+      entry.id,
+      SQLITE_STORAGE_REGISTRY.schemaVersion,
+      entry.owner,
+      input.channel,
+      nowMs,
+    );
+  }
 
   const currentVersionRow = database
     .prepare("SELECT schema_version FROM schema_version ORDER BY schema_version DESC LIMIT 1")
@@ -3301,6 +3435,335 @@ export function readObservedThroughputPenaltyState(
 export interface PersistObservedBenchmarkSampleInput {
   readonly databasePath: string;
   readonly sample: ObservedPerformanceSample;
+  readonly nowMs?: number;
+}
+
+export function configurePerformanceHistoryPolicy(input: {
+  readonly databasePath: string;
+  readonly policy: PerformanceHistoryPolicy;
+  readonly nowMs?: number;
+}): PerformanceHistoryPolicyReceipt {
+  return withSqliteBusyRetry(input.databasePath, (database) => {
+    database.exec("BEGIN IMMEDIATE");
+    try {
+      const receipt = writePerformanceHistoryPolicy(
+        database,
+        validatePerformanceHistoryPolicy(input.policy),
+      );
+      const archiveTables = [
+        "observed_performance_samples",
+        "observed_performance_samples_by_difficulty",
+        "observed_profile_snapshots",
+        "observed_profile_snapshots_by_difficulty",
+        "performance_history_rollups",
+      ] as const;
+      const archiveRowCount = archiveTables.reduce(
+        (total, table) =>
+          total +
+          Number(
+            (database.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number })
+              .count,
+          ),
+        0,
+      );
+      if (archiveRowCount > PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVE_ROWS) {
+        throw new Error(
+          "performance history policy rollback archive exceeds the bounded row limit",
+        );
+      }
+      const archive = Object.fromEntries(
+        archiveTables.map((table) => [table, database.prepare(`SELECT * FROM ${table}`).all()]),
+      );
+      const archiveJson = JSON.stringify(archive);
+      if (Buffer.byteLength(archiveJson) > PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVE_BYTES) {
+        throw new Error(
+          "performance history policy rollback archive exceeds the bounded byte limit",
+        );
+      }
+      database
+        .prepare(
+          "INSERT INTO performance_history_policy_archives (receipt_id,archive_json,created_at_ms) VALUES (?,?,?)",
+        )
+        .run(receipt.receiptId, archiveJson, input.nowMs ?? Date.now());
+      database
+        .prepare(
+          "DELETE FROM performance_history_policy_archives WHERE receipt_id NOT IN (SELECT receipt_id FROM performance_history_policy_archives ORDER BY created_at_ms DESC,receipt_id DESC LIMIT ?)",
+        )
+        .run(PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVES);
+      const enforcementNowMs = input.nowMs ?? Date.now();
+      const endpoints = database
+        .prepare(
+          "SELECT endpoint_id,MAX(timestamp_ms) AS newest FROM observed_performance_samples GROUP BY endpoint_id",
+        )
+        .all() as Array<{ endpoint_id: string; newest: number }>;
+      for (const endpoint of endpoints) {
+        enforcePerformanceHistoryPolicy(database, {
+          endpointId: endpoint.endpoint_id,
+          nowMs: enforcementNowMs,
+        });
+        const buckets = database
+          .prepare(
+            "SELECT difficulty_bucket,MAX(timestamp_ms) AS newest FROM observed_performance_samples_by_difficulty WHERE endpoint_id=? GROUP BY difficulty_bucket",
+          )
+          .all(endpoint.endpoint_id) as Array<{ difficulty_bucket: string; newest: number }>;
+        for (const bucket of buckets) {
+          enforcePerformanceHistoryPolicy(database, {
+            endpointId: endpoint.endpoint_id,
+            difficultyBucket: bucket.difficulty_bucket,
+            nowMs: enforcementNowMs,
+          });
+        }
+        rebuildObservedProfilesForEndpoint(database, endpoint.endpoint_id, enforcementNowMs);
+      }
+      database.exec("COMMIT");
+      return receipt;
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
+  });
+}
+
+export function rollbackPerformanceHistoryPolicy(input: {
+  readonly databasePath: string;
+  readonly receipt: PerformanceHistoryPolicyReceipt;
+}): PerformanceHistoryPolicyReceipt {
+  return withSqliteBusyRetry(input.databasePath, (database) => {
+    database.exec("BEGIN IMMEDIATE");
+    try {
+      const current = readPerformanceHistoryPolicy(database);
+      if (JSON.stringify(current) !== JSON.stringify(input.receipt.appliedPolicy)) {
+        throw new Error("performance history policy changed after the rollback receipt");
+      }
+      const archived = database
+        .prepare("SELECT archive_json FROM performance_history_policy_archives WHERE receipt_id=?")
+        .get(input.receipt.receiptId) as { archive_json: string } | undefined;
+      if (!archived) throw new Error("performance history rollback archive is unavailable");
+      const archive = JSON.parse(archived.archive_json) as Record<
+        string,
+        Array<Record<string, string | number | null>>
+      >;
+      for (const [table, rows] of Object.entries(archive)) {
+        if (
+          ![
+            "observed_performance_samples",
+            "observed_performance_samples_by_difficulty",
+            "observed_profile_snapshots",
+            "observed_profile_snapshots_by_difficulty",
+            "performance_history_rollups",
+          ].includes(table)
+        ) {
+          throw new Error("performance history rollback archive contains an unknown table");
+        }
+        database.exec(`DELETE FROM ${table}`);
+        for (const row of rows) {
+          const columns = Object.keys(row);
+          database
+            .prepare(
+              `INSERT INTO ${table} (${columns.join(",")}) VALUES (${columns.map(() => "?").join(",")})`,
+            )
+            .run(...columns.map((column) => row[column]));
+        }
+      }
+      const rollbackReceipt = writePerformanceHistoryPolicy(database, input.receipt.previousPolicy);
+      database
+        .prepare("DELETE FROM performance_history_policy_archives WHERE receipt_id=?")
+        .run(input.receipt.receiptId);
+      database.exec("COMMIT");
+      return rollbackReceipt;
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
+  });
+}
+
+export function readPerformanceHistoryStatus(input: {
+  readonly databasePath: string;
+  readonly endpointId: string;
+  readonly difficultyBucket?: string;
+}) {
+  const database = openSqliteDatabase(input.databasePath);
+  try {
+    const policy = readPerformanceHistoryPolicy(database);
+    const table = input.difficultyBucket
+      ? "observed_performance_samples_by_difficulty"
+      : "observed_performance_samples";
+    const bucketClause = input.difficultyBucket ? " AND difficulty_bucket=?" : "";
+    const parameters = input.difficultyBucket
+      ? [input.endpointId, input.difficultyBucket]
+      : [input.endpointId];
+    const raw = database
+      .prepare(
+        `SELECT COUNT(*) AS count,COALESCE(SUM(length(CAST(sample_json AS BLOB))),0) AS bytes
+         FROM ${table} WHERE endpoint_id=?${bucketClause}`,
+      )
+      .get(...parameters) as { count: number; bytes: number };
+    const rollup = database
+      .prepare(
+        `SELECT last_rebuild_scanned_samples,newest_timestamp_ms FROM performance_history_rollups
+         WHERE endpoint_id=? AND difficulty_bucket=?`,
+      )
+      .get(input.endpointId, input.difficultyBucket ?? "") as
+      | { last_rebuild_scanned_samples: number; newest_timestamp_ms: number | null }
+      | undefined;
+    return {
+      endpointId: input.endpointId,
+      difficultyBucket: input.difficultyBucket ?? null,
+      rawSampleCount: Number(raw.count),
+      rawBytes: Number(raw.bytes),
+      lastRebuildScannedSamples: Number(rollup?.last_rebuild_scanned_samples ?? 0),
+      newestTimestampMs: rollup?.newest_timestamp_ms ?? null,
+      maxSamplesPerEndpoint: policy.maxSamplesPerEndpoint,
+      maxAgeMs: policy.maxAgeMs,
+      maxBytesPerEndpoint: policy.maxBytesPerEndpoint,
+      maxRebuildSamples: policy.maxRebuildSamples,
+      bounded:
+        Number(raw.count) <= policy.maxSamplesPerEndpoint &&
+        Number(raw.count) <= policy.maxRebuildSamples &&
+        Number(raw.bytes) <= policy.maxBytesPerEndpoint,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+export function runSqliteRetentionMaintenance(input: {
+  readonly databasePath: string;
+  readonly nowMs: number;
+  readonly maxDeleteRows: number;
+  readonly holdRequestIds: readonly string[];
+  readonly idle: boolean;
+  readonly lockRisk: "low" | "unknown" | "high";
+}) {
+  if (!input.idle || input.lockRisk !== "low") {
+    throw new Error("SQLite retention maintenance requires an idle window and low lock risk");
+  }
+  if (
+    !Number.isSafeInteger(input.maxDeleteRows) ||
+    input.maxDeleteRows < 1 ||
+    input.maxDeleteRows > 10_000
+  ) {
+    throw new Error("SQLite retention maintenance requires a bounded delete limit");
+  }
+  const holds = [...new Set(input.holdRequestIds.map(String))].sort();
+  const physicalBytesBefore = statSync(input.databasePath).size;
+  const database = openSqliteDatabase(input.databasePath);
+  let receipt: {
+    receiptId: string;
+    deletedRows: number;
+    heldRows: number;
+    bounded: true;
+    routingInterrupted: false;
+    physicalBytesBefore: number;
+    physicalBytesAfter: number;
+    reclaimedBytes: number;
+    vacuumedPages: number;
+  };
+  try {
+    const heldRows = holds.length
+      ? Number(
+          (
+            database
+              .prepare(
+                `SELECT COUNT(*) AS count FROM runtime_observations
+                 WHERE retain_until_ms IS NOT NULL AND retain_until_ms<=?
+                   AND request_id IN (${holds.map(() => "?").join(",")})`,
+              )
+              .get(input.nowMs, ...holds) as { count: number }
+          ).count,
+        )
+      : 0;
+    const exclusion = holds.length
+      ? ` AND request_id NOT IN (${holds.map(() => "?").join(",")})`
+      : "";
+    const expired = database
+      .prepare(
+        `SELECT request_id,endpoint_id FROM runtime_observations
+         WHERE retain_until_ms IS NOT NULL AND retain_until_ms<=?${exclusion}
+         ORDER BY retain_until_ms ASC,request_id ASC LIMIT ?`,
+      )
+      .all(input.nowMs, ...holds, input.maxDeleteRows) as Array<{
+      request_id: string;
+      endpoint_id: string;
+    }>;
+    database.exec("BEGIN IMMEDIATE");
+    try {
+      const deleteObservation = database.prepare(
+        "DELETE FROM runtime_observations WHERE request_id=?",
+      );
+      const deleteSamples = database.prepare(
+        "DELETE FROM observed_performance_samples WHERE request_id=?",
+      );
+      const deleteBucketSamples = database.prepare(
+        "DELETE FROM observed_performance_samples_by_difficulty WHERE request_id=?",
+      );
+      const deleteTelemetry = database.prepare(
+        "DELETE FROM runtime_telemetry_records WHERE request_id=?",
+      );
+      for (const row of expired) {
+        deleteSamples.run(row.request_id);
+        deleteBucketSamples.run(row.request_id);
+        deleteTelemetry.run(row.request_id);
+        deleteObservation.run(row.request_id);
+      }
+      for (const endpointId of new Set(expired.map((row) => row.endpoint_id))) {
+        rebuildObservedProfilesForEndpoint(database, endpointId, input.nowMs);
+      }
+      const receiptId = randomUUID();
+      const body = {
+        receiptId,
+        deletedRows: expired.length,
+        heldRows,
+        bounded: true as const,
+        routingInterrupted: false as const,
+        physicalBytesBefore,
+        physicalBytesAfter: physicalBytesBefore,
+        reclaimedBytes: 0,
+        vacuumedPages: 0,
+      };
+      database
+        .prepare(
+          "INSERT INTO runtime_retention_receipts (receipt_id,created_at_ms,receipt_json) VALUES (?,?,?)",
+        )
+        .run(receiptId, input.nowMs, JSON.stringify(body));
+      database.exec("COMMIT");
+      receipt = body;
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
+    database.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    const pageCountBefore = Number(
+      (database.prepare("PRAGMA page_count").get() as { page_count: number }).page_count,
+    );
+    database.exec(`PRAGMA incremental_vacuum(${input.maxDeleteRows})`);
+    database.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    const pageCountAfter = Number(
+      (database.prepare("PRAGMA page_count").get() as { page_count: number }).page_count,
+    );
+    const pageSize = Number(
+      (database.prepare("PRAGMA page_size").get() as { page_size: number }).page_size,
+    );
+    receipt = {
+      ...receipt,
+      physicalBytesAfter: pageCountAfter * pageSize,
+      reclaimedBytes: Math.max(0, (pageCountBefore - pageCountAfter) * pageSize),
+      vacuumedPages: Math.max(0, pageCountBefore - pageCountAfter),
+    };
+    database
+      .prepare("UPDATE runtime_retention_receipts SET receipt_json=? WHERE receipt_id=?")
+      .run(JSON.stringify(receipt), receipt.receiptId);
+    database.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+  } finally {
+    database.close();
+  }
+  const physicalBytesAfter = statSync(input.databasePath).size;
+  return {
+    ...receipt,
+    physicalBytesAfter,
+    reclaimedBytes: Math.max(0, receipt.physicalBytesBefore - physicalBytesAfter),
+  };
 }
 
 export interface ClearObservedBenchmarkDataForEndpointInput {
@@ -3334,6 +3797,7 @@ function rebuildObservedProfilesForEndpoint(
       (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
     );
     const profile = aggregateObservedPerformanceSamples(samples, { nowMs });
+    database.prepare("DELETE FROM observed_profile_snapshots WHERE endpoint_id=?").run(endpointId);
     database
       .prepare(
         "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
@@ -3364,6 +3828,11 @@ function rebuildObservedProfilesForEndpoint(
         (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
       );
       const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, { nowMs });
+      database
+        .prepare(
+          "DELETE FROM observed_profile_snapshots_by_difficulty WHERE endpoint_id=? AND difficulty_bucket=?",
+        )
+        .run(endpointId, difficultyBucket);
       database
         .prepare(
           "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
@@ -3488,6 +3957,7 @@ export function persistObservedBenchmarkSample(input: PersistObservedBenchmarkSa
     ...input.sample,
     source_type: "benchmark" as const,
   };
+  const historyNowMs = input.nowMs ?? Date.now();
   for (let attempt = 1; ; attempt += 1) {
     const database = openSqliteDatabase(input.databasePath);
     try {
@@ -3520,17 +3990,22 @@ export function persistObservedBenchmarkSample(input: PersistObservedBenchmarkSa
             sample.timestamp_ms,
             JSON.stringify(sample),
           );
-        const priorBucketRows = database
-          .prepare(
-            "SELECT sample_json FROM observed_performance_samples_by_difficulty WHERE endpoint_id = ? AND difficulty_bucket = ? ORDER BY timestamp_ms ASC, sample_id ASC",
-          )
-          .all(sample.endpoint_id, difficultyBucket) as Array<{ sample_json: string }>;
-        const bucketSamples = priorBucketRows.map(
-          (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
+        const boundedBucket = enforcePerformanceHistoryPolicy(database, {
+          endpointId: sample.endpoint_id,
+          difficultyBucket,
+          nowMs: historyNowMs,
+        });
+        const bucketSamples = boundedBucket.sampleJson.map(
+          (value) => JSON.parse(value) as ObservedPerformanceSample,
         );
         const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, {
           nowMs: sample.timestamp_ms,
         });
+        database
+          .prepare(
+            "DELETE FROM observed_profile_snapshots_by_difficulty WHERE endpoint_id=? AND difficulty_bucket=?",
+          )
+          .run(sample.endpoint_id, difficultyBucket);
         database
           .prepare(
             "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
@@ -3543,17 +4018,21 @@ export function persistObservedBenchmarkSample(input: PersistObservedBenchmarkSa
             JSON.stringify(bucketProfile),
           );
       }
-      const priorRows = database
-        .prepare(
-          "SELECT sample_json FROM observed_performance_samples WHERE endpoint_id = ? ORDER BY timestamp_ms ASC, sample_id ASC",
-        )
-        .all(sample.endpoint_id) as Array<{ sample_json: string }>;
-      const allSamples = priorRows.map(
-        (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
+      const bounded = enforcePerformanceHistoryPolicy(database, {
+        endpointId: sample.endpoint_id,
+        nowMs: historyNowMs,
+      });
+      const allSamples = bounded.sampleJson.map(
+        (value) => JSON.parse(value) as ObservedPerformanceSample,
       );
+      if (allSamples.length === 0)
+        throw new Error("performance history policy rejected every sample");
       const profile = aggregateObservedPerformanceSamples(allSamples, {
         nowMs: sample.timestamp_ms,
       });
+      database
+        .prepare("DELETE FROM observed_profile_snapshots WHERE endpoint_id=?")
+        .run(sample.endpoint_id);
       database
         .prepare(
           "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
@@ -3577,112 +4056,263 @@ export function persistObservedBenchmarkSample(input: PersistObservedBenchmarkSa
 }
 
 export function persistRuntimeObservationBundle(input: PersistRuntimeObservationBundleInput): void {
+  assertSqliteStorageWriteAllowed(input.databasePath, input.channel, [
+    "sqlite_migration_journal",
+    "sqlite_performance_history",
+    "sqlite_profiles",
+    "sqlite_runtime_observations",
+    "sqlite_telemetry",
+  ]);
   const observation = input.observation;
+  const historyNowMs = input.nowMs ?? Date.now();
   const telemetryRecord = toRuntimeTelemetryRecord(observation);
-  withSqliteBusyRetry(input.databasePath, (database) => {
-    database
-      .prepare(
-        "INSERT OR REPLACE INTO runtime_observations (request_id, routing_decision_id, endpoint_id, conversation_id, created_at_ms, retain_until_ms, taxonomy_role_id, taxonomy_task_type, client_request_id, request_class, observation_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      )
-      .run(
-        observation.requestId,
-        observation.routingDecisionId,
-        observation.endpointId,
-        observation.conversationId,
-        observation.usageEvent.timestamp_ms,
-        observation.privacyReceipt?.retainUntil ?? null,
-        typeof observation.taxonomyDimensions?.taxonomy_role_id === "string"
-          ? observation.taxonomyDimensions.taxonomy_role_id
-          : null,
-        typeof observation.taxonomyDimensions?.taxonomy_task_type === "string"
-          ? observation.taxonomyDimensions.taxonomy_task_type
-          : null,
-        observation.clientRequestId ?? null,
-        observation.observedPerformance?.sample?.source_type === "benchmark"
-          ? "benchmark"
-          : observation.observedPerformance?.sample?.source_type === "live_request"
-            ? "live_request"
-            : null,
-        resolveRuntimeObservationStoragePayload({
-          databasePath: input.databasePath,
-          observation: observation as unknown as Readonly<Record<string, unknown>>,
-          ...(input.artifactRef ? { artifactRef: input.artifactRef } : {}),
-        }),
-      );
-    mirrorShadowRuntimeObservation(database, {
-      observation: observation as unknown as Readonly<Record<string, unknown>>,
-      ...(input.artifactRef ? { artifactRef: input.artifactRef } : {}),
-    });
-    database
-      .prepare(
-        "INSERT OR REPLACE INTO observed_performance_samples (sample_id, endpoint_id, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
-      )
-      .run(
-        sampleIdFor(observation.observedPerformance.sample),
-        observation.endpointId,
-        observation.observedPerformance.sample.request_id ?? null,
-        observation.observedPerformance.sample.routing_decision_id ?? null,
-        observation.observedPerformance.sample.source_type,
-        observation.observedPerformance.sample.timestamp_ms,
-        JSON.stringify(observation.observedPerformance.sample),
-      );
-    if (observation.observedPerformance.sample.difficulty_bucket) {
-      const difficultyBucket = observation.observedPerformance.sample.difficulty_bucket;
-      database
+  const storageState = readRuntimeObservationStorageState(input.databasePath);
+  let artifactRef = input.artifactRef;
+  let createdArtifact: import("./legacy-migration.js").LegacyArtifactWriteResult | undefined;
+  const intentId = `runtime-observation:${observation.requestId}`;
+  if (input.graphStore?.remove) {
+    withSqliteBusyRetry(input.databasePath, (database) => {
+      database.exec(`CREATE TABLE IF NOT EXISTS runtime_observation_graph_write_intents (
+        intent_id TEXT PRIMARY KEY,
+        scope_id TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        artifact_json TEXT,
+        created_at_ms INTEGER NOT NULL
+      )`);
+      const pending = database
         .prepare(
-          "INSERT OR REPLACE INTO observed_performance_samples_by_difficulty (sample_id, endpoint_id, difficulty_bucket, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+          "SELECT * FROM runtime_observation_graph_write_intents ORDER BY created_at_ms,intent_id",
         )
-        .run(
-          segmentedSampleIdFor(observation.observedPerformance.sample),
-          observation.endpointId,
-          difficultyBucket,
-          observation.observedPerformance.sample.request_id ?? null,
-          observation.observedPerformance.sample.routing_decision_id ?? null,
-          observation.observedPerformance.sample.source_type,
-          observation.observedPerformance.sample.timestamp_ms,
-          JSON.stringify(observation.observedPerformance.sample),
-        );
-      const priorBucketRows = database
-        .prepare(
-          "SELECT sample_json FROM observed_performance_samples_by_difficulty WHERE endpoint_id = ? AND difficulty_bucket = ? ORDER BY timestamp_ms ASC, sample_id ASC",
-        )
-        .all(observation.endpointId, difficultyBucket) as Array<{
-        sample_json: string;
+        .all() as Array<{
+        intent_id: string;
+        scope_id: string;
+        source_id: string;
+        content: string;
+        content_hash: string;
+        artifact_json: string | null;
       }>;
-      const bucketSamples = priorBucketRows.map(
-        (row) => JSON.parse(row.sample_json) as ObservedPerformanceSample,
-      );
-      const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, {
-        nowMs: observation.observedPerformance.sample.timestamp_ms,
-      });
+      for (const row of pending) {
+        if (row.scope_id !== input.graphStore?.scopeId) continue;
+        const artifact = row.artifact_json
+          ? (JSON.parse(row.artifact_json) as {
+              artifactId: string;
+              artifactPath: string;
+              contentHash: string;
+            })
+          : input.graphStore.write({
+              scopeId: row.scope_id,
+              sourceId: row.source_id,
+              content: row.content,
+              contentHash: row.content_hash,
+            });
+        input.graphStore.remove?.(artifact);
+        database
+          .prepare("DELETE FROM runtime_observation_graph_write_intents WHERE intent_id=?")
+          .run(row.intent_id);
+      }
+    });
+  }
+  if (
+    !artifactRef &&
+    [
+      "shadow_mirror",
+      "parity_verified",
+      "graph_primary",
+      "legacy_read_hold",
+      "legacy_retired",
+    ].includes(storageState)
+  ) {
+    const graphStore = input.graphStore;
+    if (!graphStore) throw new Error("graph artifact writer required during graph migration");
+    const content = JSON.stringify(observation);
+    const contentHash = createHash("sha256").update(content).digest("hex");
+    if (!graphStore.remove)
+      throw new Error("graph artifact compensation authority required during graph migration");
+    withSqliteBusyRetry(input.databasePath, (database) => {
       database
         .prepare(
-          "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
+          "INSERT OR REPLACE INTO runtime_observation_graph_write_intents VALUES (?,?,?,?,?,?,?)",
         )
         .run(
-          `${observation.endpointId}:${difficultyBucket}:${bucketProfile.measured_at_ms}`,
-          observation.endpointId,
-          difficultyBucket,
-          bucketProfile.measured_at_ms,
-          JSON.stringify(bucketProfile),
+          intentId,
+          graphStore.scopeId,
+          observation.requestId,
+          content,
+          contentHash,
+          null,
+          Date.now(),
         );
+    });
+    createdArtifact = graphStore.write({
+      scopeId: graphStore.scopeId,
+      sourceId: observation.requestId,
+      content,
+      contentHash,
+    });
+    if (createdArtifact.contentHash !== contentHash) {
+      graphStore.remove(createdArtifact);
+      withSqliteBusyRetry(input.databasePath, (database) => {
+        if (createdArtifact) {
+          database
+            .prepare("DELETE FROM runtime_observation_graph_write_intents WHERE intent_id=?")
+            .run(intentId);
+        }
+      });
+      throw new Error("graph observation artifact content hash mismatch");
     }
-    database
-      .prepare(
-        "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
-      )
-      .run(
-        `${observation.endpointId}:${observation.observedPerformance.profile.measured_at_ms}`,
-        observation.endpointId,
-        observation.observedPerformance.profile.measured_at_ms,
-        JSON.stringify(observation.observedPerformance.profile),
-      );
-    database
-      .prepare(
-        `INSERT OR REPLACE INTO runtime_telemetry_records (${RUNTIME_TELEMETRY_INSERT_COLUMNS.join(", ")}) VALUES (${RUNTIME_TELEMETRY_INSERT_COLUMNS.map(() => "?").join(", ")})`,
-      )
-      .run(...runtimeTelemetryInsertValues(telemetryRecord));
-  });
+    withSqliteBusyRetry(input.databasePath, (database) => {
+      database
+        .prepare(
+          "UPDATE runtime_observation_graph_write_intents SET artifact_json=? WHERE intent_id=?",
+        )
+        .run(JSON.stringify(createdArtifact), intentId);
+    });
+    artifactRef = { scopeId: graphStore.scopeId, ...createdArtifact };
+  }
+  try {
+    withSqliteBusyRetry(input.databasePath, (database) => {
+      database.exec("BEGIN IMMEDIATE");
+      try {
+        database
+          .prepare(
+            "INSERT OR REPLACE INTO runtime_observations (request_id, routing_decision_id, endpoint_id, conversation_id, created_at_ms, retain_until_ms, taxonomy_role_id, taxonomy_task_type, client_request_id, request_class, observation_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            observation.requestId,
+            observation.routingDecisionId,
+            observation.endpointId,
+            observation.conversationId,
+            observation.usageEvent.timestamp_ms,
+            observation.privacyReceipt?.retainUntil ?? null,
+            typeof observation.taxonomyDimensions?.taxonomy_role_id === "string"
+              ? observation.taxonomyDimensions.taxonomy_role_id
+              : null,
+            typeof observation.taxonomyDimensions?.taxonomy_task_type === "string"
+              ? observation.taxonomyDimensions.taxonomy_task_type
+              : null,
+            observation.clientRequestId ?? null,
+            observation.observedPerformance?.sample?.source_type === "benchmark"
+              ? "benchmark"
+              : observation.observedPerformance?.sample?.source_type === "live_request"
+                ? "live_request"
+                : null,
+            resolveRuntimeObservationStoragePayload({
+              databasePath: input.databasePath,
+              observation: observation as unknown as Readonly<Record<string, unknown>>,
+              ...(artifactRef ? { artifactRef } : {}),
+            }),
+          );
+        recordRuntimeObservationGraphReference(database, {
+          observation: observation as unknown as Readonly<Record<string, unknown>>,
+          ...(artifactRef ? { artifactRef } : {}),
+        });
+        database
+          .prepare(
+            "INSERT OR REPLACE INTO observed_performance_samples (sample_id, endpoint_id, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            sampleIdFor(observation.observedPerformance.sample),
+            observation.endpointId,
+            observation.observedPerformance.sample.request_id ?? null,
+            observation.observedPerformance.sample.routing_decision_id ?? null,
+            observation.observedPerformance.sample.source_type,
+            observation.observedPerformance.sample.timestamp_ms,
+            JSON.stringify(observation.observedPerformance.sample),
+          );
+        if (observation.observedPerformance.sample.difficulty_bucket) {
+          const difficultyBucket = observation.observedPerformance.sample.difficulty_bucket;
+          database
+            .prepare(
+              "INSERT OR REPLACE INTO observed_performance_samples_by_difficulty (sample_id, endpoint_id, difficulty_bucket, request_id, routing_decision_id, source_type, timestamp_ms, sample_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .run(
+              segmentedSampleIdFor(observation.observedPerformance.sample),
+              observation.endpointId,
+              difficultyBucket,
+              observation.observedPerformance.sample.request_id ?? null,
+              observation.observedPerformance.sample.routing_decision_id ?? null,
+              observation.observedPerformance.sample.source_type,
+              observation.observedPerformance.sample.timestamp_ms,
+              JSON.stringify(observation.observedPerformance.sample),
+            );
+          const boundedBucket = enforcePerformanceHistoryPolicy(database, {
+            endpointId: observation.endpointId,
+            difficultyBucket,
+            nowMs: historyNowMs,
+          });
+          const bucketSamples = boundedBucket.sampleJson.map(
+            (value) => JSON.parse(value) as ObservedPerformanceSample,
+          );
+          const bucketProfile = aggregateObservedPerformanceSamples(bucketSamples, {
+            nowMs: observation.observedPerformance.sample.timestamp_ms,
+          });
+          database
+            .prepare(
+              "DELETE FROM observed_profile_snapshots_by_difficulty WHERE endpoint_id=? AND difficulty_bucket=?",
+            )
+            .run(observation.endpointId, difficultyBucket);
+          database
+            .prepare(
+              "INSERT OR REPLACE INTO observed_profile_snapshots_by_difficulty (snapshot_id, endpoint_id, difficulty_bucket, measured_at_ms, profile_json) VALUES (?, ?, ?, ?, ?)",
+            )
+            .run(
+              `${observation.endpointId}:${difficultyBucket}:${bucketProfile.measured_at_ms}`,
+              observation.endpointId,
+              difficultyBucket,
+              bucketProfile.measured_at_ms,
+              JSON.stringify(bucketProfile),
+            );
+        }
+        enforcePerformanceHistoryPolicy(database, {
+          endpointId: observation.endpointId,
+          nowMs: historyNowMs,
+        });
+        database
+          .prepare("DELETE FROM observed_profile_snapshots WHERE endpoint_id=?")
+          .run(observation.endpointId);
+        database
+          .prepare(
+            "INSERT OR REPLACE INTO observed_profile_snapshots (snapshot_id, endpoint_id, measured_at_ms, profile_json) VALUES (?, ?, ?, ?)",
+          )
+          .run(
+            `${observation.endpointId}:${observation.observedPerformance.profile.measured_at_ms}`,
+            observation.endpointId,
+            observation.observedPerformance.profile.measured_at_ms,
+            JSON.stringify(observation.observedPerformance.profile),
+          );
+        database
+          .prepare(
+            `INSERT OR REPLACE INTO runtime_telemetry_records (${RUNTIME_TELEMETRY_INSERT_COLUMNS.join(", ")}) VALUES (${RUNTIME_TELEMETRY_INSERT_COLUMNS.map(() => "?").join(", ")})`,
+          )
+          .run(...runtimeTelemetryInsertValues(telemetryRecord));
+        if (createdArtifact) {
+          database
+            .prepare("DELETE FROM runtime_observation_graph_write_intents WHERE intent_id=?")
+            .run(intentId);
+        }
+        database.exec("COMMIT");
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+    });
+  } catch (error) {
+    if (createdArtifact) {
+      try {
+        input.graphStore?.remove?.(createdArtifact);
+        withSqliteBusyRetry(input.databasePath, (database) => {
+          database
+            .prepare("DELETE FROM runtime_observation_graph_write_intents WHERE intent_id=?")
+            .run(intentId);
+        });
+      } catch {
+        // Leave the durable intent for deterministic cleanup on the next write.
+      }
+    }
+    throw error;
+  }
 }
 
 export interface PersistRuntimeTelemetryFailureInput {
@@ -3802,6 +4432,24 @@ export function persistRuntimeTelemetryFailure(input: PersistRuntimeTelemetryFai
 export function readRuntimeObservationBundle(
   input: ReadRuntimeObservationBundleInput,
 ): PersistedRuntimeObservationBundle | null {
+  const parsed = readRuntimeObservationStorageRecord(input);
+  if (parsed === null) return null;
+  const hydrated = hydrateRuntimeObservationGraphPointer({
+    databasePath: input.databasePath,
+    pointer: parsed,
+    ...(input.graphStore ? { graphStore: input.graphStore } : {}),
+  });
+  return (hydrated ?? parsed) as unknown as PersistedRuntimeObservationBundle;
+}
+
+/**
+ * Administrative storage inspection. This intentionally returns the persisted
+ * graph pointer without dereferencing rich bytes and must not be used as a
+ * normal observation read path.
+ */
+export function readRuntimeObservationStorageRecord(
+  input: Pick<ReadRuntimeObservationBundleInput, "databasePath" | "requestId">,
+): Readonly<Record<string, unknown>> | null {
   const database = openSqliteDatabase(input.databasePath);
   const row = database
     .prepare("SELECT observation_json FROM runtime_observations WHERE request_id = ?")
@@ -3812,7 +4460,12 @@ export function readRuntimeObservationBundle(
     | undefined;
   database.close();
 
-  return row ? (JSON.parse(row.observation_json) as PersistedRuntimeObservationBundle) : null;
+  if (!row) return null;
+  const parsed = JSON.parse(row.observation_json) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("runtime observation storage record is malformed");
+  }
+  return parsed as Readonly<Record<string, unknown>>;
 }
 
 export interface ReadObservationTelemetryColumnsInput {

--- a/role-model-router/packages/sqlite-memory/src/legacy-migration.ts
+++ b/role-model-router/packages/sqlite-memory/src/legacy-migration.ts
@@ -58,6 +58,39 @@ export interface GraphArtifactReference {
   readonly artifactPath?: string;
 }
 
+export interface RuntimeObservationGraphStore {
+  readonly scopeId: string;
+  write(input: LegacyArtifactWriteInput): LegacyArtifactWriteResult;
+  read(reference: GraphArtifactReference): string;
+  remove?(artifact: LegacyArtifactWriteResult): void;
+}
+
+function isGraphObservationPointer(value: unknown): value is {
+  readonly requestId: string;
+  readonly artifactRef: GraphArtifactReference | string;
+  readonly graphPrimary?: boolean;
+  readonly migrated?: boolean;
+} {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.requestId === "string" &&
+    (typeof candidate.artifactRef === "string" ||
+      (Boolean(candidate.artifactRef) && typeof candidate.artifactRef === "object")) &&
+    (candidate.graphPrimary === true || candidate.migrated === true)
+  );
+}
+
+function stateRequiresGraphWrite(state: LegacyMigrationState): boolean {
+  return (
+    state === "shadow_mirror" ||
+    state === "parity_verified" ||
+    state === "graph_primary" ||
+    state === "legacy_read_hold" ||
+    state === "legacy_retired"
+  );
+}
+
 /** Records a live production write in the migration target while shadow mirroring is active. */
 export function mirrorShadowRuntimeObservation(
   database: DatabaseSync,
@@ -67,9 +100,21 @@ export function mirrorShadowRuntimeObservation(
   },
 ): boolean {
   if (currentState(database) !== "shadow_mirror") return false;
+  return recordRuntimeObservationGraphReference(database, input);
+}
+
+/** Records the authoritative graph reference for live writes throughout cutover and read hold. */
+export function recordRuntimeObservationGraphReference(
+  database: DatabaseSync,
+  input: {
+    readonly observation: Readonly<Record<string, unknown>>;
+    readonly artifactRef?: GraphArtifactReference;
+  },
+): boolean {
+  if (!stateRequiresGraphWrite(currentState(database))) return false;
   const requestId = input.observation.requestId;
   if (typeof requestId !== "string" || requestId.length === 0 || !input.artifactRef) {
-    throw new Error("shadow mirror requires a graph artifact reference for every live observation");
+    throw new Error("graph storage requires an artifact reference for every live observation");
   }
   const source = JSON.stringify(input.observation);
   const sourceHash = sha256(source);
@@ -176,17 +221,39 @@ function sourceProof(database: DatabaseSync, pageSize = 1_000): { count: number;
   let cursor = "";
   let count = 0;
   const page = database.prepare(
-    "SELECT request_id,observation_json FROM runtime_observations WHERE request_id>? ORDER BY request_id ASC LIMIT ?",
+    tableExists(database, "legacy_graph_migration_refs")
+      ? `SELECT observations.request_id, observations.observation_json, refs.source_hash
+         FROM runtime_observations AS observations
+         LEFT JOIN legacy_graph_migration_refs AS refs
+           ON refs.source_table='runtime_observations' AND refs.source_id=observations.request_id
+         WHERE observations.request_id>? ORDER BY observations.request_id ASC LIMIT ?`
+      : `SELECT request_id,observation_json,NULL AS source_hash FROM runtime_observations
+         WHERE request_id>? ORDER BY request_id ASC LIMIT ?`,
   );
   for (;;) {
     const rows = page.all(cursor, pageSize) as Array<{
       request_id: string;
       observation_json: string;
+      source_hash: string | null;
     }>;
     if (!rows.length) break;
     for (const row of rows) {
       if (count) digest.update("\n");
-      digest.update(`${row.request_id}\0${sha256(row.observation_json)}`);
+      let rowHash = sha256(row.observation_json);
+      try {
+        if (isGraphObservationPointer(JSON.parse(row.observation_json))) {
+          if (!row.source_hash)
+            throw new Error("graph observation pointer is missing its source hash");
+          rowHash = row.source_hash;
+        }
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          // Legacy payloads may not be JSON; their byte hash remains authoritative.
+        } else {
+          throw error;
+        }
+      }
+      digest.update(`${row.request_id}\0${rowHash}`);
       count += 1;
     }
     const last = rows[rows.length - 1];
@@ -290,6 +357,65 @@ export function resolveRuntimeObservationStoragePayload(input: {
   return JSON.stringify(input.observation);
 }
 
+export function readRuntimeObservationStorageState(databasePath: string): LegacyMigrationState {
+  const database = open(databasePath, true);
+  try {
+    return currentState(database);
+  } finally {
+    database.close();
+  }
+}
+
+export function hydrateRuntimeObservationGraphPointer(input: {
+  readonly databasePath: string;
+  readonly pointer: unknown;
+  readonly graphStore?: Pick<RuntimeObservationGraphStore, "read">;
+}): Readonly<Record<string, unknown>> | null {
+  if (!isGraphObservationPointer(input.pointer)) return null;
+  if (!input.graphStore) throw new Error("graph artifact reader required after cutover");
+  let reference: GraphArtifactReference;
+  if (typeof input.pointer.artifactRef === "string") {
+    const database = open(input.databasePath, true);
+    try {
+      const row = database
+        .prepare(
+          `SELECT scope_id,artifact_id,artifact_path,artifact_content_hash
+           FROM legacy_graph_migration_refs WHERE source_table=? AND source_id=?`,
+        )
+        .get("runtime_observations", input.pointer.requestId) as
+        | {
+            scope_id: string;
+            artifact_id: string;
+            artifact_path: string;
+            artifact_content_hash: string;
+          }
+        | undefined;
+      if (!row || row.artifact_id !== input.pointer.artifactRef) {
+        throw new Error("graph observation pointer reference is missing or inconsistent");
+      }
+      reference = {
+        scopeId: row.scope_id,
+        artifactId: row.artifact_id,
+        artifactPath: row.artifact_path,
+        contentHash: row.artifact_content_hash,
+      };
+    } finally {
+      database.close();
+    }
+  } else {
+    reference = input.pointer.artifactRef;
+  }
+  const content = input.graphStore.read(reference);
+  if (sha256(content) !== reference.contentHash) {
+    throw new Error("graph observation artifact content hash mismatch");
+  }
+  const observation = JSON.parse(content) as Readonly<Record<string, unknown>>;
+  if (observation.requestId !== input.pointer.requestId) {
+    throw new Error("graph observation artifact request ID mismatch");
+  }
+  return observation;
+}
+
 export class LegacySqliteMigration {
   readonly #databasePath: string;
   readonly #backupPath: string;
@@ -338,8 +464,9 @@ export class LegacySqliteMigration {
     }
   }
 
-  #ensureBackup(): void {
-    if (existsSync(this.#backupPath)) return;
+  #ensureBackup(options: { readonly refresh?: boolean } = {}): void {
+    if (existsSync(this.#backupPath) && !options.refresh) return;
+    if (options.refresh) rmSync(this.#backupPath, { force: true });
     mkdirSync(path.dirname(this.#backupPath), { recursive: true });
     const database = open(this.#databasePath);
     try {
@@ -376,7 +503,8 @@ export class LegacySqliteMigration {
     if (!input.scopeId || !Number.isInteger(input.batchSize) || input.batchSize < 1) {
       throw new Error("bounded scoped backfill input required");
     }
-    this.#ensureBackup();
+    const before = readLegacyMigrationJournal(this.#databasePath);
+    this.#ensureBackup({ refresh: before.state === "legacy_primary" });
     const database = open(this.#databasePath);
     try {
       const registry = loadMigrationRegistry({ routerRoot: this.#routerRoot });

--- a/role-model-router/packages/sqlite-memory/test/fixtures/recursive-87-performance-history.json
+++ b/role-model-router/packages/sqlite-memory/test/fixtures/recursive-87-performance-history.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "role-model.performance-history-fixture.v1",
+  "policy": {
+    "schemaVersion": "role-model.performance-history-policy.v1",
+    "maxSamplesPerEndpoint": 5,
+    "maxAgeMs": 5000,
+    "maxBytesPerEndpoint": 2048,
+    "maxRebuildSamples": 5
+  },
+  "endpointId": "run87.synthetic.bounded-history",
+  "sampleCount": 20,
+  "timestampStepMs": 1000
+}

--- a/role-model-router/packages/sqlite-memory/test/index.test.ts
+++ b/role-model-router/packages/sqlite-memory/test/index.test.ts
@@ -18,13 +18,13 @@ import * as sqliteMemory from "../src/index.ts";
 import {
   clearAllObservedBenchmarkData,
   clearObservedBenchmarkDataForEndpoint,
-  initializeSqliteMemory,
+  initializeSqliteMemory as initializeSqliteMemoryWithChannel,
   listRuntimeTelemetryRecords,
   persistContinuitySnapshot,
   persistObservedBenchmarkSample,
   persistProviderAccounts,
   persistRetrievalReceipt,
-  persistRuntimeObservationBundle,
+  persistRuntimeObservationBundle as persistRuntimeObservationBundleWithChannel,
   persistRuntimeTelemetryFailure,
   readConversationContinuity,
   readLatestObservedProfile,
@@ -34,6 +34,22 @@ import {
   readRuntimeTelemetrySummary,
   resolveSqliteMemoryLocation,
 } from "../src/index.ts";
+
+type TestRuntimeChannel = "development" | "stage" | "production";
+const initializeSqliteMemory = (
+  input: Omit<Parameters<typeof initializeSqliteMemoryWithChannel>[0], "channel"> & {
+    readonly channel?: TestRuntimeChannel;
+  },
+) => initializeSqliteMemoryWithChannel({ ...input, channel: input.channel ?? "development" });
+const persistRuntimeObservationBundle = (
+  input: Omit<Parameters<typeof persistRuntimeObservationBundleWithChannel>[0], "channel"> & {
+    readonly channel?: TestRuntimeChannel;
+  },
+) =>
+  persistRuntimeObservationBundleWithChannel({
+    ...input,
+    channel: input.channel ?? "development",
+  });
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -1007,11 +1023,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -1082,7 +1100,7 @@ describe("initializeSqliteMemory", () => {
     });
   });
 
-  test("persists a live observation into the graph migration reference set during shadow mirror", async () => {
+  test("externalizes and hydrates normal runtime observations across graph-primary cutover", async () => {
     const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-shadow-mirror-"));
     const validation = await runRuntimeAdapterValidation({
       repoRoot,
@@ -1111,6 +1129,7 @@ describe("initializeSqliteMemory", () => {
     });
     persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: initial,
     });
     const migration = new sqliteMemory.LegacySqliteMigration({
@@ -1124,6 +1143,31 @@ describe("initializeSqliteMemory", () => {
     });
     migration.backfill({ scopeId: "workspace-shadow", batchSize: 100 });
     migration.enterShadowMirror({ deadlineMs: Date.now() + 60_000 });
+    const artifacts = new Map<string, string>();
+    const graphStore = {
+      scopeId: "workspace-shadow",
+      write: ({
+        sourceId,
+        content,
+        contentHash,
+      }: {
+        sourceId: string;
+        content: string;
+        contentHash: string;
+      }) => {
+        const artifactId = `artifact-${sourceId}`;
+        artifacts.set(artifactId, content);
+        return { artifactId, artifactPath: `graph/${sourceId}`, contentHash };
+      },
+      read: (reference: { artifactId: string }) => {
+        const content = artifacts.get(reference.artifactId);
+        if (!content) throw new Error(`missing graph artifact ${reference.artifactId}`);
+        return content;
+      },
+      remove: (reference: { artifactId: string }) => {
+        artifacts.delete(reference.artifactId);
+      },
+    };
     const live = structuredClone(initial) as typeof initial;
     live.requestId = `${initial.requestId}-live`;
     live.routingDecisionId = `${initial.routingDecisionId}-live`;
@@ -1131,19 +1175,70 @@ describe("initializeSqliteMemory", () => {
     live.observedPerformance.sample.routing_decision_id = live.routingDecisionId;
     persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: live,
-      artifactRef: {
-        scopeId: "workspace-shadow",
-        artifactId: "artifact-live",
-        contentHash: "a".repeat(64),
-      },
+      graphStore,
     });
     const database = new DatabaseSync(validation.databasePath);
     const reference = database
       .prepare("SELECT source_id,artifact_id FROM legacy_graph_migration_refs WHERE source_id=?")
       .get(live.requestId) as { source_id?: string; artifact_id?: string } | undefined;
     database.close();
-    expect(reference).toEqual({ source_id: live.requestId, artifact_id: "artifact-live" });
+    expect(reference).toEqual({
+      source_id: live.requestId,
+      artifact_id: `artifact-${live.requestId}`,
+    });
+
+    migration.verifyParity({
+      backupVerified: true,
+      restoreVerified: true,
+      consumersVerified: true,
+    });
+    migration.cutover();
+    const graphPrimary = structuredClone(initial) as typeof initial;
+    graphPrimary.requestId = `${initial.requestId}-graph-primary`;
+    graphPrimary.routingDecisionId = `${initial.routingDecisionId}-graph-primary`;
+    graphPrimary.observedPerformance.sample.request_id = graphPrimary.requestId;
+    graphPrimary.observedPerformance.sample.routing_decision_id = graphPrimary.routingDecisionId;
+
+    persistRuntimeObservationBundle({
+      databasePath: validation.databasePath,
+      channel: "development",
+      observation: graphPrimary,
+      graphStore,
+    });
+
+    const pointerDatabase = new DatabaseSync(validation.databasePath);
+    const pointer = pointerDatabase
+      .prepare("SELECT observation_json FROM runtime_observations WHERE request_id=?")
+      .get(graphPrimary.requestId) as { observation_json: string };
+    pointerDatabase.close();
+    expect(pointer.observation_json).not.toContain("inspection");
+    expect(JSON.parse(pointer.observation_json)).toMatchObject({
+      requestId: graphPrimary.requestId,
+      graphPrimary: true,
+      artifactRef: { artifactId: `artifact-${graphPrimary.requestId}` },
+    });
+    expect(() =>
+      readRuntimeObservationBundle({
+        databasePath: validation.databasePath,
+        requestId: graphPrimary.requestId,
+      }),
+    ).toThrow(/graph artifact reader required/i);
+    expect(
+      readRuntimeObservationBundle({
+        databasePath: validation.databasePath,
+        requestId: graphPrimary.requestId,
+        graphStore,
+      }),
+    ).toEqual(graphPrimary);
+
+    migration.enterLegacyReadHold({ holdUntilMs: Date.now() + 60_000 });
+    migration.verifySecondParity({ consumersVerified: true });
+    expect(sqliteMemory.readLegacyMigrationJournal(validation.databasePath)).toMatchObject({
+      state: "legacy_read_hold",
+      secondParityVerified: true,
+    });
   });
 
   describe("listRecentRuntimeObservations", () => {
@@ -1558,11 +1653,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -1806,11 +1903,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -2247,22 +2346,26 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: remoteBundle,
     });
     (
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: localBundle,
     });
 
@@ -2509,11 +2612,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: controllerFallbackBundle,
     });
 
@@ -2613,6 +2718,7 @@ describe("initializeSqliteMemory", () => {
 
     persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: {
         ...bundle,
         usageEvent: {
@@ -2998,11 +3104,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -3130,11 +3238,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -3246,11 +3356,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -3355,11 +3467,13 @@ describe("initializeSqliteMemory", () => {
       sqliteMemory as {
         persistRuntimeObservationBundle(input: {
           databasePath: string;
+          channel: TestRuntimeChannel;
           observation: ReturnType<typeof createRuntimeObservationBundle>;
         }): void;
       }
     ).persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -3524,6 +3638,7 @@ describe("clearAllObservedBenchmarkData", () => {
 
     persistObservedBenchmarkSample({
       databasePath: initialized.databasePath,
+      nowMs: 1_000,
       sample: {
         endpoint_id: endpointA,
         endpoint_version: "v1",
@@ -3536,6 +3651,7 @@ describe("clearAllObservedBenchmarkData", () => {
     });
     persistObservedBenchmarkSample({
       databasePath: initialized.databasePath,
+      nowMs: 2_000,
       sample: {
         endpoint_id: endpointB,
         endpoint_version: "v1",
@@ -3579,6 +3695,7 @@ describe("persistObservedBenchmarkSample benchmark_mode", () => {
 
     persistObservedBenchmarkSample({
       databasePath: initialized.databasePath,
+      nowMs: 1_000,
       sample: {
         endpoint_id: endpointId,
         endpoint_version: "v1",
@@ -3637,6 +3754,7 @@ describe("persistObservedBenchmarkSample benchmark_mode", () => {
       await once(requireChildStdout(locker), "data");
       persistObservedBenchmarkSample({
         databasePath: initialized.databasePath,
+        nowMs: 3_000,
         sample: {
           endpoint_id: endpointId,
           endpoint_version: "v1",
@@ -3953,6 +4071,7 @@ describe("persistObservedBenchmarkSample benchmark_mode", () => {
     });
     persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -4037,6 +4156,7 @@ describe("persistObservedBenchmarkSample benchmark_mode", () => {
     });
     persistRuntimeObservationBundle({
       databasePath: validation.databasePath,
+      channel: "development",
       observation: bundle,
     });
 
@@ -4106,6 +4226,7 @@ describe("clearObservedBenchmarkDataForEndpoint", () => {
 
     persistObservedBenchmarkSample({
       databasePath: initialized.databasePath,
+      nowMs: 1_000,
       sample: {
         endpoint_id: endpointId,
         endpoint_version: "v1",

--- a/role-model-router/packages/sqlite-memory/test/legacy-migration.test.ts
+++ b/role-model-router/packages/sqlite-memory/test/legacy-migration.test.ts
@@ -21,7 +21,11 @@ function fixture() {
   const root = mkdtempSync(
     path.join(process.env.RUN00_TEMP_ROOT ?? process.cwd(), ".tmp-role-model-tb04-"),
   );
-  const initialized = initializeSqliteMemory({ runtimeStateRoot: root, scopeId: "dev" });
+  const initialized = initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "dev",
+    channel: "development",
+  });
   const backupPath = path.join(root, "backup.sqlite");
   const database = new DatabaseSync(initialized.databasePath);
   const rich = JSON.stringify({

--- a/role-model-router/packages/sqlite-memory/test/recursive-87-atomic-observation.test.ts
+++ b/role-model-router/packages/sqlite-memory/test/recursive-87-atomic-observation.test.ts
@@ -1,0 +1,176 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { expect, test } from "vitest";
+
+import {
+  LegacySqliteMigration,
+  initializeSqliteMemory,
+  persistRuntimeObservationBundle,
+} from "../src/index.js";
+
+test("Phase 3.5 public SQLite refuses durable observation writes without registered channel authority", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-sqlite-authority-"));
+  const databasePath = path.join(root, "forged.sqlite");
+  const observation = {
+    requestId: "request-forged-storage",
+    routingDecisionId: "route-forged-storage",
+    endpointId: "endpoint-forged-storage",
+    conversationId: "conversation-forged-storage",
+    usageEvent: { timestamp_ms: Date.now() },
+    observedPerformance: {
+      sample: {
+        endpoint_id: "endpoint-forged-storage",
+        source_type: "live_request",
+        timestamp_ms: Date.now(),
+        latency_ms: 1,
+        success: true,
+      },
+      profile: { measured_at_ms: Date.now() },
+    },
+  } as Parameters<typeof persistRuntimeObservationBundle>[0]["observation"];
+  expect(() =>
+    persistRuntimeObservationBundle({
+      databasePath,
+      observation,
+      channel: "forged",
+      storageRegistry: {
+        schemaVersion: "role-model.storage-registry.v1",
+        entries: [
+          "sqlite_migration_journal",
+          "sqlite_performance_history",
+          "sqlite_profiles",
+          "sqlite_runtime_observations",
+          "sqlite_telemetry",
+        ].map((id) => ({ id, owner: "sqlite-memory", channels: ["development"] })),
+      },
+    } as never),
+  ).toThrow(/registered|writable|storage/i);
+  expect(existsSync(databasePath)).toBe(false);
+});
+
+test("Phase 3.5 graph-primary observation persistence rolls back every SQLite row after a late failure", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-atomic-observation-"));
+  const initialized = initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  const artifacts = new Map<string, string>();
+  let removed = 0;
+  const graphStore = {
+    scopeId: "tenant:run87",
+    write: ({
+      sourceId,
+      content,
+      contentHash,
+    }: { sourceId: string; content: string; contentHash: string }) => {
+      const result = {
+        artifactId: `artifact-${sourceId}`,
+        artifactPath: `artifact://${sourceId}`,
+        contentHash,
+      };
+      artifacts.set(result.artifactId, content);
+      return result;
+    },
+    remove: ({ artifactId }: { artifactId: string }) => {
+      removed += Number(artifacts.delete(artifactId));
+    },
+  };
+  const migration = new LegacySqliteMigration({
+    databasePath: initialized.databasePath,
+    backupPath: path.join(root, "legacy.sqlite"),
+    artifactWriter: graphStore.write,
+  });
+  migration.backfill({ scopeId: graphStore.scopeId, batchSize: 1 });
+  migration.enterShadowMirror({ deadlineMs: Date.now() + 60_000 });
+
+  const database = new DatabaseSync(initialized.databasePath);
+  database.exec(`CREATE TRIGGER fail_late_runtime_telemetry
+    BEFORE INSERT ON runtime_telemetry_records
+    BEGIN SELECT RAISE(ABORT, 'phase35 late telemetry failure'); END`);
+  database.close();
+
+  const observation = {
+    requestId: "request-phase35-atomic",
+    routingDecisionId: "route-phase35-atomic",
+    endpointId: "endpoint-phase35-atomic",
+    conversationId: "conversation-phase35-atomic",
+    usageEvent: { timestamp_ms: Date.now() },
+    observedPerformance: {
+      sample: {
+        endpoint_id: "endpoint-phase35-atomic",
+        source_type: "live_request",
+        timestamp_ms: Date.now(),
+        latency_ms: 1,
+        success: true,
+      },
+      profile: { measured_at_ms: Date.now() },
+    },
+  } as Parameters<typeof persistRuntimeObservationBundle>[0]["observation"];
+
+  expect(() =>
+    persistRuntimeObservationBundle({
+      databasePath: initialized.databasePath,
+      channel: "development",
+      observation,
+      graphStore,
+    }),
+  ).toThrow(/phase35 late telemetry failure/i);
+  expect(removed).toBe(1);
+  const audit = new DatabaseSync(initialized.databasePath);
+  for (const table of [
+    "runtime_observations",
+    "legacy_graph_migration_refs",
+    "observed_performance_samples",
+    "observed_profile_snapshots",
+    "runtime_telemetry_records",
+  ]) {
+    const row = audit.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number };
+    expect(Number(row.count), table).toBe(0);
+  }
+  audit.close();
+
+  const orphanContent = JSON.stringify(observation);
+  const orphanHash = createHash("sha256").update(orphanContent).digest("hex");
+  artifacts.set("artifact-request-phase35-atomic", orphanContent);
+  const journal = new DatabaseSync(initialized.databasePath);
+  journal.prepare("INSERT INTO runtime_observation_graph_write_intents VALUES (?,?,?,?,?,?,?)").run(
+    "crash-window-intent",
+    graphStore.scopeId,
+    observation.requestId,
+    orphanContent,
+    orphanHash,
+    JSON.stringify({
+      artifactId: "artifact-request-phase35-atomic",
+      artifactPath: "artifact://request-phase35-atomic",
+      contentHash: orphanHash,
+    }),
+    Date.now(),
+  );
+  journal.close();
+  expect(() =>
+    persistRuntimeObservationBundle({
+      databasePath: initialized.databasePath,
+      channel: "development",
+      observation,
+      graphStore,
+    }),
+  ).toThrow(/phase35 late telemetry failure/i);
+  expect(artifacts.size).toBe(0);
+  const recovered = new DatabaseSync(initialized.databasePath);
+  expect(
+    Number(
+      (
+        recovered
+          .prepare("SELECT COUNT(*) AS count FROM runtime_observation_graph_write_intents")
+          .get() as { count: number }
+      ).count,
+    ),
+  ).toBe(0);
+  recovered.close();
+});

--- a/role-model-router/packages/sqlite-memory/test/recursive-87-history-policy.test.ts
+++ b/role-model-router/packages/sqlite-memory/test/recursive-87-history-policy.test.ts
@@ -1,0 +1,249 @@
+import { readFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { expect, test } from "vitest";
+
+import * as sqliteMemory from "../src/index.js";
+
+test("SP3 bounds raw performance history, bytes, rebuild work, late data, and restart state", async () => {
+  expect(typeof sqliteMemory.configurePerformanceHistoryPolicy).toBe("function");
+  expect(typeof sqliteMemory.readPerformanceHistoryStatus).toBe("function");
+  expect(typeof sqliteMemory.rollbackPerformanceHistoryPolicy).toBe("function");
+  const fixture = JSON.parse(
+    await readFile(
+      path.join(import.meta.dirname, "fixtures", "recursive-87-performance-history.json"),
+      "utf8",
+    ),
+  ) as {
+    policy: {
+      schemaVersion: "role-model.performance-history-policy.v1";
+      maxSamplesPerEndpoint: number;
+      maxAgeMs: number;
+      maxBytesPerEndpoint: number;
+      maxRebuildSamples: number;
+    };
+    endpointId: string;
+    sampleCount: number;
+    timestampStepMs: number;
+  };
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-history-policy-"));
+  const initialized = sqliteMemory.initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  const receipt = sqliteMemory.configurePerformanceHistoryPolicy({
+    databasePath: initialized.databasePath,
+    policy: fixture.policy,
+  });
+  for (let index = 1; index <= fixture.sampleCount; index += 1) {
+    sqliteMemory.persistObservedBenchmarkSample({
+      databasePath: initialized.databasePath,
+      nowMs: index * fixture.timestampStepMs,
+      sample: {
+        endpoint_id: fixture.endpointId,
+        endpoint_version: "v1",
+        source_type: "benchmark",
+        timestamp_ms: index * fixture.timestampStepMs,
+        latency_ms: index,
+        judge_score: index / fixture.sampleCount,
+      },
+    });
+  }
+
+  const status = sqliteMemory.readPerformanceHistoryStatus({
+    databasePath: initialized.databasePath,
+    endpointId: fixture.endpointId,
+  });
+  expect(status).toMatchObject({
+    rawSampleCount: 5,
+    maxSamplesPerEndpoint: 5,
+    lastRebuildScannedSamples: 5,
+    bounded: true,
+  });
+  expect(status.rawBytes).toBeLessThanOrEqual(fixture.policy.maxBytesPerEndpoint);
+
+  // A late sample outside the retained age window cannot resurrect unbounded history.
+  sqliteMemory.persistObservedBenchmarkSample({
+    databasePath: initialized.databasePath,
+    nowMs: fixture.sampleCount * fixture.timestampStepMs,
+    sample: {
+      endpoint_id: fixture.endpointId,
+      endpoint_version: "v1",
+      source_type: "benchmark",
+      timestamp_ms: fixture.timestampStepMs,
+      latency_ms: 999,
+      judge_score: 0,
+    },
+  });
+  expect(
+    sqliteMemory.readPerformanceHistoryStatus({
+      databasePath: initialized.databasePath,
+      endpointId: fixture.endpointId,
+    }),
+  ).toMatchObject({ rawSampleCount: 5, lastRebuildScannedSamples: 5, bounded: true });
+
+  const restarted = sqliteMemory.initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  expect(
+    sqliteMemory.readPerformanceHistoryStatus({
+      databasePath: restarted.databasePath,
+      endpointId: fixture.endpointId,
+    }),
+  ).toMatchObject({ rawSampleCount: 5, maxSamplesPerEndpoint: 5, bounded: true });
+
+  const database = new DatabaseSync(restarted.databasePath);
+  const snapshots = database
+    .prepare("SELECT COUNT(*) AS count FROM observed_profile_snapshots WHERE endpoint_id=?")
+    .get(fixture.endpointId) as { count: number };
+  database.close();
+  expect(snapshots.count).toBe(1);
+
+  sqliteMemory.rollbackPerformanceHistoryPolicy({
+    databasePath: restarted.databasePath,
+    receipt,
+  });
+  expect(() =>
+    sqliteMemory.configurePerformanceHistoryPolicy({
+      databasePath: restarted.databasePath,
+      policy: { ...fixture.policy, schemaVersion: "role-model.performance-history-policy.v2" },
+    }),
+  ).toThrow(/unsupported performance history policy/i);
+});
+
+test("Phase 3.5 wall-clock aging and policy rollback restore the prior physical history", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-history-rollback-"));
+  const initialized = sqliteMemory.initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  const nowMs = Date.now();
+  for (let index = 0; index < 5; index += 1) {
+    const timestampMs = nowMs - 10_000 + index;
+    sqliteMemory.persistObservedBenchmarkSample({
+      databasePath: initialized.databasePath,
+      sample: {
+        endpoint_id: "inactive-endpoint",
+        endpoint_version: "v1",
+        source_type: "benchmark",
+        timestamp_ms: timestampMs,
+        latency_ms: index + 1,
+        success: true,
+      },
+      nowMs: timestampMs,
+    });
+  }
+  const policy = {
+    schemaVersion: "role-model.performance-history-policy.v1" as const,
+    maxSamplesPerEndpoint: 1,
+    maxAgeMs: 1_000,
+    maxBytesPerEndpoint: 16_384,
+    maxRebuildSamples: 1,
+  };
+  const configuration = { databasePath: initialized.databasePath, policy, nowMs };
+  const receipt = sqliteMemory.configurePerformanceHistoryPolicy(configuration);
+  expect(
+    sqliteMemory.readPerformanceHistoryStatus({
+      databasePath: initialized.databasePath,
+      endpointId: "inactive-endpoint",
+    }).rawSampleCount,
+  ).toBe(0);
+  sqliteMemory.rollbackPerformanceHistoryPolicy({
+    databasePath: initialized.databasePath,
+    receipt,
+  });
+  expect(
+    sqliteMemory.readPerformanceHistoryStatus({
+      databasePath: initialized.databasePath,
+      endpointId: "inactive-endpoint",
+    }).rawSampleCount,
+  ).toBe(5);
+});
+
+test("Phase 3.5 normal benchmark writes expire stale samples against wall clock", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-history-wall-clock-write-"));
+  const initialized = sqliteMemory.initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  sqliteMemory.configurePerformanceHistoryPolicy({
+    databasePath: initialized.databasePath,
+    nowMs: 10_000,
+    policy: {
+      schemaVersion: "role-model.performance-history-policy.v1",
+      maxSamplesPerEndpoint: 5,
+      maxAgeMs: 100,
+      maxBytesPerEndpoint: 32_000,
+      maxRebuildSamples: 5,
+    },
+  });
+  expect(() =>
+    sqliteMemory.persistObservedBenchmarkSample({
+      databasePath: initialized.databasePath,
+      nowMs: 10_000,
+      sample: {
+        endpoint_id: "endpoint:stale",
+        endpoint_version: "v1",
+        source_type: "benchmark",
+        timestamp_ms: 1,
+        latency_ms: 1,
+        judge_score: 1,
+      },
+    }),
+  ).toThrow(/rejected every sample/);
+  expect(
+    sqliteMemory.readPerformanceHistoryStatus({
+      databasePath: initialized.databasePath,
+      endpointId: "endpoint:stale",
+    }),
+  ).toMatchObject({ rawSampleCount: 0, bounded: true });
+});
+
+test("Phase 3.5 policy rollback archives have a fixed retention bound", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-history-policy-archives-"));
+  const initialized = sqliteMemory.initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  const receipts = [];
+  for (
+    let index = 0;
+    index < sqliteMemory.PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVES + 3;
+    index += 1
+  ) {
+    receipts.push(
+      sqliteMemory.configurePerformanceHistoryPolicy({
+        databasePath: initialized.databasePath,
+        nowMs: 10_000 + index,
+        policy: {
+          schemaVersion: "role-model.performance-history-policy.v1",
+          maxSamplesPerEndpoint: 10 + index,
+          maxAgeMs: 100_000,
+          maxBytesPerEndpoint: 32_000,
+          maxRebuildSamples: 5,
+        },
+      }),
+    );
+  }
+  const database = new DatabaseSync(initialized.databasePath);
+  const row = database
+    .prepare("SELECT COUNT(*) AS count FROM performance_history_policy_archives")
+    .get() as { count: number };
+  database.close();
+  expect(Number(row.count)).toBe(sqliteMemory.PERFORMANCE_HISTORY_POLICY_MAX_ARCHIVES);
+  expect(() =>
+    sqliteMemory.rollbackPerformanceHistoryPolicy({
+      databasePath: initialized.databasePath,
+      receipt: receipts[0],
+    }),
+  ).toThrow(/changed|unavailable/i);
+});

--- a/role-model-router/packages/sqlite-memory/test/recursive-87-maintenance.test.ts
+++ b/role-model-router/packages/sqlite-memory/test/recursive-87-maintenance.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { expect, test } from "vitest";
+
+import * as sqliteMemory from "../src/index.js";
+
+test("SP5 SQLite maintenance is bounded, hold-safe, physical, and restart durable", async () => {
+  expect(typeof sqliteMemory.runSqliteRetentionMaintenance).toBe("function");
+  const root = await mkdtemp(path.join(os.tmpdir(), "run87-maintenance-"));
+  const initialized = sqliteMemory.initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  const database = new DatabaseSync(initialized.databasePath);
+  const insert = database.prepare(
+    `INSERT INTO runtime_observations
+     (request_id,routing_decision_id,endpoint_id,conversation_id,created_at_ms,retain_until_ms,observation_json)
+     VALUES (?,?,?,?,?,?,?)`,
+  );
+  for (let index = 0; index < 8; index += 1) {
+    insert.run(
+      `request-${index}`,
+      `route-${index}`,
+      "endpoint",
+      "conversation",
+      index,
+      10,
+      JSON.stringify({ index, rich: "x".repeat(4000) }),
+    );
+  }
+  database.close();
+  const first = sqliteMemory.runSqliteRetentionMaintenance({
+    databasePath: initialized.databasePath,
+    nowMs: 100,
+    maxDeleteRows: 3,
+    holdRequestIds: ["request-0"],
+    idle: true,
+    lockRisk: "low",
+  });
+  expect(first).toMatchObject({
+    deletedRows: 3,
+    heldRows: 1,
+    bounded: true,
+    routingInterrupted: false,
+  });
+  expect(first.physicalBytesBefore).toBeGreaterThan(0);
+  const restarted = sqliteMemory.initializeSqliteMemory({
+    runtimeStateRoot: root,
+    scopeId: "run87",
+    channel: "development",
+  });
+  const second = sqliteMemory.runSqliteRetentionMaintenance({
+    databasePath: restarted.databasePath,
+    nowMs: 100,
+    maxDeleteRows: 10,
+    holdRequestIds: ["request-0"],
+    idle: true,
+    lockRisk: "low",
+  });
+  expect(second.deletedRows).toBe(4);
+  expect(first.reclaimedBytes + second.reclaimedBytes).toBeGreaterThan(0);
+  expect(first.vacuumedPages).toBeLessThanOrEqual(3);
+  expect(second.vacuumedPages).toBeLessThanOrEqual(10);
+  expect(second.physicalBytesAfter).toBeLessThanOrEqual(first.physicalBytesAfter);
+  const verify = new DatabaseSync(restarted.databasePath);
+  const rows = verify
+    .prepare("SELECT request_id FROM runtime_observations ORDER BY request_id")
+    .all();
+  verify.close();
+  expect(rows).toEqual([{ request_id: "request-0" }]);
+  expect(() =>
+    sqliteMemory.runSqliteRetentionMaintenance({
+      databasePath: restarted.databasePath,
+      nowMs: 100,
+      maxDeleteRows: 1,
+      holdRequestIds: [],
+      idle: false,
+      lockRisk: "high",
+    }),
+  ).toThrow(/idle|lock risk/i);
+});

--- a/role-model-router/packages/trace/src/index.ts
+++ b/role-model-router/packages/trace/src/index.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import type { TraceEvent, TraceSpan } from "@role-model/protocol-types";
 
+export * from "./projections/index.js";
+
 export type TraceSpanRecord = TraceSpan;
 export type TraceEventRecord = TraceEvent;
 

--- a/role-model-router/packages/trace/src/projections/index.ts
+++ b/role-model-router/packages/trace/src/projections/index.ts
@@ -31,3 +31,297 @@ export function deriveProjectionReadiness(evidence: ProjectionEvidence): Project
 export function projectionIdentity(evidence: ProjectionEvidence): string {
   return `sha256:${createHash("sha256").update(JSON.stringify(evidence)).digest("hex")}`;
 }
+
+export type ProjectionV2Evidence = {
+  readonly artifactRef: string;
+  readonly sourceHash: string;
+  readonly scope: string;
+  readonly verified: boolean;
+  readonly capabilities: readonly string[];
+  readonly invalidation?: "pruned" | "revoked";
+};
+
+export type ProjectionV2 = {
+  readonly schemaVersion: "role-model.projection.v2";
+  readonly id: string;
+  readonly scope: string;
+  readonly payload: Readonly<Record<string, unknown>>;
+  readonly evidence: readonly ProjectionV2Evidence[];
+  readonly policy: {
+    readonly permittedUse: boolean;
+    readonly purpose: string;
+    readonly authorizationState: "authorized" | "revoked" | "unknown";
+    readonly validUntilMs: number | null;
+    readonly trainingAllowed: boolean;
+    readonly evaluatedAtMs: number;
+  };
+  readonly readiness: {
+    readonly completeness: "complete" | "partial" | "unavailable";
+    readonly evidenceCapability: "token_exact" | "full_replay" | "routing_history" | "unavailable";
+    readonly tokenFidelity: "exact" | "semantic" | "unknown";
+    readonly permittedUse: boolean;
+    readonly rolloutPurpose: string;
+    readonly authorizationState: "authorized" | "revoked" | "unknown";
+    readonly lifecycleReadiness: "ready" | "expired" | "unavailable";
+    readonly routingTrainingSuitability: "eligible" | "ineligible" | "unknown";
+  };
+};
+
+function canonical(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) {
+    if (value.some((item) => item === undefined))
+      throw new Error("projection content must be JSON-safe");
+    return `[${value.map(canonical).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    if (
+      Object.getPrototypeOf(value) !== Object.prototype &&
+      Object.getPrototypeOf(value) !== null
+    ) {
+      throw new Error("projection content must use plain JSON objects");
+    }
+    const record = value as Record<string, unknown>;
+    if (Reflect.ownKeys(record).some((key) => typeof key !== "string")) {
+      throw new Error("projection content must not contain symbol keys");
+    }
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => {
+        if (record[key] === undefined) throw new Error("projection content must be JSON-safe");
+        return `${JSON.stringify(key)}:${canonical(record[key])}`;
+      })
+      .join(",")}}`;
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new Error("projection content must contain finite JSON numbers");
+  }
+  if (["string", "number", "boolean"].includes(typeof value)) return JSON.stringify(value);
+  throw new Error("projection content must be JSON-safe");
+}
+
+function projectionV2Readiness(input: {
+  readonly evidence: readonly ProjectionV2Evidence[];
+  readonly permittedUse: boolean;
+  readonly purpose: string;
+  readonly authorizationState: "authorized" | "revoked" | "unknown";
+  readonly validUntilMs: number | null;
+  readonly trainingAllowed: boolean;
+  readonly evaluatedAtMs: number;
+}) {
+  const usable = input.evidence.filter((row) => row.verified && !row.invalidation);
+  const capabilities = new Set(usable.flatMap((row) => row.capabilities));
+  const evidenceCapability = capabilities.has("token_exact")
+    ? ("token_exact" as const)
+    : capabilities.has("full_replay")
+      ? ("full_replay" as const)
+      : capabilities.has("routing_history")
+        ? ("routing_history" as const)
+        : ("unavailable" as const);
+  const lifecycleReadiness =
+    input.validUntilMs === null
+      ? ("ready" as const)
+      : input.validUntilMs >= input.evaluatedAtMs
+        ? ("ready" as const)
+        : ("expired" as const);
+  const permittedUse =
+    input.permittedUse &&
+    input.authorizationState === "authorized" &&
+    lifecycleReadiness === "ready" &&
+    usable.length > 0 &&
+    !input.evidence.some((row) => row.invalidation === "revoked");
+  const routingTrainingSuitability =
+    input.authorizationState === "unknown"
+      ? ("unknown" as const)
+      : permittedUse && input.trainingAllowed
+        ? ("eligible" as const)
+        : ("ineligible" as const);
+  return {
+    completeness:
+      usable.length === input.evidence.length
+        ? ("complete" as const)
+        : usable.length
+          ? ("partial" as const)
+          : ("unavailable" as const),
+    evidenceCapability,
+    tokenFidelity: capabilities.has("token_exact")
+      ? ("exact" as const)
+      : usable.length
+        ? ("semantic" as const)
+        : ("unknown" as const),
+    permittedUse,
+    rolloutPurpose: input.purpose,
+    authorizationState: input.authorizationState,
+    lifecycleReadiness,
+    routingTrainingSuitability,
+  };
+}
+
+function projectionV2Id(body: Omit<ProjectionV2, "id">): string {
+  return `sha256:${createHash("sha256").update(canonical(body)).digest("hex")}`;
+}
+
+export function createProjectionV2(input: {
+  readonly scope: string;
+  readonly purpose: string;
+  readonly permittedUse: boolean;
+  readonly authorizationState: "authorized" | "revoked" | "unknown";
+  readonly validUntilMs: number | null;
+  readonly trainingAllowed: boolean;
+  readonly evaluatedAtMs: number;
+  readonly evidence: readonly ProjectionV2Evidence[];
+  readonly payload: Readonly<Record<string, unknown>>;
+}): ProjectionV2 {
+  if (!input.scope || !input.purpose || !input.evidence.length) {
+    throw new Error("complete projection scope, purpose, and evidence are required");
+  }
+  const evidence = input.evidence
+    .map((row) => ({ ...row, capabilities: [...new Set(row.capabilities)].sort() }))
+    .sort((left, right) => left.artifactRef.localeCompare(right.artifactRef));
+  for (const row of evidence) {
+    if (row.scope !== input.scope) throw new Error("projection evidence scope mismatch");
+    if (!row.artifactRef || !/^sha256:[a-f0-9]{64}$/u.test(row.sourceHash)) {
+      throw new Error("projection evidence reference and source hash are required");
+    }
+  }
+  if (
+    !Number.isFinite(input.evaluatedAtMs) ||
+    (input.validUntilMs !== null && !Number.isFinite(input.validUntilMs))
+  ) {
+    throw new Error("projection lifecycle timestamps must be finite");
+  }
+  const policy = {
+    permittedUse: input.permittedUse,
+    purpose: input.purpose,
+    authorizationState: input.authorizationState,
+    validUntilMs: input.validUntilMs,
+    trainingAllowed: input.trainingAllowed,
+    evaluatedAtMs: input.evaluatedAtMs,
+  } as const;
+  const body = {
+    schemaVersion: "role-model.projection.v2" as const,
+    scope: input.scope,
+    payload: structuredClone(input.payload),
+    evidence,
+    policy,
+    readiness: projectionV2Readiness({
+      evidence,
+      permittedUse: input.permittedUse,
+      purpose: input.purpose,
+      authorizationState: input.authorizationState,
+      validUntilMs: input.validUntilMs,
+      trainingAllowed: input.trainingAllowed,
+      evaluatedAtMs: input.evaluatedAtMs,
+    }),
+  };
+  return {
+    ...body,
+    id: projectionV2Id(body),
+  };
+}
+
+export function validateProjectionV2(
+  value: unknown,
+  options: { readonly nowMs?: number } = {},
+): ProjectionV2 {
+  if (!value || typeof value !== "object") throw new Error("projection v2 is required");
+  const projection = value as ProjectionV2;
+  if (projection.schemaVersion !== "role-model.projection.v2") {
+    throw new Error("unsupported projection schema version");
+  }
+  if (
+    !projection.id ||
+    !projection.scope ||
+    !projection.readiness ||
+    !projection.policy ||
+    !Array.isArray(projection.evidence)
+  ) {
+    throw new Error("projection v2 is incomplete");
+  }
+  if (projection.evidence.some((row) => row.scope !== projection.scope)) {
+    throw new Error("projection evidence scope mismatch");
+  }
+  if (
+    projection.evidence.some(
+      (row) =>
+        !row.artifactRef ||
+        !/^sha256:[a-f0-9]{64}$/u.test(row.sourceHash) ||
+        typeof row.verified !== "boolean" ||
+        !Array.isArray(row.capabilities) ||
+        row.capabilities.some(
+          (capability: string) =>
+            !["routing_history", "full_replay", "token_exact"].includes(capability),
+        ) ||
+        (row.invalidation !== undefined && !["pruned", "revoked"].includes(row.invalidation)),
+    )
+  ) {
+    throw new Error("projection evidence is malformed");
+  }
+  if (
+    !projection.evidence.length ||
+    new Set(projection.evidence.map((row) => row.artifactRef)).size !==
+      projection.evidence.length ||
+    typeof projection.policy.permittedUse !== "boolean" ||
+    typeof projection.policy.purpose !== "string" ||
+    !projection.policy.purpose ||
+    !["authorized", "revoked", "unknown"].includes(projection.policy.authorizationState) ||
+    typeof projection.policy.trainingAllowed !== "boolean" ||
+    !Number.isFinite(projection.policy.evaluatedAtMs) ||
+    (projection.policy.validUntilMs !== null && !Number.isFinite(projection.policy.validUntilMs))
+  ) {
+    throw new Error("projection policy and unique evidence are required");
+  }
+  canonical(projection.payload);
+  const expectedReadiness = projectionV2Readiness({
+    evidence: projection.evidence,
+    permittedUse: projection.policy.permittedUse,
+    purpose: projection.policy.purpose,
+    authorizationState: projection.policy.authorizationState,
+    validUntilMs: projection.policy.validUntilMs,
+    trainingAllowed: projection.policy.trainingAllowed,
+    evaluatedAtMs: projection.policy.evaluatedAtMs,
+  });
+  if (canonical(projection.readiness) !== canonical(expectedReadiness)) {
+    throw new Error("projection readiness does not match authoritative evidence and policy");
+  }
+  const { id, ...body } = projection;
+  if (projectionV2Id(body) !== id)
+    throw new Error("projection identity does not match its content");
+  const nowMs = options.nowMs ?? Date.now();
+  if (!Number.isFinite(nowMs)) throw new Error("projection validation time must be finite");
+  if (projection.policy.validUntilMs !== null && nowMs > projection.policy.validUntilMs) {
+    throw new Error("projection lifecycle expired before consumption");
+  }
+  return structuredClone(projection);
+}
+
+export function downgradeProjectionV2(
+  value: ProjectionV2,
+  input: { readonly artifactRef: string; readonly reason: "pruned" | "revoked" },
+): ProjectionV2 {
+  const projection = validateProjectionV2(value, { nowMs: value.policy.evaluatedAtMs });
+  if (!projection.evidence.some((row) => row.artifactRef === input.artifactRef)) {
+    throw new Error("projection invalidation evidence reference is missing");
+  }
+  const evidence = projection.evidence.map((row) =>
+    row.artifactRef === input.artifactRef ? { ...row, invalidation: input.reason } : row,
+  );
+  const { id: _priorId, ...priorBody } = projection;
+  const body = {
+    ...priorBody,
+    evidence,
+    readiness: projectionV2Readiness({
+      evidence,
+      permittedUse: projection.policy.permittedUse,
+      purpose: projection.policy.purpose,
+      authorizationState: projection.policy.authorizationState,
+      validUntilMs: projection.policy.validUntilMs,
+      trainingAllowed: projection.policy.trainingAllowed,
+      evaluatedAtMs: projection.policy.evaluatedAtMs,
+    }),
+  };
+  return {
+    ...body,
+    id: projectionV2Id(body),
+  };
+}

--- a/role-model-router/packages/trace/test/recursive-87-projections.test.ts
+++ b/role-model-router/packages/trace/test/recursive-87-projections.test.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto";
+
+import { expect, test } from "vitest";
+
+import * as projections from "../src/projections/index.js";
+
+const evidence = [
+  {
+    artifactRef: "sha256:semantic",
+    sourceHash: `sha256:${"a".repeat(64)}`,
+    scope: "tenant:run87",
+    verified: true,
+    capabilities: ["routing_history", "full_replay"],
+  },
+  {
+    artifactRef: "sha256:tokens",
+    sourceHash: `sha256:${"b".repeat(64)}`,
+    scope: "tenant:run87",
+    verified: true,
+    capabilities: ["token_exact"],
+  },
+];
+
+test("SP4 creates deterministic v2 projections with independent readiness axes", () => {
+  expect(typeof projections.createProjectionV2).toBe("function");
+  const input = {
+    scope: "tenant:run87",
+    purpose: "routing_shadow",
+    permittedUse: true,
+    authorizationState: "authorized",
+    validUntilMs: 20_000,
+    trainingAllowed: true,
+    evaluatedAtMs: 10_000,
+    evidence,
+    payload: { decision: "endpoint-a", score: 1 },
+  } as const;
+  const left = projections.createProjectionV2(input);
+  const right = projections.createProjectionV2({ ...input, evidence: [...evidence].reverse() });
+  expect(left).toEqual(right);
+  expect(left).toMatchObject({
+    schemaVersion: "role-model.projection.v2",
+    scope: "tenant:run87",
+    readiness: {
+      completeness: "complete",
+      evidenceCapability: "token_exact",
+      tokenFidelity: "exact",
+      permittedUse: true,
+      rolloutPurpose: "routing_shadow",
+      authorizationState: "authorized",
+      lifecycleReadiness: "ready",
+      routingTrainingSuitability: "eligible",
+    },
+  });
+
+  const tokenPruned = projections.downgradeProjectionV2(left, {
+    artifactRef: "sha256:tokens",
+    reason: "pruned",
+  });
+  expect(tokenPruned.readiness).toEqual({
+    completeness: "partial",
+    evidenceCapability: "full_replay",
+    tokenFidelity: "semantic",
+    permittedUse: true,
+    rolloutPurpose: "routing_shadow",
+    authorizationState: "authorized",
+    lifecycleReadiness: "ready",
+    routingTrainingSuitability: "eligible",
+  });
+  const revoked = projections.downgradeProjectionV2(tokenPruned, {
+    artifactRef: "sha256:semantic",
+    reason: "revoked",
+  });
+  expect(revoked.readiness).toMatchObject({
+    completeness: "unavailable",
+    evidenceCapability: "unavailable",
+    tokenFidelity: "unknown",
+    permittedUse: false,
+    rolloutPurpose: "routing_shadow",
+  });
+});
+
+test("SP4 rejects malformed, cross-scope, and unsupported future projection inputs", () => {
+  expect(() =>
+    projections.createProjectionV2({
+      scope: "tenant:run87",
+      purpose: "evaluation",
+      permittedUse: true,
+      authorizationState: "authorized",
+      validUntilMs: null,
+      trainingAllowed: true,
+      evaluatedAtMs: 10_000,
+      evidence: [{ ...evidence[0], scope: "tenant:other" }],
+      payload: {},
+    }),
+  ).toThrow(/scope/i);
+  expect(() =>
+    projections.validateProjectionV2({ schemaVersion: "role-model.projection.v3" }),
+  ).toThrow(/unsupported projection schema/i);
+});
+
+test("Phase 3.5 rejects caller-forged readiness even when the attacker recomputes the content ID", () => {
+  const projection = projections.createProjectionV2({
+    scope: "tenant:run87",
+    purpose: "routing_shadow",
+    permittedUse: true,
+    authorizationState: "authorized",
+    validUntilMs: null,
+    trainingAllowed: true,
+    evaluatedAtMs: 10_000,
+    evidence,
+    payload: { decision: "endpoint-a" },
+  });
+  const forgedBody = {
+    ...projection,
+    evidence: projection.evidence.map((row) => ({ ...row, invalidation: "revoked" as const })),
+    readiness: { ...projection.readiness, permittedUse: true },
+  };
+  const canonical = (value: unknown): string => {
+    if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+    if (value && typeof value === "object") {
+      const record = value as Record<string, unknown>;
+      return `{${Object.keys(record)
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`)
+        .join(",")}}`;
+    }
+    return JSON.stringify(value);
+  };
+  const { id: _oldId, ...body } = forgedBody;
+  const forged = {
+    ...body,
+    id: `sha256:${createHash("sha256").update(canonical(body)).digest("hex")}`,
+  };
+  expect(() => projections.validateProjectionV2(forged)).toThrow(/readiness|policy/i);
+  expect(() =>
+    projections.createProjectionV2({
+      scope: "tenant:run87",
+      purpose: "routing_shadow",
+      permittedUse: true,
+      authorizationState: "authorized",
+      validUntilMs: null,
+      trainingAllowed: true,
+      evaluatedAtMs: 10_000,
+      evidence,
+      payload: { ambiguous: [undefined] },
+    }),
+  ).toThrow(/json|undefined|payload/i);
+});
+
+test("Phase 3.5 derives authorization, expiry, and routing-training suitability independently", () => {
+  const make = (overrides: Partial<Parameters<typeof projections.createProjectionV2>[0]>) =>
+    projections.createProjectionV2({
+      scope: "tenant:run87",
+      purpose: "routing_shadow",
+      permittedUse: true,
+      authorizationState: "authorized",
+      validUntilMs: 20_000,
+      trainingAllowed: true,
+      evaluatedAtMs: 10_000,
+      evidence,
+      payload: {},
+      ...overrides,
+    });
+  expect(make({ authorizationState: "revoked" }).readiness).toMatchObject({
+    authorizationState: "revoked",
+    lifecycleReadiness: "ready",
+    routingTrainingSuitability: "ineligible",
+    permittedUse: false,
+  });
+  expect(make({ validUntilMs: 9_999 }).readiness).toMatchObject({
+    authorizationState: "authorized",
+    lifecycleReadiness: "expired",
+    routingTrainingSuitability: "ineligible",
+    permittedUse: false,
+  });
+  expect(make({ trainingAllowed: false }).readiness).toMatchObject({
+    authorizationState: "authorized",
+    lifecycleReadiness: "ready",
+    routingTrainingSuitability: "ineligible",
+    permittedUse: true,
+  });
+});
+
+test("Phase 3.5 rejects a projection that expires after its original evaluation", () => {
+  const projection = projections.createProjectionV2({
+    scope: "tenant:run87",
+    purpose: "routing_shadow",
+    permittedUse: true,
+    authorizationState: "authorized",
+    validUntilMs: 11_000,
+    trainingAllowed: true,
+    evaluatedAtMs: 10_000,
+    evidence,
+    payload: { decision: "endpoint-a" },
+  });
+  expect(projection.readiness.lifecycleReadiness).toBe("ready");
+  expect(() => projections.validateProjectionV2(projection, { nowMs: 11_001 })).toThrow(
+    /expired|lifecycle|valid/i,
+  );
+});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -46,6 +46,14 @@ test("Track B CI is always-on, explicit, and runs the tagged browser contract", 
     publicBuild < trackBJob.indexOf("corepack pnpm build:run00-runtime"),
     "the public workspace must be built before private paired tests import public dist files",
   );
+  for (const required of [
+    "run87-recommendation-fixture-server.mjs",
+    "--qa-extension-manifest",
+    "--fixture-root",
+    "--recommendation-material-file",
+  ]) {
+    assert.match(trackBJob, new RegExp(required.replaceAll("-", "\\-")), `paired browser gate missing ${required}`);
+  }
 });
 
 test("promotion guard encodes dev to stage to main with a hotfix exception", () => {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -24,9 +24,21 @@ test("CI is scoped to long-lived branches with stable cancellable lanes", () => 
     "runtime-router",
     "rust",
     "smoke",
+    "track-b-runtime",
   ]) {
     assert.match(workflow, new RegExp(`^  ${job}:`, "m"));
   }
+});
+
+test("Track B CI is always-on, explicit, and runs the tagged browser contract", () => {
+  assert.match(workflow, /^ {2}track-b-runtime:/m);
+  assert.doesNotMatch(workflow, /track-b-runtime:[\s\S]*?if:\s*\$\{\{\s*false\s*\}\}/);
+  assert.match(workflow, /recursive-87-ci-contract\.test\.ts/);
+  assert.match(workflow, /@recursive:87-direct-track-b-semantic-completion/);
+  assert.match(workflow, /playwright install --with-deps chromium/);
+  assert.match(workflow, /repository:\s*try-works\/role-model-internal/);
+  assert.match(workflow, /PRIVATE_PAIRED_SHA/);
+  assert.match(workflow, /ROLE_MODEL_PUBLIC_WORKTREE/);
 });
 
 test("promotion guard encodes dev to stage to main with a hotfix exception", () => {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -39,6 +39,13 @@ test("Track B CI is always-on, explicit, and runs the tagged browser contract", 
   assert.match(workflow, /repository:\s*try-works\/role-model-internal/);
   assert.match(workflow, /PRIVATE_PAIRED_SHA/);
   assert.match(workflow, /ROLE_MODEL_PUBLIC_WORKTREE/);
+  const trackBJob = workflow.slice(workflow.indexOf("  track-b-runtime:"));
+  const publicBuild = trackBJob.indexOf("run: pnpm run build");
+  assert.notEqual(publicBuild, -1, "the paired Track B job must build the public workspace");
+  assert.ok(
+    publicBuild < trackBJob.indexOf("corepack pnpm build:run00-runtime"),
+    "the public workspace must be built before private paired tests import public dist files",
+  );
 });
 
 test("promotion guard encodes dev to stage to main with a hotfix exception", () => {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -52,7 +52,11 @@ test("Track B CI is always-on, explicit, and runs the tagged browser contract", 
     "--fixture-root",
     "--recommendation-material-file",
   ]) {
-    assert.match(trackBJob, new RegExp(required.replaceAll("-", "\\-")), `paired browser gate missing ${required}`);
+    assert.match(
+      trackBJob,
+      new RegExp(required.replaceAll("-", "\\-")),
+      `paired browser gate missing ${required}`,
+    );
   }
 });
 


### PR DESCRIPTION
## What changed

- Completes the public runtime-host, UI, SQLite-memory, trace/projection, CI, compatibility, and packaged-runtime side of Direct Track B v1.1.
- Adds registry-driven extension lifecycle support, graph-primary migration, bounded history, projection consumers, retention visibility, and full shadow-pipeline coverage.
- Keeps Knowledge Worker production activation and prompt injection unavailable at the v1.1 shadow-only boundary.

## Why

Run 87 reconciles the crowdsourced-evals proposal against executable behavior and closes gaps where earlier manifests, helpers, or historical receipts did not prove the current runtime semantics.

## Impact

The public runtime now exposes truthful extension, storage, migration, retention, and projection behavior while preserving N/N-1 compatibility and privacy boundaries.

## Validation

- Public CI/check suite passed against the paired private implementation.
- Unit, integration, regression, compatibility, Playwright, packaged SEA, restart, migration, retention, and privacy verification passed.
- Phase 5 manual QA: 29/29 scenarios PASS.
