### PR TITLE
feat: prepare Run 88 stage release candidate

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -12,6 +12,14 @@ on:
           - development
           - stage
           - production
+      private_sha:
+        description: Exact private role-model-internal commit embedded in a stage candidate
+        required: false
+        type: string
+      release_id:
+        description: Exact sha256-prefixed Run 88 candidate identity to bind into a stage package
+        required: false
+        type: string
   push:
     branches:
       - stage
@@ -21,6 +29,8 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROLE_MODEL_BUILD_CHANNEL: ${{ github.ref_type == 'tag' && 'production' || (github.ref_name == 'stage' && 'stage' || inputs.channel || 'development') }}
+  PRIVATE_PAIRED_SHA: ${{ inputs.private_sha || vars.ROLE_MODEL_PAIRED_PRIVATE_SHA }}
+  RUN88_RELEASE_ID: ${{ inputs.release_id || vars.RUN88_RELEASE_ID }}
 
 concurrency:
   group: runtime-build-${{ github.ref }}-${{ inputs.channel || 'automatic' }}
@@ -51,6 +61,25 @@ jobs:
             target: win32-x64
 
     steps:
+      - name: Validate Run 88 stage identity inputs
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+        shell: bash
+        env:
+          PUBLIC_PAIRED_SHA: ${{ github.sha }}
+        run: |
+          if [[ ! "$PUBLIC_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Stage public revision must be an exact 40-character commit."
+            exit 1
+          fi
+          if [[ ! "$PRIVATE_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Stage private revision must be an exact 40-character commit."
+            exit 1
+          fi
+          if [[ ! "$RUN88_RELEASE_ID" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "RUN88_RELEASE_ID must be an exact sha256-prefixed candidate identity."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
@@ -79,8 +108,43 @@ jobs:
       - name: Build UI
         run: pnpm --filter @role-model-router/runtime-ui run build
 
+      - name: Validate exact private stage revision
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+        shell: bash
+        run: |
+          if [[ ! "$PRIVATE_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ROLE_MODEL_PAIRED_PRIVATE_SHA (or private_sha) must be an exact 40-character commit."
+            exit 1
+          fi
+
+      - name: Checkout exact private stage revision
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+        uses: actions/checkout@v4
+        with:
+          repository: try-works/role-model-internal
+          ref: ${{ env.PRIVATE_PAIRED_SHA }}
+          token: ${{ secrets.ROLE_MODEL_INTERNAL_READ_TOKEN }}
+          path: _private
+
+      - name: Build exact private stage distribution
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+        working-directory: _private
+        env:
+          ROLE_MODEL_PUBLIC_WORKTREE: ${{ github.workspace }}
+          NODE_OPTIONS: --conditions=runtime
+        run: |
+          corepack pnpm install --frozen-lockfile
+          corepack pnpm build:run00-runtime
+
       - name: Package SEA runtime
+        env:
+          ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT: ${{ env.ROLE_MODEL_BUILD_CHANNEL == 'stage' && format('{0}/_private/dist/run00-dev', github.workspace) || '' }}
         run: pnpm run runtime:package-sea
+
+      - name: Bind canonical Run 88 identity into stage package
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+        shell: pwsh
+        run: node scripts/run88-stage-release.mjs --manifest "${{ github.workspace }}/role-model-router/dist/release/${{ matrix.target }}/manifest.json" --release-id "$env:RUN88_RELEASE_ID"
 
       - name: Verify channel manifest identity
         id: runtime_identity
@@ -102,6 +166,15 @@ jobs:
           if ($manifest.name -ne $expectedName) {
             throw "Manifest name '$($manifest.name)' does not match '$expectedName'"
           }
+          if ($env:ROLE_MODEL_BUILD_CHANNEL -eq "stage") {
+            if (-not $manifest.track_b_runtime.manifest_sha256) { throw "Missing stage private_distribution_sha256" }
+            if ($manifest.track_b_runtime.compatibility_generation -notin @("N", "N-1")) { throw "Invalid stage private distribution generation" }
+            "private_distribution_sha256=$($manifest.track_b_runtime.manifest_sha256)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            if ($manifest.release_id -ne $env:RUN88_RELEASE_ID) { throw "Stage manifest release_id mismatch" }
+            if ($manifest.private_distribution_sha256 -ne $manifest.track_b_runtime.manifest_sha256) { throw "Stage manifest private distribution binding mismatch" }
+          }
+          $manifestSha256 = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          "manifest_sha256=$manifestSha256" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "source_tree=$($manifest.source_tree)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "core_payload_sha256=$($manifest.core_payload_sha256)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
+      - name: Validate Run 88 stage release identity contract
+        run: node --test scripts/run88-stage-release.test.mjs scripts/run88-stage-release-workflow.test.mjs
       - run: pnpm run test
 
   runtime-critical:

--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import os from "node:os";
@@ -15,15 +16,19 @@ import {
   resolveBridgeServerOptions,
   startBridgeServer,
 } from "./index.js";
+import { validateRun88PrivateDistributionIdentity } from "./kw-private-loader.js";
 import { readPackagedRuntimeProfile } from "./runtime-channel.js";
 import { migrateLegacyProductionState } from "./runtime-state-migration.js";
+import { validateRun88PackagedStageIdentity } from "./runtime-version.js";
 import {
   createOwnedTrackBSidecarSpec,
   createPackagedProductionRuntime,
   createProductionExtensionRuntime,
+  createRun88RuntimeCorrelation,
   createTrackBPostObservationOutbox,
   runTrackBPostObservation,
   trackBDistributionRequiresSQLiteMaintenance,
+  validateRun88ProviderResponseObservation,
 } from "./track-b-runtime.js";
 
 type CliBackend = Pick<
@@ -130,6 +135,80 @@ type CliBackend = Pick<
   | "getEffectiveRoutableInventory"
   | "shutdown"
 >;
+
+type Run88PiInvocationProvenance = Readonly<{
+  source: "routed-execution-callback";
+  piInvocationProof: Readonly<Record<string, unknown>>;
+  trustedAuthorityPublicKey: string;
+  expectedReleaseId: string;
+}>;
+
+function readRun88PiInvocationProvenance(
+  env: NodeJS.ProcessEnv,
+  expectedReleaseId: string | undefined,
+): Run88PiInvocationProvenance | null {
+  const proofPath = env.RUN88_PI_INVOCATION_PROOF_PATH;
+  const authorityPath = env.RUN88_PI_PROOF_AUTHORITY_PUBLIC_KEY_PATH;
+  if (!proofPath && !authorityPath) return null;
+  if (
+    !proofPath ||
+    !authorityPath ||
+    !path.isAbsolute(proofPath) ||
+    !path.isAbsolute(authorityPath)
+  )
+    throw new Error("Run 88 Pi proof and authority paths must both be absolute");
+  if (!/^sha256:[0-9a-f]{64}$/.test(expectedReleaseId ?? ""))
+    throw new Error("Run 88 Pi proof requires the packaged release identity");
+  let piInvocationProof: Readonly<Record<string, unknown>>;
+  try {
+    piInvocationProof = JSON.parse(readFileSync(proofPath, "utf8")) as Readonly<
+      Record<string, unknown>
+    >;
+  } catch {
+    throw new Error("Run 88 Pi invocation proof file is unreadable or malformed");
+  }
+  const trustedAuthorityPublicKey = readFileSync(authorityPath, "utf8").trim();
+  if (!trustedAuthorityPublicKey) throw new Error("Run 88 Pi proof authority public key is empty");
+  return Object.freeze({
+    source: "routed-execution-callback",
+    piInvocationProof,
+    trustedAuthorityPublicKey,
+    expectedReleaseId: expectedReleaseId as string,
+  });
+}
+
+export function createRun88StagePostObservation(input: {
+  readonly observation: Readonly<Record<string, unknown>>;
+  readonly piInvocationProvenance: Run88PiInvocationProvenance | null;
+  readonly proofRequired: boolean;
+  readonly releaseId: string;
+  readonly sourceId: string;
+  readonly executableSha256: string;
+  readonly scope: string;
+}): Readonly<Record<string, unknown>> {
+  if (input.proofRequired && !input.piInvocationProvenance)
+    throw new Error("Run 88 Phase 5 provider observation requires signed Pi CLI provenance");
+  return Object.freeze({
+    ...input.observation,
+    ...(input.piInvocationProvenance
+      ? {
+          run88ProviderResponse: validateRun88ProviderResponseObservation(
+            input.observation,
+            input.piInvocationProvenance,
+          ),
+        }
+      : {}),
+    run88Correlation: createRun88RuntimeCorrelation({
+      requestId: String(input.observation.requestId ?? ""),
+      routingDecisionId: String(input.observation.routingDecisionId ?? ""),
+      endpointId: String(input.observation.endpointId ?? ""),
+      releaseId: input.releaseId,
+      sourceId: input.sourceId,
+      deploymentId: `local-stage:${input.executableSha256}`,
+      scope: input.scope,
+    }),
+  });
+}
 
 interface CliBootstrapState {
   status: "pending" | "ready" | "failed";
@@ -679,6 +758,22 @@ export async function main(): Promise<void> {
     unifiedRuntimeConfigPath: args.values["unified-runtime-config"],
   });
   const packagedProfile = readPackagedRuntimeProfile(process.execPath);
+  const packagedManifestRecord = packagedProfile
+    ? (JSON.parse(
+        readFileSync(path.join(path.dirname(process.execPath), "manifest.json"), "utf8"),
+      ) as Record<string, unknown>)
+    : null;
+  const packagedReleaseId =
+    typeof packagedManifestRecord?.release_id === "string"
+      ? packagedManifestRecord.release_id
+      : undefined;
+  const loadRun88PiInvocationProvenance =
+    packagedProfile?.channel === "stage"
+      ? () => readRun88PiInvocationProvenance(process.env, packagedReleaseId)
+      : null;
+  if (packagedProfile?.channel === "stage") {
+    validateRun88PackagedStageIdentity(packagedManifestRecord ?? {});
+  }
   if (packagedProfile?.channel === "production" && !args.values["runtime-state-root"]) {
     const migration = await migrateLegacyProductionState({
       legacyRoot: path.join(process.env.LOCALAPPDATA || os.tmpdir(), "Role Model Runtime"),
@@ -827,6 +922,12 @@ export async function main(): Promise<void> {
           scope: options.scopeId,
           channel: packagedProfile?.channel ?? "development",
           authorizationEpoch: 1,
+          ...(packagedReleaseId
+            ? {
+                expectedReleaseId: packagedReleaseId,
+                run88Correlation: observation.run88Correlation as Record<string, unknown>,
+              }
+            : {}),
         }),
       );
     const createBackend = async (
@@ -875,7 +976,23 @@ export async function main(): Promise<void> {
         ...(trackBManifestText
           ? {
               trackBPostObservation: async (observation: Readonly<Record<string, unknown>>) => {
-                await postObservationOutbox.enqueue(observation);
+                const run88PiInvocationProvenance = loadRun88PiInvocationProvenance?.() ?? null;
+                const correlatedObservation =
+                  packagedProfile?.channel === "stage"
+                    ? createRun88StagePostObservation({
+                        observation,
+                        piInvocationProvenance: run88PiInvocationProvenance,
+                        proofRequired: Boolean(
+                          process.env.RUN88_PI_INVOCATION_PROOF_PATH ||
+                            process.env.RUN88_PI_PROOF_AUTHORITY_PUBLIC_KEY_PATH,
+                        ),
+                        releaseId: String(packagedManifestRecord?.release_id ?? ""),
+                        sourceId: String(packagedManifestRecord?.source_tree ?? ""),
+                        executableSha256: String(packagedManifestRecord?.executable_sha256 ?? ""),
+                        scope: options.scopeId,
+                      })
+                    : observation;
+                await postObservationOutbox.enqueue(correlatedObservation);
                 const runtime = extensionRuntimeRef.current;
                 if (!runtime) return { status: "queued_for_extension_runtime" };
                 await drainPostObservationOutbox(runtime);
@@ -936,6 +1053,21 @@ export async function main(): Promise<void> {
         throw new Error("v2 Track B distribution is missing its public runtime adapter");
       }
       const distributionRoot = path.dirname(trackBManifestPath);
+      if (packagedReleaseId) {
+        validateRun88PrivateDistributionIdentity(
+          {
+            generation:
+              manifest.schemaVersion === "role-model.track-b-runtime-distribution.v2" ? "N" : "N-1",
+            manifestSha256: createHash("sha256").update(trackBManifestText).digest("hex"),
+            channel: packagedProfile?.channel ?? "development",
+          },
+          {
+            channel: "stage",
+            manifestSha256: String(packagedManifestRecord?.private_distribution_sha256 ?? ""),
+            publicGeneration: "N",
+          },
+        );
+      }
       const trackBStateRoot = path.join(options.runtimeStateRoot, options.scopeId, "track-b");
       // Start extension-host registration in parallel with sidecar/backend bring-up, but
       // mark core APIs ready as soon as the packaged backend exists. Waiting on all

--- a/role-model-router/apps/runtime-host-bridge/src/kw-private-loader.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/kw-private-loader.ts
@@ -22,6 +22,37 @@ export type PrivateKnowledgeWorkerModule = {
   };
 };
 
+export interface Run88PrivateDistributionIdentity {
+  readonly generation: "N" | "N-1" | string;
+  readonly manifestSha256: string;
+  readonly channel: string;
+}
+
+export function validateRun88PrivateDistributionIdentity(
+  identity: Run88PrivateDistributionIdentity | null,
+  expected: {
+    readonly channel: "stage";
+    readonly manifestSha256: string;
+    readonly publicGeneration: "N";
+  },
+) {
+  if (!identity) {
+    return { available: false, compatible: false, degradation: "public-routing-only" } as const;
+  }
+  if (identity.channel !== expected.channel)
+    throw new Error("private distribution channel mismatch");
+  if (
+    !/^[a-f0-9]{64}$/.test(identity.manifestSha256) ||
+    identity.manifestSha256 !== expected.manifestSha256
+  ) {
+    throw new Error("private distribution manifest identity mismatch");
+  }
+  if (expected.publicGeneration !== "N" || !new Set(["N", "N-1"]).has(identity.generation)) {
+    throw new Error("private distribution generation is incompatible");
+  }
+  return { available: true, compatible: true, generation: identity.generation } as const;
+}
+
 export function resolvePrivateKnowledgeWorkerModulePath(
   distributionRoot?: string,
 ): string | undefined {

--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -598,6 +598,13 @@ export async function packageSeaRuntime(): Promise<{
     throw new Error("Unable to resolve source_tree for packaged runtime");
   }
   const sourceTree = sourceTreeResult.stdout.trim();
+  const run88ReleaseId = process.env.RUN88_RELEASE_ID?.trim();
+  if (
+    profile.channel === "stage" &&
+    (!/^sha256:[0-9a-f]{64}$/.test(run88ReleaseId ?? "") || !trackBRuntime)
+  ) {
+    throw new Error("Stage packaging requires an exact RUN88_RELEASE_ID and private distribution");
+  }
   await writeFile(
     path.join(releaseDir, "manifest.json"),
     JSON.stringify(
@@ -615,11 +622,19 @@ export async function packageSeaRuntime(): Promise<{
         build_date: versionInfo.build_date,
         ...profile,
         endpoint: `http://${profile.host}:${profile.port}`,
+        ...(profile.channel === "stage"
+          ? {
+              release_id: run88ReleaseId,
+              private_distribution_sha256: trackBRuntime?.manifestSha256,
+            }
+          : {}),
         track_b_runtime: trackBRuntime
           ? {
               manifest: "track-b-runtime/track-b-runtime-manifest.json",
               sidecar: path.relative(releaseDir, trackBRuntime.sidecarPath).replaceAll("\\", "/"),
               sidecar_sha256: trackBRuntime.sidecarSha256,
+              manifest_sha256: trackBRuntime.manifestSha256,
+              compatibility_generation: trackBRuntime.compatibilityGeneration,
               extension_count: trackBRuntime.extensionCount,
             }
           : null,

--- a/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts
@@ -15,6 +15,8 @@ export interface RuntimeVersionInfoRecord {
   readonly source_tree?: string;
   readonly executable_sha256?: string;
   readonly core_payload_sha256?: string;
+  readonly release_id?: string;
+  readonly private_distribution_sha256?: string;
 }
 
 interface RuntimeVersionManifest {
@@ -27,6 +29,8 @@ interface RuntimeVersionManifest {
   readonly source_tree?: unknown;
   readonly executable_sha256?: unknown;
   readonly core_payload_sha256?: unknown;
+  readonly release_id?: unknown;
+  readonly private_distribution_sha256?: unknown;
 }
 
 function readManifestIdentity(
@@ -39,6 +43,8 @@ function readManifestIdentity(
     "source_tree",
     "executable_sha256",
     "core_payload_sha256",
+    "release_id",
+    "private_distribution_sha256",
   ] as const;
   return Object.fromEntries(
     fields.flatMap((field) => {
@@ -57,6 +63,38 @@ export interface ResolveRuntimeVersionInfoOptions {
 
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function validateRun88PackagedStageIdentity(
+  manifest: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+  if (manifest.channel !== "stage")
+    throw new Error("Run 88 packaged stage identity requires the stage channel");
+  if (
+    manifest.name !== "role-model-stage" ||
+    manifest.host !== "127.0.0.1" ||
+    manifest.port !== 3457 ||
+    manifest.endpoint !== "http://127.0.0.1:3457" ||
+    manifest.state_root_name !== "role-model-runtime-stage" ||
+    manifest.scope_id !== "standalone-runtime-stage"
+  )
+    throw new Error("Run 88 stage package endpoint, state root, scope, name, or port is invalid");
+  if (!/^sha256:[0-9a-f]{64}$/.test(String(manifest.release_id ?? "")))
+    throw new Error("Run 88 stage release identity is missing or invalid");
+  for (const field of [
+    "private_distribution_sha256",
+    "executable_sha256",
+    "core_payload_sha256",
+  ] as const) {
+    if (!/^[0-9a-f]{64}$/.test(String(manifest[field] ?? "")))
+      throw new Error(`Run 88 stage ${field} is missing or invalid`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(String(manifest.source_tree ?? "")))
+    throw new Error("Run 88 stage source tree identity is missing or invalid");
+  const trackB = manifest.track_b_runtime as Record<string, unknown> | null | undefined;
+  if (!trackB || trackB.manifest_sha256 !== manifest.private_distribution_sha256)
+    throw new Error("Run 88 stage private distribution identity mismatch");
+  return Object.freeze({ ...manifest });
 }
 
 function normalizeTaggedVersion(value: string | null | undefined): string | null {

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, verify as verifySignature } from "node:crypto";
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -18,6 +18,26 @@ import {
 import { createProjectionV2 } from "@role-model-router/trace";
 
 import { consumeTrackBProjection } from "./track-b-projections.js";
+
+const RUN88_PI_PROOF_VALIDITY_MS = 90 * 60 * 1000;
+const isSuppressedRun88Capture = (value: unknown): boolean =>
+  Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      (value as Record<string, unknown>).suppressed === true,
+  );
+
+function canonicalizeRun88Proof(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeRun88Proof);
+  if (value && typeof value === "object")
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => [key, canonicalizeRun88Proof((value as Record<string, unknown>)[key])]),
+    );
+  return value;
+}
 
 export { consumeTrackBProjection } from "./track-b-projections.js";
 
@@ -254,12 +274,292 @@ export function createTrackBBridgeServerOptions<
   ) as Pick<Backend, (typeof trackBServerOperationNames)[number]>;
 }
 
+const run88CorrelationFields = new Set([
+  "schemaVersion",
+  "eventId",
+  "correlationId",
+  "traceId",
+  "spanId",
+  "causalParentId",
+  "service",
+  "operation",
+  "runtimeChannel",
+  "scopeHash",
+  "cohort",
+  "releaseId",
+  "sourceId",
+  "deploymentId",
+  "attempt",
+  "outcome",
+  "timestamp",
+  "durationMs",
+]);
+
+export function normalizeRun88RuntimeCorrelation(
+  value: Record<string, unknown>,
+  expectedReleaseId: string,
+): Record<string, unknown> {
+  if (!value || value.schemaVersion !== "run88-correlation.v1")
+    throw new Error("unsupported Run 88 correlation schema");
+  for (const field of Object.keys(value)) {
+    if (!run88CorrelationFields.has(field))
+      throw new Error(`unknown Run 88 correlation field ${field}`);
+  }
+  if (value.releaseId !== expectedReleaseId)
+    throw new Error("Run 88 correlation release identity mismatch");
+  if (value.runtimeChannel !== "staging")
+    throw new Error("Run 88 correlation requires staging runtime channel");
+  for (const field of [
+    "eventId",
+    "correlationId",
+    "causalParentId",
+    "service",
+    "operation",
+    "cohort",
+    "sourceId",
+    "deploymentId",
+    "outcome",
+  ] as const) {
+    if (typeof value[field] !== "string" || !String(value[field]).trim())
+      throw new Error(`Run 88 correlation ${field} is incomplete`);
+  }
+  if (
+    !/^sha256:[a-f0-9]{64}$/.test(String(value.scopeHash)) ||
+    !/^sha256:[a-f0-9]{64}$/.test(String(value.releaseId))
+  ) {
+    throw new Error("Run 88 correlation scopeHash or releaseId is invalid");
+  }
+  if (
+    !/^[a-f0-9]{32}$/.test(String(value.traceId)) ||
+    !/^[a-f0-9]{16}$/.test(String(value.spanId))
+  ) {
+    throw new Error("Run 88 correlation identity is incomplete");
+  }
+  if (!Number.isSafeInteger(value.attempt) || Number(value.attempt) < 1)
+    throw new Error("Run 88 correlation attempt is invalid");
+  if (!Number.isFinite(value.durationMs) || Number(value.durationMs) < 0)
+    throw new Error("Run 88 correlation durationMs is invalid");
+  if (
+    typeof value.timestamp !== "string" ||
+    new Date(value.timestamp).toISOString() !== value.timestamp
+  )
+    throw new Error("Run 88 correlation timestamp is invalid");
+  return Object.freeze({ ...value });
+}
+
+export function createRun88RuntimeCorrelation(input: {
+  readonly requestId: string;
+  readonly routingDecisionId: string;
+  readonly releaseId: string;
+  readonly sourceId: string;
+  readonly deploymentId: string;
+  readonly scope: string;
+  readonly endpointId?: string;
+  readonly timestamp?: string;
+}): Record<string, unknown> {
+  for (const field of [
+    "requestId",
+    "routingDecisionId",
+    "sourceId",
+    "deploymentId",
+    "scope",
+  ] as const) {
+    if (!input[field]?.trim()) throw new Error(`Run 88 correlation ${field} is required`);
+  }
+  if (!/^sha256:[0-9a-f]{64}$/.test(input.releaseId))
+    throw new Error("Run 88 correlation releaseId is invalid");
+  if (!/^[0-9a-f]{40}$/.test(input.sourceId))
+    throw new Error("Run 88 correlation sourceId is invalid");
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const seed = `${input.releaseId}\0${input.requestId}\0${input.routingDecisionId}`;
+  const hex = (label: string, length: number) =>
+    createHash("sha256").update(`${label}\0${seed}`).digest("hex").slice(0, length);
+  return normalizeRun88RuntimeCorrelation(
+    {
+      schemaVersion: "run88-correlation.v1",
+      eventId: `evt-${hex("event", 24)}`,
+      correlationId: `corr-${hex("correlation", 24)}`,
+      traceId: hex("trace", 32),
+      spanId: hex("span", 16),
+      causalParentId: input.routingDecisionId,
+      service: "runtime-host-bridge",
+      operation: "track-b.post-observation",
+      runtimeChannel: "staging",
+      scopeHash: `sha256:${createHash("sha256").update(input.scope).digest("hex")}`,
+      cohort: "stage-1pct",
+      releaseId: input.releaseId,
+      sourceId: input.sourceId,
+      deploymentId: input.deploymentId,
+      attempt: 1,
+      outcome: "observed",
+      timestamp,
+      durationMs: 0,
+    },
+    input.releaseId,
+  );
+}
+
+export function validateRun88ProviderResponseObservation(
+  observation: Readonly<Record<string, unknown>>,
+  provenance:
+    | Readonly<{
+        source: "routed-execution-callback";
+        piInvocationProof: Readonly<Record<string, unknown>>;
+        trustedAuthorityPublicKey: string;
+        expectedReleaseId: string;
+      }>
+    | undefined,
+): Readonly<{
+  requestId: string;
+  clientRequestId: string;
+  routingDecisionId: string;
+  endpointId: string;
+  statusCode: number;
+  responseSha256: string;
+  piInvocationProofSha256: string;
+  outcome: "provider-success";
+}> {
+  const requestId = typeof observation.requestId === "string" ? observation.requestId.trim() : "";
+  const clientRequestId =
+    typeof observation.clientRequestId === "string" ? observation.clientRequestId.trim() : "";
+  const routingDecisionId =
+    typeof observation.routingDecisionId === "string" ? observation.routingDecisionId.trim() : "";
+  const endpointId =
+    typeof observation.endpointId === "string" ? observation.endpointId.trim() : "";
+  const inspection = observation.inspection as Record<string, unknown> | null | undefined;
+  const inspectedRequest = inspection?.request as Record<string, unknown> | null | undefined;
+  const inspectedEndpoint = inspection?.endpoint as Record<string, unknown> | null | undefined;
+  const requestCapture = inspectedRequest?.requestCapture as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const responseCapture = inspectedRequest?.responseCapture as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const executionTelemetry = observation.executionTelemetry as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const providerFamily =
+    typeof executionTelemetry?.providerFamily === "string"
+      ? executionTelemetry.providerFamily.trim()
+      : "";
+  const statusCode = responseCapture?.statusCode;
+  const requestBody = requestCapture?.body as Record<string, unknown> | null | undefined;
+  const responseBody = responseCapture?.body;
+  if (provenance?.source !== "routed-execution-callback")
+    throw new Error("Run 88 provider response requires trusted routed-execution provenance");
+  const proof = provenance.piInvocationProof;
+  const proofKeys = new Set([
+    "schemaVersion",
+    "executionClass",
+    "clientRequestId",
+    "releaseId",
+    "processId",
+    "executableSha256",
+    "issuedAt",
+    "expiresAt",
+    "signature",
+  ]);
+  if (
+    !proof ||
+    Object.keys(proof).some((key) => !proofKeys.has(key)) ||
+    [...proofKeys].some((key) => !Object.hasOwn(proof, key))
+  )
+    throw new Error("Run 88 provider response requires a complete signed Pi invocation proof");
+  const { signature, ...claim } = proof;
+  const issuedAt = Date.parse(String(claim.issuedAt ?? ""));
+  const expiresAt = Date.parse(String(claim.expiresAt ?? ""));
+  const canonicalIso = (value: unknown, parsed: number) =>
+    typeof value === "string" &&
+    Number.isFinite(parsed) &&
+    new Date(parsed).toISOString() === value;
+  if (
+    claim.schemaVersion !== "run88-pi-invocation-proof.v1" ||
+    claim.executionClass !== "actual-pi-cli" ||
+    claim.clientRequestId !== clientRequestId ||
+    claim.releaseId !== provenance.expectedReleaseId ||
+    !/^sha256:[0-9a-f]{64}$/.test(provenance.expectedReleaseId) ||
+    !Number.isInteger(claim.processId) ||
+    Number(claim.processId) < 1 ||
+    !/^[0-9a-f]{64}$/.test(String(claim.executableSha256 ?? "")) ||
+    !canonicalIso(claim.issuedAt, issuedAt) ||
+    !canonicalIso(claim.expiresAt, expiresAt) ||
+    expiresAt <= issuedAt ||
+    expiresAt - issuedAt > RUN88_PI_PROOF_VALIDITY_MS ||
+    Date.now() < issuedAt ||
+    Date.now() >= expiresAt
+  )
+    throw new Error("Run 88 Pi invocation proof identity or validity window is invalid");
+  let signatureValid = false;
+  try {
+    signatureValid = verifySignature(
+      null,
+      Buffer.from(JSON.stringify(canonicalizeRun88Proof(claim))),
+      provenance.trustedAuthorityPublicKey,
+      Buffer.from(String(signature ?? ""), "base64"),
+    );
+  } catch {
+    signatureValid = false;
+  }
+  if (!signatureValid)
+    throw new Error("Run 88 Pi invocation proof signature or trusted authority is invalid");
+  for (const value of [observation, inspectedRequest]) {
+    if (
+      value?.mocked === true ||
+      value?.fixture === true ||
+      value?.directHostCall === true ||
+      value?.apiOnly === true
+    )
+      throw new Error(
+        "Run 88 mocked, fixture, direct-host, or API-only provider proof is forbidden",
+      );
+  }
+  if (!requestId || !clientRequestId || !routingDecisionId || !endpointId)
+    throw new Error("Run 88 provider response observation or Pi client identity is incomplete");
+  if (
+    inspectedRequest?.requestId !== requestId ||
+    inspectedRequest.clientRequestId !== clientRequestId ||
+    inspectedRequest.routingDecisionId !== routingDecisionId ||
+    inspectedEndpoint?.endpointId !== endpointId
+  )
+    throw new Error("Run 88 provider response inspection identity is incomplete or mixed");
+  if (!Number.isInteger(statusCode) || Number(statusCode) < 200 || Number(statusCode) >= 300)
+    throw new Error("Run 88 provider response observation is not successful");
+  if (
+    !providerFamily ||
+    !requestBody ||
+    isSuppressedRun88Capture(requestBody) ||
+    Object.keys(requestBody).length === 0
+  )
+    throw new Error("Run 88 provider response observation has no configured provider request");
+  if (responseBody === undefined || responseBody === null || isSuppressedRun88Capture(responseBody))
+    throw new Error("Run 88 provider response observation has no real provider output");
+  const responseBytes = JSON.stringify(canonicalizeRun88Proof(responseBody));
+  if (!responseBytes || responseBytes === "{}" || responseBytes === "[]" || responseBytes === '""')
+    throw new Error("Run 88 provider response observation has no real provider output");
+  return Object.freeze({
+    requestId,
+    clientRequestId,
+    routingDecisionId,
+    endpointId,
+    statusCode: Number(statusCode),
+    responseSha256: createHash("sha256").update(responseBytes).digest("hex"),
+    piInvocationProofSha256: createHash("sha256")
+      .update(JSON.stringify(canonicalizeRun88Proof(proof)))
+      .digest("hex"),
+    outcome: "provider-success",
+  });
+}
+
 export async function stageTrackBRuntimeDistribution(options: {
   readonly sourceRoot: string;
   readonly releaseDir: string;
 }) {
   const manifestPath = path.join(options.sourceRoot, "track-b-runtime-manifest.json");
   const manifestBytes = await readFile(manifestPath);
+  const manifestSha256 = createHash("sha256").update(manifestBytes).digest("hex");
   const manifest = JSON.parse(manifestBytes.toString("utf8")) as {
     readonly schemaVersion: string;
     readonly sidecar: { readonly modulePath: string; readonly artifactSha256: string };
@@ -339,6 +639,7 @@ export async function stageTrackBRuntimeDistribution(options: {
     sidecarSha256: manifest.sidecar.artifactSha256,
     extensionCount: manifest.extensions.length,
     compatibilityGeneration,
+    manifestSha256,
   };
 }
 
@@ -418,6 +719,7 @@ export interface TrackBPostObservationWorkItem extends Readonly<Record<string, u
   readonly requestId: string;
   readonly routingDecisionId: string;
   readonly endpointId: string;
+  readonly run88Correlation?: Readonly<Record<string, unknown>>;
 }
 
 export interface TrackBPostObservationReceipt {
@@ -466,6 +768,14 @@ export function createTrackBPostObservationOutbox({
         requestId: String(row.requestId),
         routingDecisionId: String(row.routingDecisionId),
         endpointId: String(row.endpointId),
+        ...(row.run88Correlation && typeof row.run88Correlation === "object"
+          ? {
+              run88Correlation: normalizeRun88RuntimeCorrelation(
+                row.run88Correlation as Record<string, unknown>,
+                String((row.run88Correlation as Record<string, unknown>).releaseId ?? ""),
+              ),
+            }
+          : {}),
       };
     });
     const normalizedReceipts = receipts.map((item) => {
@@ -503,6 +813,14 @@ export function createTrackBPostObservationOutbox({
           requestId: String(observation.requestId ?? ""),
           routingDecisionId: String(observation.routingDecisionId ?? ""),
           endpointId: String(observation.endpointId ?? ""),
+          ...(observation.run88Correlation && typeof observation.run88Correlation === "object"
+            ? {
+                run88Correlation: normalizeRun88RuntimeCorrelation(
+                  observation.run88Correlation as Record<string, unknown>,
+                  String((observation.run88Correlation as Record<string, unknown>).releaseId ?? ""),
+                ),
+              }
+            : {}),
         };
         if (!item.requestId || !item.routingDecisionId || !item.endpointId) {
           throw new Error("complete Track B post-observation identity required");
@@ -732,6 +1050,8 @@ export async function runTrackBPostObservation(
     readonly scope: string;
     readonly channel: "development" | "stage" | "production";
     readonly authorizationEpoch: number;
+    readonly expectedReleaseId?: string;
+    readonly run88Correlation?: Record<string, unknown>;
   },
 ) {
   const requestId = String(observation.requestId ?? "");
@@ -740,6 +1060,9 @@ export async function runTrackBPostObservation(
   if (!requestId || !sourceDecisionId || !routePackage || !input.scope) {
     throw new Error("persisted observation identity is required for Track B shadow processing");
   }
+  const run88Correlation = input.expectedReleaseId
+    ? normalizeRun88RuntimeCorrelation(input.run88Correlation ?? {}, input.expectedReleaseId)
+    : null;
   const businessEnvelope = (
     capability: string,
     extra: Readonly<Record<string, unknown>> = {},
@@ -751,6 +1074,7 @@ export async function runTrackBPostObservation(
     scope: input.scope,
     authorizationEpoch: input.authorizationEpoch,
     capability,
+    ...(run88Correlation ? { run88Correlation } : {}),
     ...extra,
   });
   const artifact = await runtime.invoke(

--- a/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
@@ -990,7 +990,7 @@ observed_data:
     );
 
     await backend.shutdown();
-  }, 60_000);
+  }, 90_000);
 
   test("bootstraps a settings-specific primary routing alias for remote-only posture without preconfigured aliases", async () => {
     const tempRoot = await mkdtemp(

--- a/role-model-router/apps/runtime-host-bridge/test/openai-codex-subscription-matrix.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/openai-codex-subscription-matrix.test.ts
@@ -31,7 +31,7 @@ const EXPECTED_OPENAI_CODEX_SUBSCRIPTION_MODEL_IDS = [
   "chatgpt/gpt-5.3-chat-latest",
 ] as const;
 
-const OPENAI_CODEX_SUBSCRIPTION_CODER_PATCH_TIMEOUT_MS = 30_000;
+const OPENAI_CODEX_SUBSCRIPTION_CODER_PATCH_TIMEOUT_MS = 90_000;
 
 describe("OpenAI Codex Subscription model matrix", () => {
   test("defines only the supported OpenAI GPT-5.3+ subscription rows", () => {

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-compatibility.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-compatibility.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -62,6 +62,11 @@ test("SP7 stages N and N-1 distributions and refuses unsupported future versions
         releaseDir: path.join(root, `release-${expectedGeneration}`),
       });
       expect(staged.compatibilityGeneration).toBe(expectedGeneration);
+      expect(staged.manifestSha256).toBe(
+        createHash("sha256")
+          .update(await readFile(path.join(root, "track-b-runtime-manifest.json")))
+          .digest("hex"),
+      );
     }
     await writeFile(
       path.join(root, "track-b-runtime-manifest.json"),

--- a/role-model-router/apps/runtime-host-bridge/test/run88-public-runtime-probes.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run88-public-runtime-probes.ts
@@ -1,0 +1,1061 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect } from "vitest";
+
+import {
+  validatePublicRollbackTarget,
+  validatePublicStageIdentity,
+} from "../../../../scripts/run88-stage-release.mjs";
+import { createRun88StagePostObservation } from "../src/cli.js";
+import { validateRun88PrivateDistributionIdentity } from "../src/kw-private-loader.js";
+import { validateRun88PackagedStageIdentity } from "../src/runtime-version.js";
+import { createTrackBOperations } from "../src/track-b-operations.js";
+import {
+  createRun88RuntimeCorrelation,
+  createTrackBPostObservationOutbox,
+  normalizeRun88RuntimeCorrelation,
+  runTrackBShadowPipeline,
+  validateRun88ProviderResponseObservation,
+} from "../src/track-b-runtime.js";
+
+type Probe = () => unknown | Promise<unknown>;
+type ProbeLayers = Readonly<{
+  unit: Probe;
+  integration: Probe;
+  regression: Probe;
+}>;
+
+const releaseId = `sha256:${"a".repeat(64)}`;
+const manifestSha256 = "c".repeat(64);
+
+const correlation = (overrides: Readonly<Record<string, unknown>> = {}) =>
+  createRun88RuntimeCorrelation({
+    requestId: "request-1",
+    routingDecisionId: "decision-1",
+    endpointId: "endpoint-1",
+    releaseId,
+    sourceId: "b".repeat(40),
+    deploymentId: "local-stage-runtime",
+    scope: "stage-scope",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    ...overrides,
+  });
+
+const stageManifest = (overrides: Readonly<Record<string, unknown>> = {}) => ({
+  channel: "stage",
+  name: "role-model-stage",
+  host: "127.0.0.1",
+  port: 3457,
+  endpoint: "http://127.0.0.1:3457",
+  state_root_name: "role-model-runtime-stage",
+  scope_id: "standalone-runtime-stage",
+  release_id: releaseId,
+  private_distribution_sha256: manifestSha256,
+  source_tree: "b".repeat(40),
+  executable_sha256: "d".repeat(64),
+  core_payload_sha256: "e".repeat(64),
+  track_b_runtime: { manifest_sha256: manifestSha256 },
+  ...overrides,
+});
+
+const packageIdentity = (overrides: Readonly<Record<string, unknown>> = {}) => ({
+  schemaVersion: "run88-public-stage-identity.v1",
+  channel: "stage",
+  name: "role-model-stage",
+  port: 3457,
+  publicSource: "a".repeat(40),
+  publicSourceTree: "b".repeat(40),
+  privateDistribution: {
+    generation: "N",
+    manifestSha256,
+    sidecarSha256: "d".repeat(64),
+  },
+  package: {
+    executableSha256: "d".repeat(64),
+    corePayloadSha256: "e".repeat(64),
+    embeddedPrivateManifestSha256: manifestSha256,
+  },
+  ...overrides,
+});
+
+const rollbackTarget = (overrides: Readonly<Record<string, unknown>> = {}) => ({
+  channel: "stage",
+  ref: "1".repeat(40),
+  sourceTree: "2".repeat(40),
+  packageSha256: "3".repeat(64),
+  compatibilityGeneration: "N",
+  ...overrides,
+});
+
+const expectedDistribution = {
+  channel: "stage" as const,
+  manifestSha256,
+  publicGeneration: "N" as const,
+};
+
+function compatibleDistribution(generation: "N" | "N-1" = "N") {
+  return validateRun88PrivateDistributionIdentity(
+    { generation, manifestSha256, channel: "stage" },
+    expectedDistribution,
+  );
+}
+
+async function workflowBytes() {
+  const [ci, binaries] = await Promise.all([
+    readFile(new URL("../../../../.github/workflows/ci.yml", import.meta.url), "utf8"),
+    readFile(new URL("../../../../.github/workflows/build-binaries.yml", import.meta.url), "utf8"),
+  ]);
+  return { ci, binaries, combined: `${ci}\n${binaries}` };
+}
+
+async function withDurableOutbox<T>(
+  run: (outbox: ReturnType<typeof createTrackBPostObservationOutbox>) => Promise<T>,
+) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run88-public-probe-"));
+  try {
+    return await run(
+      createTrackBPostObservationOutbox({ filePath: path.join(root, "outbox.json") }),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function enqueueCorrelatedObservation(
+  outbox: ReturnType<typeof createTrackBPostObservationOutbox>,
+  overrides: Readonly<Record<string, unknown>> = {},
+) {
+  const item = {
+    requestId: "request-1",
+    routingDecisionId: "decision-1",
+    endpointId: "endpoint-1",
+    run88Correlation: correlation(),
+    ...overrides,
+  };
+  await outbox.enqueue(item);
+  return item;
+}
+
+const providerObservation = (overrides: Readonly<Record<string, unknown>> = {}) => ({
+  requestId: "pi-request-1",
+  clientRequestId: "pi-client-request-1",
+  routingDecisionId: "provider-decision-1",
+  endpointId: "provider-endpoint-1",
+  executionTelemetry: { providerFamily: "openai" },
+  inspection: {
+    request: {
+      requestId: "pi-request-1",
+      clientRequestId: "pi-client-request-1",
+      routingDecisionId: "provider-decision-1",
+      requestCapture: { headers: { "content-type": "application/json" }, body: { model: "gpt" } },
+      responseCapture: {
+        statusCode: 200,
+        body: { output: [{ text: "successful provider response" }] },
+      },
+    },
+    endpoint: { endpointId: "provider-endpoint-1" },
+  },
+  ...overrides,
+});
+
+const piProofAuthority = generateKeyPairSync("ed25519");
+const canonicalProof = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalProof);
+  if (value && typeof value === "object")
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => [key, canonicalProof((value as Record<string, unknown>)[key])]),
+    );
+  return value;
+};
+const piProvenance = () => {
+  const issuedAt = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + 60_000).toISOString();
+  const claim = {
+    schemaVersion: "run88-pi-invocation-proof.v1",
+    executionClass: "actual-pi-cli",
+    clientRequestId: "pi-client-request-1",
+    releaseId: `sha256:${"a".repeat(64)}`,
+    processId: 4242,
+    executableSha256: "a".repeat(64),
+    issuedAt,
+    expiresAt,
+  } as const;
+  return {
+    source: "routed-execution-callback" as const,
+    piInvocationProof: {
+      ...claim,
+      signature: sign(
+        null,
+        Buffer.from(JSON.stringify(canonicalProof(claim))),
+        piProofAuthority.privateKey,
+      ).toString("base64"),
+    },
+    expectedReleaseId: claim.releaseId,
+    trustedAuthorityPublicKey: piProofAuthority.publicKey
+      .export({ type: "spki", format: "pem" })
+      .toString(),
+  };
+};
+
+async function withRecommendationOperations<T>(
+  recommendation: Readonly<Record<string, unknown>>,
+  run: (operations: ReturnType<typeof createTrackBOperations>, statePath: string) => Promise<T>,
+) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "run88-recommendation-probe-"));
+  const statePath = path.join(root, "track-b-production-bridge.json");
+  try {
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        schemaVersion: "role-model.track-b-production-bridge.v1",
+        protocolVersion: "1.0",
+        revision: 1,
+        generatedAt: "2026-08-02T00:00:00.000Z",
+        extensions: [],
+        storageServices: [],
+        retention: { managedPolicy: false, receipts: [], activeJob: null },
+        contribution: {
+          mode: "contributor",
+          contributionTier: "advanced",
+          recommendationTier: "advanced",
+          recommendationAccess: "preview_and_apply",
+          allowCloudUpload: true,
+          authorizationState: "active",
+          revocationEpoch: 0,
+          queuedCount: 0,
+          managed: false,
+        },
+        recommendations: [recommendation],
+        recommendationRevision: 1,
+        activePack: null,
+      }),
+      "utf8",
+    );
+    return await run(createTrackBOperations({ statePath, catalog: [] }), statePath);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const recommendation = (overrides: Readonly<Record<string, unknown>> = {}) => ({
+  id: "stage-recommendation-1",
+  version: "1",
+  status: "validated",
+  signatureValid: true,
+  policyAllowed: true,
+  provenance: "cloud:stage-bundle",
+  ...overrides,
+});
+
+const shadowInput = (overrides: Readonly<Record<string, unknown>> = {}) => ({
+  requestId: "shadow-request-1",
+  channel: "stage",
+  scope: "stage-scope",
+  authorizationEpoch: 88,
+  productionState: Object.freeze({ route: "unchanged", providerCalls: 1 }),
+  routePackage: "candidate-stage",
+  sourceDecisionId: "decision-1",
+  sourceGraphRef: "sha256:graph-1",
+  prefix: ["request"],
+  counterfactuals: [{ id: "candidate-stage", suffix: ["candidate-stage"] }],
+  evaluationCases: [{ expected: "candidate-stage", actual: "candidate-stage" }],
+  trajectoryEvents: [],
+  ...overrides,
+});
+
+const shadowRuntime = {
+  async invoke(id: string) {
+    if (id === "evaluation-runner-local")
+      return { scores: [1], provenance: { evidenceRef: "sha256:graph-1" } };
+    if (id === "knowledge-worker") return { id: "shadow-candidate-1", state: "shadow" };
+    return { id: `${id}-result` };
+  },
+};
+
+export const publicRuntimeAcceptanceProbes: Readonly<Record<string, ProbeLayers>> = Object.freeze({
+  "R2-AC02": Object.freeze({
+    unit: async () => {
+      const manifest = validateRun88PackagedStageIdentity(stageManifest());
+      expect(manifest.private_distribution_sha256).toBe(manifestSha256);
+      expect((manifest.track_b_runtime as Record<string, unknown>).manifest_sha256).toBe(
+        manifestSha256,
+      );
+    },
+    integration: async () => {
+      const packaged = validateRun88PackagedStageIdentity(stageManifest());
+      const distribution = validateRun88PrivateDistributionIdentity(
+        { generation: "N", manifestSha256, channel: "stage" },
+        expectedDistribution,
+      );
+      expect(packaged.private_distribution_sha256).toBe(manifestSha256);
+      expect(distribution).toMatchObject({ available: true, compatible: true });
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PackagedStageIdentity(
+          stageManifest({ track_b_runtime: { manifest_sha256: "0".repeat(64) } }),
+        ),
+      ).toThrow(/distribution/i);
+    },
+  }),
+  "R2-AC03": Object.freeze({
+    unit: async () => {
+      expect(validateRun88PackagedStageIdentity(stageManifest())).toMatchObject({
+        channel: "stage",
+        name: "role-model-stage",
+        host: "127.0.0.1",
+        port: 3457,
+        endpoint: "http://127.0.0.1:3457",
+      });
+    },
+    integration: async () => {
+      const manifest = validateRun88PackagedStageIdentity(stageManifest());
+      expect(manifest).toMatchObject({
+        state_root_name: "role-model-runtime-stage",
+        scope_id: "standalone-runtime-stage",
+        release_id: releaseId,
+      });
+      expect(String(manifest.executable_sha256)).toHaveLength(64);
+      expect(String(manifest.core_payload_sha256)).toHaveLength(64);
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PackagedStageIdentity(
+          stageManifest({ endpoint: "http://127.0.0.1:3456", port: 3456 }),
+        ),
+      ).toThrow(/stage package/i);
+    },
+  }),
+  "R2-AC04": Object.freeze({
+    unit: async () => {
+      const first = validatePublicStageIdentity(packageIdentity());
+      const second = validatePublicStageIdentity(structuredClone(packageIdentity()));
+      expect(first.identitySha256).toBe(second.identitySha256);
+    },
+    integration: async () => {
+      const publicIdentity = validatePublicStageIdentity(packageIdentity());
+      const runtimeIdentity = validateRun88PackagedStageIdentity(stageManifest());
+      expect(publicIdentity.package.corePayloadSha256).toBe(runtimeIdentity.core_payload_sha256);
+      expect(publicIdentity.privateDistribution.manifestSha256).toBe(
+        runtimeIdentity.private_distribution_sha256,
+      );
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PackagedStageIdentity(stageManifest({ source_tree: "not-a-source-tree" })),
+      ).toThrow(/source tree/i);
+    },
+  }),
+  "R4-AC05": Object.freeze({
+    unit: async () => {
+      const { binaries } = await workflowBytes();
+      expect(binaries).toContain('"phase5.mock"');
+      expect(binaries).toContain("Forbidden QA/mock marker");
+      return { acceptanceId: "R4-AC05", layer: "unit", enforcement: "phase5-live-cloud-required" };
+    },
+    integration: async () => {
+      expect(validateRun88PackagedStageIdentity(stageManifest()).channel).toBe("stage");
+      const { combined } = await workflowBytes();
+      expect(combined).not.toContain("wrangler deploy");
+      return {
+        acceptanceId: "R4-AC05",
+        layer: "integration",
+        enforcement: "phase5-live-platform-state-required",
+      };
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PrivateDistributionIdentity(
+          { generation: "N", manifestSha256, channel: "production" },
+          expectedDistribution,
+        ),
+      ).toThrow(/channel/i);
+      return {
+        acceptanceId: "R4-AC05",
+        layer: "regression",
+        enforcement: "offline-cloud-readiness-refused",
+      };
+    },
+  }),
+  "R4-AC06": Object.freeze({
+    unit: async () => {
+      expect(validateRun88PrivateDistributionIdentity(null, expectedDistribution)).toEqual({
+        available: false,
+        compatible: false,
+        degradation: "public-routing-only",
+      });
+    },
+    integration: async () => {
+      expect(validateRun88PackagedStageIdentity(stageManifest()).name).toBe("role-model-stage");
+      expect(validateRun88PrivateDistributionIdentity(null, expectedDistribution).degradation).toBe(
+        "public-routing-only",
+      );
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PrivateDistributionIdentity(
+          { generation: "N", manifestSha256, channel: "production" },
+          expectedDistribution,
+        ),
+      ).toThrow(/channel/i);
+    },
+  }),
+  "R5-AC01": Object.freeze({
+    unit: async () => {
+      const envelope = correlation();
+      expect(normalizeRun88RuntimeCorrelation(envelope, releaseId)).toEqual(envelope);
+      expect(envelope.scopeHash).not.toBe("stage-scope");
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        const item = await enqueueCorrelatedObservation(outbox);
+        let observed: Readonly<Record<string, unknown>> | undefined;
+        await outbox.drain(async (value) => {
+          observed = value;
+          return { status: "processed" };
+        });
+        expect(observed?.run88Correlation).toEqual(item.run88Correlation);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 0, receiptCount: 1 });
+      });
+    },
+    regression: async () => {
+      expect(() =>
+        normalizeRun88RuntimeCorrelation({ ...correlation(), prompt: "raw" }, releaseId),
+      ).toThrow(/field/i);
+      expect(() =>
+        normalizeRun88RuntimeCorrelation(
+          { ...correlation(), releaseId: `sha256:${"f".repeat(64)}` },
+          releaseId,
+        ),
+      ).toThrow(/release/i);
+    },
+  }),
+  "R6-AC06": Object.freeze({
+    unit: async () => {
+      expect(validatePublicRollbackTarget(rollbackTarget())).toMatchObject({
+        ok: true,
+        channel: "stage",
+      });
+      return { acceptanceId: "R6-AC06", layer: "unit", enforcement: "phase5-soak-required" };
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await expect(
+          outbox.drain(async () => {
+            throw new Error("threshold controller paused delivery");
+          }),
+        ).rejects.toThrow(/paused/);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1, receiptCount: 0 });
+      });
+      return {
+        acceptanceId: "R6-AC06",
+        layer: "integration",
+        enforcement: "phase5-measured-threshold-receipt-required",
+      };
+    },
+    regression: async () => {
+      expect(() =>
+        validatePublicRollbackTarget(rollbackTarget({ compatibilityGeneration: "future" })),
+      ).toThrow(/generation/i);
+      return {
+        acceptanceId: "R6-AC06",
+        layer: "regression",
+        enforcement: "fabricated-soak-pass-refused",
+      };
+    },
+  }),
+  "R7-AC03": Object.freeze({
+    unit: async () => {
+      const observed = validateRun88ProviderResponseObservation(
+        providerObservation(),
+        piProvenance(),
+      );
+      expect(observed).toMatchObject({
+        requestId: "pi-request-1",
+        clientRequestId: "pi-client-request-1",
+        routingDecisionId: "provider-decision-1",
+        endpointId: "provider-endpoint-1",
+        statusCode: 200,
+        outcome: "provider-success",
+      });
+      expect(observed.responseSha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(observed.piInvocationProofSha256).toMatch(/^[a-f0-9]{64}$/);
+      return {
+        acceptanceId: "R7-AC03",
+        layer: "unit",
+        enforcement: "phase5-real-pi-provider-response-required",
+      };
+    },
+    integration: async () => {
+      const observed = createRun88StagePostObservation({
+        observation: providerObservation(),
+        piInvocationProvenance: piProvenance(),
+        proofRequired: true,
+        releaseId,
+        sourceId: "b".repeat(40),
+        executableSha256: "c".repeat(64),
+        scope: "stage-scope",
+      });
+      expect(observed.run88ProviderResponse).toMatchObject({
+        requestId: "pi-request-1",
+        clientRequestId: "pi-client-request-1",
+        outcome: "provider-success",
+      });
+      expect(observed.run88Correlation).toMatchObject({
+        causalParentId: "provider-decision-1",
+        releaseId,
+        sourceId: "b".repeat(40),
+        deploymentId: `local-stage:${"c".repeat(64)}`,
+      });
+      await withDurableOutbox(async (outbox) => {
+        await outbox.enqueue(observed);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1, receiptCount: 0 });
+      });
+      return {
+        acceptanceId: "R7-AC03",
+        layer: "integration",
+        enforcement: "validated-provider-response-to-durable-observation",
+      };
+    },
+    regression: async () => {
+      expect(() =>
+        createRun88StagePostObservation({
+          observation: providerObservation(),
+          piInvocationProvenance: null,
+          proofRequired: true,
+          releaseId,
+          sourceId: "b".repeat(40),
+          executableSha256: "c".repeat(64),
+          scope: "stage-scope",
+        }),
+      ).toThrow(/requires signed Pi CLI provenance/i);
+      expect(() =>
+        validateRun88ProviderResponseObservation(providerObservation(), {
+          source: "routed-execution-callback",
+        }),
+      ).toThrow(/Pi|invocation|proof|authority/i);
+      expect(() =>
+        validateRun88ProviderResponseObservation(
+          {
+            requestId: "pi-request-1",
+            routingDecisionId: "provider-decision-1",
+            endpointId: "direct-host-method",
+            statusCode: 200,
+            outputText: "direct response",
+          },
+          piProvenance(),
+        ),
+      ).toThrow(/identity|successful|output/i);
+      expect(() =>
+        validateRun88ProviderResponseObservation(
+          providerObservation({ mocked: true }),
+          piProvenance(),
+        ),
+      ).toThrow(/real|mock|provider/i);
+      expect(() =>
+        validateRun88ProviderResponseObservation(
+          providerObservation({ endpointId: "" }),
+          piProvenance(),
+        ),
+      ).toThrow(/identity|successful|output/i);
+      const failed = providerObservation();
+      expect(() =>
+        validateRun88ProviderResponseObservation(
+          providerObservation({
+            inspection: {
+              ...(failed.inspection as Readonly<Record<string, unknown>>),
+              request: {
+                ...failed.inspection.request,
+                responseCapture: { statusCode: 503, body: { error: "provider failed" } },
+              },
+            },
+          }),
+          piProvenance(),
+        ),
+      ).toThrow(/successful/i);
+    },
+  }),
+  "R8-AC03": Object.freeze({
+    unit: async () => {
+      await withRecommendationOperations(recommendation(), async (operations) => {
+        const rows = await operations.listRecommendations();
+        expect(rows).toContainEqual(
+          expect.objectContaining({
+            id: "stage-recommendation-1",
+            status: "validated",
+            signatureValid: true,
+          }),
+        );
+      });
+    },
+    integration: async () => {
+      await withRecommendationOperations(recommendation(), async (operations, statePath) => {
+        const applied = (await operations.applyRecommendation({
+          id: "stage-recommendation-1",
+        })) as {
+          activePack: Readonly<Record<string, unknown>>;
+        };
+        expect(applied.activePack).toMatchObject({ id: "stage-recommendation-1", version: "1" });
+        const persisted = await readFile(statePath, "utf8");
+        expect(persisted).not.toContain("routePackageActivation");
+        expect(persisted).not.toContain('productionActivation":true');
+      });
+    },
+    regression: async () => {
+      await withRecommendationOperations(
+        recommendation({ signatureValid: false }),
+        async (operations) => {
+          await expect(
+            operations.applyRecommendation({ id: "stage-recommendation-1" }),
+          ).rejects.toThrow(/signature/i);
+        },
+      );
+      await withRecommendationOperations(
+        recommendation({ status: "dismissed" }),
+        async (operations) => {
+          await expect(
+            operations.applyRecommendation({ id: "stage-recommendation-1" }),
+          ).rejects.toThrow(/dismissed/i);
+        },
+      );
+    },
+  }),
+  "R8-AC05": Object.freeze({
+    unit: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1, receiptCount: 0 });
+      });
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await expect(
+          outbox.drain(async () => {
+            throw new Error("cloud queue unavailable");
+          }),
+        ).rejects.toThrow(/unavailable/);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1 });
+        await outbox.drain(async () => ({ status: "completed-after-recovery" }));
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 0, receiptCount: 1 });
+      });
+      return {
+        acceptanceId: "R8-AC05",
+        layer: "integration",
+        enforcement: "runtime-recovery-plus-phase5-live-cloud-required",
+      };
+    },
+    regression: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await enqueueCorrelatedObservation(outbox);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1, receiptCount: 0 });
+      });
+    },
+  }),
+  "R9-AC01": Object.freeze({
+    unit: async () => {
+      expect(validatePublicRollbackTarget(rollbackTarget())).toMatchObject({
+        ok: true,
+        ref: "1".repeat(40),
+        sourceTree: "2".repeat(40),
+        packageSha256: "3".repeat(64),
+      });
+      return { acceptanceId: "R9-AC01", layer: "unit", enforcement: "phase5-snapshot-required" };
+    },
+    integration: async () => {
+      const current = validateRun88PackagedStageIdentity(stageManifest());
+      const recovery = validatePublicRollbackTarget(rollbackTarget());
+      expect(current.channel).toBe(recovery.channel);
+      expect(current.source_tree).not.toBe(recovery.ref);
+      return {
+        acceptanceId: "R9-AC01",
+        layer: "integration",
+        enforcement: "current-and-recovery-identities-bound",
+      };
+    },
+    regression: async () => {
+      expect(() => validatePublicRollbackTarget(rollbackTarget({ sourceTree: "missing" }))).toThrow(
+        /identity/i,
+      );
+      expect(() =>
+        validatePublicRollbackTarget(rollbackTarget({ packageSha256: "missing" })),
+      ).toThrow(/sha256/i);
+    },
+  }),
+  "R9-AC02": Object.freeze({
+    unit: async () => {
+      expect(validatePublicRollbackTarget(rollbackTarget()).compatibilityGeneration).toBe("N");
+      return {
+        acceptanceId: "R9-AC02",
+        layer: "unit",
+        enforcement: "phase5-features-private-public-order-required",
+      };
+    },
+    integration: async () => {
+      const target = validatePublicRollbackTarget(
+        rollbackTarget({ compatibilityGeneration: "N-1" }),
+      );
+      expect(target).toMatchObject({ ok: true, channel: "stage", compatibilityGeneration: "N-1" });
+      return {
+        acceptanceId: "R9-AC02",
+        layer: "integration",
+        enforcement: "n-minus-one-rollback-window",
+      };
+    },
+    regression: async () => {
+      expect(() => validatePublicRollbackTarget(rollbackTarget({ channel: "production" }))).toThrow(
+        /stage/i,
+      );
+      expect(() =>
+        validatePublicRollbackTarget(rollbackTarget({ compatibilityGeneration: "N+1" })),
+      ).toThrow(/generation/i);
+    },
+  }),
+  "R9-AC03": Object.freeze({
+    unit: async () => {
+      expect(validateRun88PrivateDistributionIdentity(null, expectedDistribution)).toMatchObject({
+        available: false,
+        degradation: "public-routing-only",
+      });
+      return {
+        acceptanceId: "R9-AC03",
+        layer: "unit",
+        enforcement: "phase5-executed-fault-matrix-required",
+      };
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await expect(
+          outbox.drain(async () => {
+            throw new Error("outbox interruption drill");
+          }),
+        ).rejects.toThrow(/interruption/);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1 });
+      });
+      return {
+        acceptanceId: "R9-AC03",
+        layer: "integration",
+        enforcement: "runtime-fault-plus-phase5-drills-required",
+      };
+    },
+    regression: async () => {
+      const { binaries } = await workflowBytes();
+      expect(binaries).toContain("Verify package contains no QA fixtures or mock data");
+      expect(binaries).toContain("Forbidden QA/mock marker");
+    },
+  }),
+  "R9-AC04": Object.freeze({
+    unit: async () => {
+      expect(validateRun88PrivateDistributionIdentity(null, expectedDistribution)).toEqual({
+        available: false,
+        compatible: false,
+        degradation: "public-routing-only",
+      });
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await outbox.drain(async () => ({ status: "resumed" }));
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 0, receiptCount: 1 });
+      });
+      expect(validateRun88PackagedStageIdentity(stageManifest()).channel).toBe("stage");
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PrivateDistributionIdentity(
+          { generation: "N", manifestSha256: "f".repeat(64), channel: "stage" },
+          expectedDistribution,
+        ),
+      ).toThrow(/manifest/i);
+    },
+  }),
+  "R9-AC05": Object.freeze({
+    unit: async () => {
+      const first = validatePublicStageIdentity(packageIdentity());
+      const rebuilt = validatePublicStageIdentity(structuredClone(packageIdentity()));
+      expect(rebuilt.identitySha256).toBe(first.identitySha256);
+    },
+    integration: async () => {
+      const candidate = validateRun88PackagedStageIdentity(stageManifest());
+      const rollback = validatePublicRollbackTarget(rollbackTarget());
+      expect(candidate.channel).toBe(rollback.channel);
+      expect(candidate.source_tree).not.toBe(rollback.ref);
+      return {
+        acceptanceId: "R9-AC05",
+        layer: "integration",
+        enforcement: "phase5-forward-repair-rerun-required",
+      };
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PackagedStageIdentity(
+          stageManifest({ private_distribution_sha256: "f".repeat(64) }),
+        ),
+      ).toThrow(/distribution/i);
+    },
+  }),
+  "R9-AC06": Object.freeze({
+    unit: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await expect(
+          outbox.drain(async () => {
+            throw new Error("attempt-1 failed");
+          }),
+        ).rejects.toThrow(/attempt-1/);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1, receiptCount: 0 });
+      });
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await expect(
+          outbox.drain(async () => Promise.reject(new Error("partial attempt"))),
+        ).rejects.toThrow(/partial/);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1 });
+        await outbox.drain(async () => ({ status: "authoritative-success" }));
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 0, receiptCount: 1 });
+      });
+      return {
+        acceptanceId: "R9-AC06",
+        layer: "integration",
+        enforcement: "phase5-immutable-failed-attempt-receipts-required",
+      };
+    },
+    regression: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await outbox.drain(async () => ({ status: "passed" }));
+        await enqueueCorrelatedObservation(outbox);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 0, receiptCount: 1 });
+      });
+    },
+  }),
+  "R10-AC01": Object.freeze({
+    unit: async () => {
+      expect(compatibleDistribution("N")).toEqual({
+        available: true,
+        compatible: true,
+        generation: "N",
+      });
+      expect(compatibleDistribution("N-1").generation).toBe("N-1");
+    },
+    integration: async () => {
+      expect(validateRun88PackagedStageIdentity(stageManifest()).channel).toBe("stage");
+      expect(compatibleDistribution("N-1").compatible).toBe(true);
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PrivateDistributionIdentity(
+          { generation: "N+1", manifestSha256, channel: "stage" },
+          expectedDistribution,
+        ),
+      ).toThrow(/generation/i);
+    },
+  }),
+  "R10-AC02": Object.freeze({
+    unit: async () => {
+      expect(compatibleDistribution("N").generation).toBe("N");
+      expect(compatibleDistribution("N-1").generation).toBe("N-1");
+    },
+    integration: async () => {
+      const packageN = validatePublicStageIdentity(packageIdentity());
+      const packagePrevious = validatePublicStageIdentity(
+        packageIdentity({
+          privateDistribution: {
+            ...(packageIdentity().privateDistribution as Record<string, unknown>),
+            generation: "N-1",
+          },
+        }),
+      );
+      expect(packageN.privateDistribution.generation).toBe("N");
+      expect(packagePrevious.privateDistribution.generation).toBe("N-1");
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PrivateDistributionIdentity(
+          { generation: "future", manifestSha256, channel: "stage" },
+          expectedDistribution,
+        ),
+      ).toThrow(/generation/i);
+    },
+  }),
+  "R10-AC03": Object.freeze({
+    unit: async () => {
+      expect(validateRun88PrivateDistributionIdentity(null, expectedDistribution)).toMatchObject({
+        available: false,
+        compatible: false,
+        degradation: "public-routing-only",
+      });
+    },
+    integration: async () => {
+      expect(validateRun88PrivateDistributionIdentity(null, expectedDistribution).degradation).toBe(
+        "public-routing-only",
+      );
+      expect(validateRun88PackagedStageIdentity(stageManifest()).name).toBe("role-model-stage");
+    },
+    regression: async () => {
+      expect(() =>
+        validateRun88PrivateDistributionIdentity(
+          { generation: "N", manifestSha256: "d".repeat(64), channel: "stage" },
+          expectedDistribution,
+        ),
+      ).toThrow(/manifest/i);
+    },
+  }),
+  "R10-AC04": Object.freeze({
+    unit: async () => {
+      expect(correlation()).toMatchObject({
+        schemaVersion: "run88-correlation.v1",
+        runtimeChannel: "staging",
+      });
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await outbox.drain(async (item) => ({
+          correlationVersion: item.run88Correlation?.schemaVersion,
+        }));
+        const state = await outbox.read();
+        expect(state.receipts[0]?.result).toEqual({ correlationVersion: "run88-correlation.v1" });
+      });
+      expect(compatibleDistribution("N-1").compatible).toBe(true);
+    },
+    regression: async () => {
+      expect(() =>
+        normalizeRun88RuntimeCorrelation(
+          { ...correlation(), schemaVersion: "run88-correlation.v2" },
+          releaseId,
+        ),
+      ).toThrow(/schema/i);
+      await withDurableOutbox(async (outbox) => {
+        await expect(
+          outbox.enqueue({
+            requestId: "request-1",
+            routingDecisionId: "decision-1",
+            endpointId: "endpoint-1",
+            run88Correlation: { ...correlation(), schemaVersion: "run88-correlation.v2" },
+          }),
+        ).rejects.toThrow(/schema/i);
+      });
+    },
+  }),
+  "R10-AC05": Object.freeze({
+    unit: async () => {
+      await expect(
+        runTrackBShadowPipeline(shadowRuntime, shadowInput({ channel: "production" }) as never),
+      ).rejects.toThrow(/shadow-only|production/i);
+    },
+    integration: async () => {
+      const input = shadowInput();
+      const result = await runTrackBShadowPipeline(shadowRuntime, input as never);
+      expect(result.productionState).toEqual(input.productionState);
+      expect(result.receipt).toMatchObject({
+        mode: "shadow",
+        providerCalls: 0,
+        productionMutation: false,
+      });
+    },
+    regression: async () => {
+      await expect(
+        runTrackBShadowPipeline(shadowRuntime, shadowInput({ routePackage: "" }) as never),
+      ).rejects.toThrow(/identity/i);
+      expect(compatibleDistribution("N").compatible).toBe(true);
+      expect(compatibleDistribution("N-1").compatible).toBe(true);
+    },
+  }),
+  "R11-AC04": Object.freeze({
+    unit: async () => {
+      expect(() => validateRun88PackagedStageIdentity(stageManifest())).not.toThrow();
+      expect(() =>
+        validateRun88PackagedStageIdentity(stageManifest({ release_id: "missing" })),
+      ).toThrow(/release/i);
+    },
+    integration: async () => {
+      const packageValue = validateRun88PackagedStageIdentity(stageManifest());
+      const distribution = compatibleDistribution("N");
+      expect(packageValue.private_distribution_sha256).toBe(manifestSha256);
+      expect(distribution.compatible).toBe(true);
+    },
+    regression: async () => {
+      for (const invalid of [
+        stageManifest({ channel: "stage", name: "production" }),
+        stageManifest({ private_distribution_sha256: "f".repeat(64) }),
+        stageManifest({ source_tree: "bad" }),
+      ])
+        expect(() => validateRun88PackagedStageIdentity(invalid)).toThrow();
+    },
+  }),
+  "R11-AC05": Object.freeze({
+    unit: async () => {
+      const envelope = correlation();
+      expect(normalizeRun88RuntimeCorrelation(envelope, releaseId).deploymentId).toBe(
+        "local-stage-runtime",
+      );
+    },
+    integration: async () => {
+      await withDurableOutbox(async (outbox) => {
+        const original = await enqueueCorrelatedObservation(outbox);
+        await outbox.drain(async (item) => {
+          expect(item.run88Correlation).toEqual(original.run88Correlation);
+          return { status: "actual-boundary-crossed" };
+        });
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 0, receiptCount: 1 });
+      });
+    },
+    regression: async () => {
+      await withDurableOutbox(async (outbox) => {
+        await enqueueCorrelatedObservation(outbox);
+        await expect(
+          outbox.drain(async () => {
+            throw new Error("private process boundary unavailable");
+          }),
+        ).rejects.toThrow(/unavailable/);
+        await expect(outbox.read()).resolves.toMatchObject({ pendingCount: 1, receiptCount: 0 });
+      });
+    },
+  }),
+  "R14-AC06": Object.freeze({
+    unit: async () => {
+      const source = await readFile(
+        new URL("../../../../scripts/run88-run-focused-tests.mjs", import.meta.url),
+        "utf8",
+      );
+      expect(source).toContain('for (const layer of ["unit", "integration", "regression"])');
+      expect(source).toContain("const PLANS = Object.freeze");
+    },
+    integration: async () => {
+      const source = await readFile(
+        new URL("../../../../scripts/run88-run-focused-tests.mjs", import.meta.url),
+        "utf8",
+      );
+      expect(source).toContain("workflow: {");
+      expect(source).toContain("package: {");
+      expect(source).toContain("runtime: {");
+    },
+    regression: async () => {
+      const source = await readFile(
+        new URL("../../../../scripts/run88-run-focused-tests.mjs", import.meta.url),
+        "utf8",
+      );
+      expect(source).toContain("focused GREEN failed layers");
+      expect(source).toContain("focused RED unexpectedly passed every layer");
+    },
+  }),
+});
+
+export async function runPublicRuntimeAcceptanceProbe(acceptanceId: string, layer: string) {
+  expect(["unit", "integration", "regression"]).toContain(layer);
+  const record = publicRuntimeAcceptanceProbes[acceptanceId];
+  expect(record, `no exact public runtime probe for ${acceptanceId}`).toBeDefined();
+  const probe = record?.[layer as keyof ProbeLayers];
+  expect(typeof probe, `no exact ${layer} runtime probe for ${acceptanceId}`).toBe("function");
+  return probe?.();
+}

--- a/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.integration.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.integration.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { validateRun88PrivateDistributionIdentity } from "../src/kw-private-loader.js";
+import { normalizeRun88RuntimeCorrelation } from "../src/track-b-runtime.js";
+import { runPublicRuntimeAcceptanceProbe } from "./run88-public-runtime-probes.js";
+
+const ids = [
+  "R4-AC06",
+  "R5-AC01",
+  "R7-AC03",
+  "R8-AC03",
+  "R10-AC01",
+  "R10-AC03",
+  "R10-AC04",
+  "R10-AC05",
+  "R11-AC05",
+  "R2-AC02",
+  "R2-AC03",
+  "R2-AC04",
+  "R4-AC05",
+  "R6-AC06",
+  "R8-AC05",
+  "R9-AC01",
+  "R9-AC02",
+  "R9-AC03",
+  "R9-AC04",
+  "R9-AC05",
+  "R9-AC06",
+  "R10-AC02",
+  "R11-AC04",
+  "R14-AC06",
+];
+const releaseId = `sha256:${"a".repeat(64)}`;
+const envelope = {
+  schemaVersion: "run88-correlation.v1",
+  eventId: "event",
+  correlationId: "correlation",
+  traceId: "1".repeat(32),
+  spanId: "2".repeat(16),
+  causalParentId: "root",
+  service: "runtime-host-bridge",
+  operation: "private.invoke",
+  runtimeChannel: "staging",
+  scopeHash: `sha256:${"3".repeat(64)}`,
+  cohort: "stage-1pct",
+  releaseId,
+  sourceId: "4".repeat(40),
+  deploymentId: "local-stage",
+  attempt: 1,
+  outcome: "accepted",
+  timestamp: "2026-08-02T00:00:00.000Z",
+  durationMs: 1,
+};
+
+describe("Run 88 public integration ownership", () => {
+  for (const acceptanceId of ids) {
+    it(`RUN88-I-PUB-${acceptanceId}`, () =>
+      runPublicRuntimeAcceptanceProbe(acceptanceId, "integration"));
+  }
+});

--- a/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.regression.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.regression.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { validateRun88PrivateDistributionIdentity } from "../src/kw-private-loader.js";
+import { normalizeRun88RuntimeCorrelation } from "../src/track-b-runtime.js";
+import { runPublicRuntimeAcceptanceProbe } from "./run88-public-runtime-probes.js";
+
+const ids = [
+  "R4-AC06",
+  "R5-AC01",
+  "R7-AC03",
+  "R8-AC03",
+  "R10-AC01",
+  "R10-AC03",
+  "R10-AC04",
+  "R10-AC05",
+  "R11-AC05",
+];
+const releaseId = `sha256:${"a".repeat(64)}`;
+const envelope = {
+  schemaVersion: "run88-correlation.v1",
+  eventId: "event",
+  correlationId: "correlation",
+  traceId: "1".repeat(32),
+  spanId: "2".repeat(16),
+  causalParentId: "root",
+  service: "runtime-host-bridge",
+  operation: "private.invoke",
+  runtimeChannel: "staging",
+  scopeHash: `sha256:${"3".repeat(64)}`,
+  cohort: "stage-1pct",
+  releaseId,
+  sourceId: "4".repeat(40),
+  deploymentId: "local-stage",
+  attempt: 1,
+  outcome: "accepted",
+  timestamp: "2026-08-02T00:00:00.000Z",
+  durationMs: 1,
+};
+
+describe("Run 88 public runtime regressions", () => {
+  for (const acceptanceId of ids) {
+    it(`RUN88-R-PUB-${acceptanceId}`, () =>
+      runPublicRuntimeAcceptanceProbe(acceptanceId, "regression"));
+  }
+});

--- a/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
@@ -1,0 +1,325 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateRun88PrivateDistributionIdentity } from "../src/kw-private-loader.js";
+import * as runtimeVersion from "../src/runtime-version.js";
+import * as trackBRuntime from "../src/track-b-runtime.js";
+import {
+  publicRuntimeAcceptanceProbes,
+  runPublicRuntimeAcceptanceProbe,
+} from "./run88-public-runtime-probes.js";
+
+const { resolveRuntimeVersionInfo } = runtimeVersion;
+const { createTrackBPostObservationOutbox, normalizeRun88RuntimeCorrelation } = trackBRuntime;
+
+const roots: string[] = [];
+afterEach(async () =>
+  Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))),
+);
+
+describe("Run 88 stage release boundary", () => {
+  it("public runtime probes are criterion-specific at every required layer", () => {
+    const expected = [
+      "R2-AC02",
+      "R2-AC03",
+      "R2-AC04",
+      "R4-AC05",
+      "R4-AC06",
+      "R5-AC01",
+      "R6-AC06",
+      "R7-AC03",
+      "R8-AC03",
+      "R8-AC05",
+      "R9-AC01",
+      "R9-AC02",
+      "R9-AC03",
+      "R9-AC04",
+      "R9-AC05",
+      "R9-AC06",
+      "R10-AC01",
+      "R10-AC02",
+      "R10-AC03",
+      "R10-AC04",
+      "R10-AC05",
+      "R11-AC04",
+      "R11-AC05",
+      "R14-AC06",
+    ];
+    expect(Object.keys(publicRuntimeAcceptanceProbes).sort()).toEqual(expected.sort());
+    for (const layer of ["unit", "integration", "regression"] as const) {
+      const probes = expected.map((id) => publicRuntimeAcceptanceProbes[id]?.[layer]);
+      expect(probes.every((probe) => typeof probe === "function")).toBe(true);
+      expect(new Set(probes).size).toBe(expected.length);
+    }
+  });
+  const fullCorrelation = () => ({
+    schemaVersion: "run88-correlation.v1",
+    eventId: "event-1",
+    correlationId: "corr-1",
+    traceId: "1".repeat(32),
+    spanId: "2".repeat(16),
+    causalParentId: "root",
+    service: "runtime-host-bridge",
+    operation: "private-distribution.invoke",
+    runtimeChannel: "staging",
+    scopeHash: `sha256:${"3".repeat(64)}`,
+    cohort: "stage-1pct",
+    releaseId: `sha256:${"a".repeat(64)}`,
+    sourceId: "4".repeat(40),
+    deploymentId: "local-stage-runtime",
+    attempt: 1,
+    outcome: "accepted",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    durationMs: 1,
+  });
+  it("RUN88-U-PUB-R10-AC01 accepts N/N and N/N-1, degrades when private is absent, and refuses mixed identity", () => {
+    expect(typeof validateRun88PrivateDistributionIdentity).toBe("function");
+    const expected = {
+      channel: "stage",
+      manifestSha256: "a".repeat(64),
+      publicGeneration: "N" as const,
+    };
+    expect(
+      validateRun88PrivateDistributionIdentity(
+        { generation: "N", manifestSha256: "a".repeat(64), channel: "stage" },
+        expected,
+      ).compatible,
+    ).toBe(true);
+    expect(
+      validateRun88PrivateDistributionIdentity(
+        { generation: "N-1", manifestSha256: "a".repeat(64), channel: "stage" },
+        expected,
+      ).compatible,
+    ).toBe(true);
+    expect(validateRun88PrivateDistributionIdentity(null, expected)).toEqual({
+      available: false,
+      compatible: false,
+      degradation: "public-routing-only",
+    });
+    expect(() =>
+      validateRun88PrivateDistributionIdentity(
+        { generation: "N+1", manifestSha256: "a".repeat(64), channel: "stage" },
+        expected,
+      ),
+    ).toThrow(/generation/i);
+    expect(() =>
+      validateRun88PrivateDistributionIdentity(
+        { generation: "N", manifestSha256: "b".repeat(64), channel: "stage" },
+        expected,
+      ),
+    ).toThrow(/manifest/i);
+  });
+
+  it("RUN88-U-PUB-R2-AC03 rejects every partial packaged stage identity field", () => {
+    expect(typeof runtimeVersion.validateRun88PackagedStageIdentity).toBe("function");
+    const complete = {
+      channel: "stage",
+      name: "role-model-stage",
+      host: "127.0.0.1",
+      port: 3457,
+      endpoint: "http://127.0.0.1:3457",
+      state_root_name: "role-model-runtime-stage",
+      scope_id: "standalone-runtime-stage",
+      source_tree: "1".repeat(40),
+      executable_sha256: "2".repeat(64),
+      core_payload_sha256: "3".repeat(64),
+      release_id: `sha256:${"4".repeat(64)}`,
+      private_distribution_sha256: "5".repeat(64),
+      track_b_runtime: { manifest_sha256: "5".repeat(64) },
+    };
+    expect(runtimeVersion.validateRun88PackagedStageIdentity(complete).endpoint).toBe(
+      complete.endpoint,
+    );
+    for (const field of [
+      "channel",
+      "name",
+      "host",
+      "port",
+      "endpoint",
+      "state_root_name",
+      "scope_id",
+      "source_tree",
+      "executable_sha256",
+      "core_payload_sha256",
+      "release_id",
+      "private_distribution_sha256",
+      "track_b_runtime",
+    ] as const) {
+      const partial = { ...complete } as Record<string, unknown>;
+      delete partial[field];
+      expect(() => runtimeVersion.validateRun88PackagedStageIdentity(partial)).toThrow(
+        /stage|identity|missing|invalid|distribution/i,
+      );
+    }
+  });
+
+  it("RUN88-U-PUB-R7-AC03 refuses provider success without signed Pi CLI process proof", () => {
+    const validate = (
+      trackBRuntime as unknown as {
+        validateRun88ProviderResponseObservation: (
+          observation: Readonly<Record<string, unknown>>,
+          provenance: Readonly<Record<string, unknown>>,
+        ) => unknown;
+      }
+    ).validateRun88ProviderResponseObservation;
+    expect(() =>
+      validate(
+        {
+          requestId: "api-only-request",
+          clientRequestId: "api-only-client-request",
+          routingDecisionId: "decision-1",
+          endpointId: "provider-endpoint",
+          executionTelemetry: { providerFamily: "openai" },
+          inspection: {
+            request: {
+              requestId: "api-only-request",
+              clientRequestId: "api-only-client-request",
+              routingDecisionId: "decision-1",
+              requestCapture: { headers: {}, body: { model: "gpt" } },
+              responseCapture: { statusCode: 200, body: { output: "provider output" } },
+            },
+          },
+        },
+        { source: "routed-execution-callback" },
+      ),
+    ).toThrow(/Pi|invocation|proof|authority/i);
+  });
+
+  it("RUN88-U-PUB-R5-AC01 preserves the versioned correlation envelope at the public/private boundary", () => {
+    expect(typeof normalizeRun88RuntimeCorrelation).toBe("function");
+    const envelope = fullCorrelation();
+    expect(normalizeRun88RuntimeCorrelation(envelope, envelope.releaseId)).toEqual(envelope);
+    expect(() =>
+      normalizeRun88RuntimeCorrelation({ ...envelope, prompt: "raw" }, envelope.releaseId),
+    ).toThrow(/field/i);
+    expect(() =>
+      normalizeRun88RuntimeCorrelation(
+        { ...envelope, releaseId: `sha256:${"b".repeat(64)}` },
+        envelope.releaseId,
+      ),
+    ).toThrow(/release/i);
+    for (const field of [
+      "eventId",
+      "service",
+      "operation",
+      "scopeHash",
+      "cohort",
+      "deploymentId",
+      "attempt",
+      "outcome",
+      "timestamp",
+      "durationMs",
+    ]) {
+      const incomplete = { ...envelope } as Record<string, unknown>;
+      delete incomplete[field];
+      expect(() => normalizeRun88RuntimeCorrelation(incomplete, envelope.releaseId)).toThrow(
+        new RegExp(field, "i"),
+      );
+    }
+  });
+
+  it("stage runtime constructs correlation at actual ingress and the durable outbox preserves it", async () => {
+    const createRun88RuntimeCorrelation = (
+      trackBRuntime as unknown as {
+        createRun88RuntimeCorrelation?: (input: Record<string, unknown>) => Record<string, unknown>;
+      }
+    ).createRun88RuntimeCorrelation;
+    expect(typeof createRun88RuntimeCorrelation).toBe("function");
+    const correlation = createRun88RuntimeCorrelation?.({
+      requestId: "request-1",
+      routingDecisionId: "decision-1",
+      releaseId: `sha256:${"a".repeat(64)}`,
+      sourceId: "b".repeat(40),
+      deploymentId: "local-stage-runtime",
+      scope: "synthetic-stage-scope",
+      timestamp: "2026-08-02T00:00:00.000Z",
+    });
+    const root = path.join(os.tmpdir(), `run88-outbox-${process.pid}-${Date.now()}`);
+    roots.push(root);
+    await mkdir(root, { recursive: true });
+    const outbox = createTrackBPostObservationOutbox({ filePath: path.join(root, "outbox.json") });
+    await outbox.enqueue({
+      requestId: "request-1",
+      routingDecisionId: "decision-1",
+      endpointId: "endpoint-1",
+      run88Correlation: correlation,
+    });
+    let observed: Readonly<Record<string, unknown>> | undefined;
+    await outbox.drain(async (item) => {
+      observed = item;
+      return { status: "observed" };
+    });
+    expect(observed?.run88Correlation).toEqual(correlation);
+  });
+
+  it("packaged stage identity fails closed when release or private-distribution binding is missing", () => {
+    const validateRun88PackagedStageIdentity = (
+      runtimeVersion as unknown as {
+        validateRun88PackagedStageIdentity?: (
+          manifest: Record<string, unknown>,
+        ) => Readonly<Record<string, unknown>>;
+      }
+    ).validateRun88PackagedStageIdentity;
+    expect(typeof validateRun88PackagedStageIdentity).toBe("function");
+    expect(() =>
+      validateRun88PackagedStageIdentity?.({
+        channel: "stage",
+        name: "role-model-stage",
+        port: 3457,
+      }),
+    ).toThrow(/release|distribution|endpoint|state|scope/i);
+    expect(
+      validateRun88PackagedStageIdentity?.({
+        channel: "stage",
+        name: "role-model-stage",
+        host: "127.0.0.1",
+        port: 3457,
+        endpoint: "http://127.0.0.1:3457",
+        state_root_name: "role-model-runtime-stage",
+        scope_id: "standalone-runtime-stage",
+        release_id: `sha256:${"a".repeat(64)}`,
+        private_distribution_sha256: "b".repeat(64),
+        source_tree: "c".repeat(40),
+        executable_sha256: "d".repeat(64),
+        core_payload_sha256: "e".repeat(64),
+        track_b_runtime: { manifest_sha256: "b".repeat(64) },
+      }),
+    ).toMatchObject({ channel: "stage" });
+  });
+
+  it("reports release and private-distribution identity through runtime version metadata", async () => {
+    const root = path.join(os.tmpdir(), `run88-version-${process.pid}-${Date.now()}`);
+    roots.push(root);
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      path.join(root, "manifest.json"),
+      JSON.stringify({
+        version: "1.1.0",
+        commit: "a".repeat(40),
+        build_date: "2026-08-02T00:00:00.000Z",
+        release_id: `sha256:${"b".repeat(64)}`,
+        private_distribution_sha256: "c".repeat(64),
+      }),
+    );
+    const value = await resolveRuntimeVersionInfo({ repoRoot: root });
+    expect(value.release_id).toBe(`sha256:${"b".repeat(64)}`);
+    expect(value.private_distribution_sha256).toBe("c".repeat(64));
+  });
+
+  {
+    const acceptances = [
+      "R4-AC06",
+      "R7-AC03",
+      "R8-AC03",
+      "R10-AC03",
+      "R10-AC04",
+      "R10-AC05",
+      "R11-AC05",
+    ];
+    for (const acceptanceId of acceptances) {
+      it(`RUN88-U-PUB-${acceptanceId}`, () =>
+        runPublicRuntimeAcceptanceProbe(acceptanceId, "unit"));
+    }
+  }
+});

--- a/scripts/run88-format-regression.test.mjs
+++ b/scripts/run88-format-regression.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const run88LintPaths = Object.freeze([
+  ".github/workflows/build-binaries.yml",
+  ".github/workflows/ci.yml",
+  "role-model-router/apps/runtime-host-bridge/src/cli.ts",
+  "role-model-router/apps/runtime-host-bridge/src/kw-private-loader.ts",
+  "role-model-router/apps/runtime-host-bridge/src/package-sea.ts",
+  "role-model-router/apps/runtime-host-bridge/src/runtime-version.ts",
+  "role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts",
+  "role-model-router/apps/runtime-host-bridge/test/recursive-87-compatibility.test.ts",
+  "role-model-router/apps/runtime-host-bridge/test/run88-public-runtime-probes.ts",
+  "role-model-router/apps/runtime-host-bridge/test/run88-stage-release.integration.test.ts",
+  "role-model-router/apps/runtime-host-bridge/test/run88-stage-release.regression.test.ts",
+  "role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts",
+  "scripts/run88-format-regression.test.mjs",
+  "scripts/run88-public-semantic-probes.mjs",
+  "scripts/run88-run-focused-tests.mjs",
+  "scripts/run88-run-focused-tests.test.mjs",
+  "scripts/run88-stage-release-regression.test.mjs",
+  "scripts/run88-stage-release-workflow.integration.test.mjs",
+  "scripts/run88-stage-release-workflow.regression.test.mjs",
+  "scripts/run88-stage-release-workflow.test.mjs",
+  "scripts/run88-stage-release.mjs",
+  "scripts/run88-stage-release.test.mjs",
+]);
+
+test("Run 88 public release paths remain formatter- and linter-clean", () => {
+  const [executable, args] =
+    process.platform === "win32"
+      ? [
+          "cmd.exe",
+          ["/d", "/s", "/c", "corepack", "pnpm", "exec", "biome", "check", ...run88LintPaths],
+        ]
+      : ["corepack", ["pnpm", "exec", "biome", "check", ...run88LintPaths]];
+  const result = spawnSync(executable, args, {
+    cwd: new URL("..", import.meta.url),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, [result.stdout, result.stderr].filter(Boolean).join("\n"));
+});

--- a/scripts/run88-public-semantic-probes.mjs
+++ b/scripts/run88-public-semantic-probes.mjs
@@ -1,0 +1,651 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import {
+  validatePublicRollbackTarget,
+  validatePublicStageIdentity,
+} from "./run88-stage-release.mjs";
+
+const sha = (character) => character.repeat(64);
+const ref = (character) => character.repeat(40);
+
+const stageIdentity = (overrides = {}) => ({
+  schemaVersion: "run88-public-stage-identity.v1",
+  channel: "stage",
+  name: "role-model-stage",
+  port: 3457,
+  publicSource: ref("a"),
+  publicSourceTree: ref("b"),
+  privateDistribution: {
+    generation: "N",
+    manifestSha256: sha("c"),
+    sidecarSha256: sha("d"),
+  },
+  package: {
+    executableSha256: sha("e"),
+    corePayloadSha256: sha("f"),
+    embeddedPrivateManifestSha256: sha("c"),
+  },
+  ...overrides,
+});
+
+const rollbackTarget = (overrides = {}) => ({
+  channel: "stage",
+  ref: ref("1"),
+  sourceTree: ref("2"),
+  packageSha256: sha("3"),
+  compatibilityGeneration: "N",
+  ...overrides,
+});
+
+async function workflowBytes() {
+  const [ci, binaries] = await Promise.all([
+    readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"),
+    readFile(new URL("../.github/workflows/build-binaries.yml", import.meta.url), "utf8"),
+  ]);
+  return Object.freeze({ ci, binaries, combined: `${ci}\n${binaries}` });
+}
+
+function lines(text) {
+  return text.split(/\r?\n/).map((line) => line.trim());
+}
+
+export const publicAcceptanceProbes = Object.freeze({
+  "R1-AC03": Object.freeze({
+    unit: async () => {
+      const { ci, binaries } = await workflowBytes();
+      assert.ok(lines(ci).includes("promotion-guard:"));
+      assert.ok(lines(binaries).includes("- stage"));
+      assert.ok(binaries.includes("github.ref_name == 'stage' && 'stage'"));
+      return { acceptanceId: "R1-AC03", layer: "unit", enforcement: "workflow-bytes" };
+    },
+    integration: async () => {
+      const { ci, binaries } = await workflowBytes();
+      assert.ok(ci.includes("ROLE_MODEL_PAIRED_PRIVATE_SHA"));
+      assert.ok(binaries.includes("Validate exact private stage revision"));
+      assert.ok(binaries.includes("Bind canonical Run 88 identity into stage package"));
+      return {
+        acceptanceId: "R1-AC03",
+        layer: "integration",
+        enforcement: "paired-stage-workflow",
+      };
+    },
+    regression: async () => {
+      const { combined } = await workflowBytes();
+      assert.ok(combined.includes('BASE_REF" == "stage"'));
+      assert.ok(combined.includes('HEAD_REF" != "dev"'));
+      assert.ok(!combined.includes("environment: production"));
+      assert.ok(!combined.includes("wrangler deploy"));
+      return { acceptanceId: "R1-AC03", layer: "regression", enforcement: "production-refusal" };
+    },
+  }),
+  "R2-AC02": Object.freeze({
+    unit: async () => {
+      const identity = validatePublicStageIdentity(stageIdentity());
+      assert.equal(
+        identity.privateDistribution.manifestSha256,
+        identity.package.embeddedPrivateManifestSha256,
+      );
+      return { acceptanceId: "R2-AC02", layer: "unit", enforcement: "distribution-binding" };
+    },
+    integration: async () => {
+      const { binaries } = await workflowBytes();
+      assert.ok(binaries.includes("ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT"));
+      assert.ok(binaries.includes("ROLE_MODEL_PRIVATE_DISTRIBUTION_MANIFEST_SHA256"));
+      assert.ok(binaries.includes("package/private distribution mismatch"));
+      return {
+        acceptanceId: "R2-AC02",
+        layer: "integration",
+        enforcement: "packaged-distribution",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () =>
+          validatePublicStageIdentity(
+            stageIdentity({
+              package: { ...stageIdentity().package, embeddedPrivateManifestSha256: sha("0") },
+            }),
+          ),
+        /distribution/i,
+      );
+      return { acceptanceId: "R2-AC02", layer: "regression", enforcement: "source-only-refusal" };
+    },
+  }),
+  "R2-AC03": Object.freeze({
+    unit: async () => {
+      const identity = validatePublicStageIdentity(stageIdentity());
+      assert.deepEqual(
+        [identity.channel, identity.name, identity.port],
+        ["stage", "role-model-stage", 3457],
+      );
+      return { acceptanceId: "R2-AC03", layer: "unit", enforcement: "stage-endpoint-identity" };
+    },
+    integration: async () => {
+      const identity = validatePublicStageIdentity(stageIdentity());
+      assert.equal(identity.publicSource.length, 40);
+      assert.equal(identity.package.executableSha256.length, 64);
+      assert.equal(identity.package.corePayloadSha256.length, 64);
+      return {
+        acceptanceId: "R2-AC03",
+        layer: "integration",
+        enforcement: "package-byte-identity",
+      };
+    },
+    regression: async () => {
+      assert.throws(() => validatePublicStageIdentity(stageIdentity({ port: 3456 })), /stage/i);
+      assert.throws(
+        () => validatePublicStageIdentity(stageIdentity({ name: "role-model" })),
+        /stage/i,
+      );
+      return { acceptanceId: "R2-AC03", layer: "regression", enforcement: "non-stage-refusal" };
+    },
+  }),
+  "R2-AC04": Object.freeze({
+    unit: async () => {
+      const first = validatePublicStageIdentity(stageIdentity());
+      const second = validatePublicStageIdentity(structuredClone(stageIdentity()));
+      assert.equal(first.identitySha256, second.identitySha256);
+      return { acceptanceId: "R2-AC04", layer: "unit", enforcement: "deterministic-identity" };
+    },
+    integration: async () => {
+      const original = stageIdentity();
+      const reordered = Object.fromEntries(Object.entries(original).reverse());
+      assert.equal(
+        validatePublicStageIdentity(original).identitySha256,
+        validatePublicStageIdentity(reordered).identitySha256,
+      );
+      return { acceptanceId: "R2-AC04", layer: "integration", enforcement: "canonical-bytes" };
+    },
+    regression: async () => {
+      const original = validatePublicStageIdentity(stageIdentity()).identitySha256;
+      const changed = validatePublicStageIdentity(
+        stageIdentity({ package: { ...stageIdentity().package, corePayloadSha256: sha("9") } }),
+      ).identitySha256;
+      assert.notEqual(original, changed);
+      return {
+        acceptanceId: "R2-AC04",
+        layer: "regression",
+        enforcement: "digest-drift-detection",
+      };
+    },
+  }),
+  "R3-AC01": Object.freeze({
+    unit: async () => {
+      const { ci } = await workflowBytes();
+      assert.ok(ci.includes('BASE_REF" == "stage"'));
+      assert.ok(ci.includes('HEAD_REF" != "dev"'));
+      return { acceptanceId: "R3-AC01", layer: "unit", enforcement: "dev-to-stage-only" };
+    },
+    integration: async () => {
+      const { ci, binaries } = await workflowBytes();
+      assert.ok(ci.includes("promotion-guard"));
+      assert.ok(binaries.includes("Validate exact private stage revision"));
+      assert.ok(binaries.includes("ROLE_MODEL_PAIRED_PRIVATE_SHA"));
+      return {
+        acceptanceId: "R3-AC01",
+        layer: "integration",
+        enforcement: "protected-promotion-bytes",
+      };
+    },
+    regression: async () => {
+      const { ci } = await workflowBytes();
+      assert.ok(ci.includes("Invalid promotion source: stage only accepts dev."));
+      assert.ok(ci.includes("exit 1"));
+      assert.ok(!ci.includes("git push --force"));
+      return { acceptanceId: "R3-AC01", layer: "regression", enforcement: "wrong-head-refusal" };
+    },
+  }),
+  "R4-AC05": Object.freeze({
+    unit: async () => {
+      const { binaries } = await workflowBytes();
+      assert.ok(binaries.includes('"phase5.mock"'));
+      assert.ok(binaries.includes("Forbidden QA/mock marker"));
+      return {
+        acceptanceId: "R4-AC05",
+        layer: "unit",
+        enforcement: "phase5-live-cloud-evidence-required",
+      };
+    },
+    integration: async () => {
+      assert.equal(validatePublicStageIdentity(stageIdentity()).channel, "stage");
+      const { combined } = await workflowBytes();
+      assert.ok(!combined.includes("wrangler deploy"));
+      assert.ok(!combined.includes("livePlatformState: true"));
+      return {
+        acceptanceId: "R4-AC05",
+        layer: "integration",
+        enforcement: "phase5-live-platform-state-required",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () => validatePublicStageIdentity(stageIdentity({ channel: "production" })),
+        /stage/i,
+      );
+      const { combined } = await workflowBytes();
+      assert.ok(!combined.includes("cloudReadiness({"));
+      return {
+        acceptanceId: "R4-AC05",
+        layer: "regression",
+        enforcement: "offline-readiness-substitution-refused",
+      };
+    },
+  }),
+  "R6-AC06": Object.freeze({
+    unit: async () => {
+      assert.equal(validatePublicRollbackTarget(rollbackTarget()).ok, true);
+      return {
+        acceptanceId: "R6-AC06",
+        layer: "unit",
+        enforcement: "phase5-measured-soak-decision-required",
+      };
+    },
+    integration: async () => {
+      const target = validatePublicRollbackTarget(
+        rollbackTarget({ compatibilityGeneration: "N-1" }),
+      );
+      assert.equal(target.channel, "stage");
+      assert.equal(target.compatibilityGeneration, "N-1");
+      return {
+        acceptanceId: "R6-AC06",
+        layer: "integration",
+        enforcement: "phase5-threshold-receipt-required",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () => validatePublicRollbackTarget(rollbackTarget({ channel: "production" })),
+        /stage/i,
+      );
+      const { binaries } = await workflowBytes();
+      assert.ok(binaries.includes("Forbidden QA/mock marker"));
+      return {
+        acceptanceId: "R6-AC06",
+        layer: "regression",
+        enforcement: "fabricated-soak-pass-refused",
+      };
+    },
+  }),
+  "R8-AC05": Object.freeze({
+    unit: async () => {
+      const { binaries } = await workflowBytes();
+      assert.ok(binaries.includes('"phase5.mock"'));
+      return {
+        acceptanceId: "R8-AC05",
+        layer: "unit",
+        enforcement: "phase5-live-outage-recovery-required",
+      };
+    },
+    integration: async () => {
+      const identity = validatePublicStageIdentity(stageIdentity());
+      assert.equal(identity.package.embeddedPrivateManifestSha256, sha("c"));
+      return {
+        acceptanceId: "R8-AC05",
+        layer: "integration",
+        enforcement: "runtime-outbox-and-live-cloud-recovery-required",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () => validatePublicRollbackTarget(rollbackTarget({ packageSha256: "not-a-digest" })),
+        /sha256/i,
+      );
+      return {
+        acceptanceId: "R8-AC05",
+        layer: "regression",
+        enforcement: "unbound-recovery-target-refused",
+      };
+    },
+  }),
+  "R9-AC01": Object.freeze({
+    unit: async () => {
+      const target = validatePublicRollbackTarget(rollbackTarget());
+      assert.deepEqual(
+        [target.ref, target.sourceTree, target.packageSha256],
+        [ref("1"), ref("2"), sha("3")],
+      );
+      return {
+        acceptanceId: "R9-AC01",
+        layer: "unit",
+        enforcement: "phase5-immutable-snapshot-required",
+      };
+    },
+    integration: async () => {
+      const current = validatePublicStageIdentity(stageIdentity());
+      const target = validatePublicRollbackTarget(rollbackTarget());
+      assert.equal(current.channel, target.channel);
+      assert.notEqual(current.publicSource, target.ref);
+      return {
+        acceptanceId: "R9-AC01",
+        layer: "integration",
+        enforcement: "candidate-and-recovery-target-bound",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () => validatePublicRollbackTarget(rollbackTarget({ sourceTree: undefined })),
+        /identity/i,
+      );
+      assert.throws(
+        () => validatePublicRollbackTarget(rollbackTarget({ packageSha256: undefined })),
+        /sha256/i,
+      );
+      return {
+        acceptanceId: "R9-AC01",
+        layer: "regression",
+        enforcement: "partial-snapshot-refused",
+      };
+    },
+  }),
+  "R9-AC02": Object.freeze({
+    unit: async () => {
+      assert.equal(validatePublicRollbackTarget(rollbackTarget()).compatibilityGeneration, "N");
+      return {
+        acceptanceId: "R9-AC02",
+        layer: "unit",
+        enforcement: "phase5-executed-order-receipts-required",
+      };
+    },
+    integration: async () => {
+      assert.equal(
+        validatePublicRollbackTarget(rollbackTarget({ compatibilityGeneration: "N-1" }))
+          .compatibilityGeneration,
+        "N-1",
+      );
+      return {
+        acceptanceId: "R9-AC02",
+        layer: "integration",
+        enforcement: "ordered-n-minus-one-target-bound",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () => validatePublicRollbackTarget(rollbackTarget({ compatibilityGeneration: "future" })),
+        /generation/i,
+      );
+      return { acceptanceId: "R9-AC02", layer: "regression", enforcement: "future-target-refused" };
+    },
+  }),
+  "R9-AC03": Object.freeze({
+    unit: async () => {
+      assert.equal(validatePublicRollbackTarget(rollbackTarget()).channel, "stage");
+      return {
+        acceptanceId: "R9-AC03",
+        layer: "unit",
+        enforcement: "phase5-executed-fault-drills-required",
+      };
+    },
+    integration: async () => {
+      const { binaries } = await workflowBytes();
+      assert.ok(binaries.includes("Verify package contains no QA fixtures or mock data"));
+      assert.ok(binaries.includes("Forbidden QA/mock marker"));
+      return {
+        acceptanceId: "R9-AC03",
+        layer: "integration",
+        enforcement: "real-package-fault-drills-only",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () => validatePublicRollbackTarget(rollbackTarget({ ref: "fault-fixture" })),
+        /identity/i,
+      );
+      return {
+        acceptanceId: "R9-AC03",
+        layer: "regression",
+        enforcement: "fixture-target-refused",
+      };
+    },
+  }),
+  "R9-AC04": Object.freeze({
+    unit: async () => {
+      assert.equal(validatePublicStageIdentity(stageIdentity()).name, "role-model-stage");
+      return {
+        acceptanceId: "R9-AC04",
+        layer: "unit",
+        enforcement: "runtime-continuity-tested-separately",
+      };
+    },
+    integration: async () => {
+      const current = validatePublicStageIdentity(stageIdentity());
+      const recovery = validatePublicRollbackTarget(rollbackTarget());
+      assert.deepEqual([current.channel, recovery.channel], ["stage", "stage"]);
+      return {
+        acceptanceId: "R9-AC04",
+        layer: "integration",
+        enforcement: "stage-continuity-identities-bound",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () => validatePublicStageIdentity(stageIdentity({ channel: "development" })),
+        /stage/i,
+      );
+      return {
+        acceptanceId: "R9-AC04",
+        layer: "regression",
+        enforcement: "cross-channel-write-refused",
+      };
+    },
+  }),
+  "R9-AC05": Object.freeze({
+    unit: async () => {
+      const candidate = validatePublicStageIdentity(stageIdentity());
+      const repaired = validatePublicStageIdentity(structuredClone(stageIdentity()));
+      assert.equal(candidate.identitySha256, repaired.identitySha256);
+      return {
+        acceptanceId: "R9-AC05",
+        layer: "unit",
+        enforcement: "same-reviewed-source-rebuild",
+      };
+    },
+    integration: async () => {
+      const candidate = validatePublicStageIdentity(stageIdentity());
+      const recovery = validatePublicRollbackTarget(rollbackTarget());
+      assert.notEqual(candidate.publicSource, recovery.ref);
+      assert.equal(candidate.channel, recovery.channel);
+      return {
+        acceptanceId: "R9-AC05",
+        layer: "integration",
+        enforcement: "phase5-forward-repair-rerun-required",
+      };
+    },
+    regression: async () => {
+      const first = validatePublicStageIdentity(stageIdentity()).identitySha256;
+      const mixed = validatePublicStageIdentity(
+        stageIdentity({ publicSource: ref("9") }),
+      ).identitySha256;
+      assert.notEqual(first, mixed);
+      return { acceptanceId: "R9-AC05", layer: "regression", enforcement: "mixed-source-detected" };
+    },
+  }),
+  "R9-AC06": Object.freeze({
+    unit: async () => {
+      assert.equal(validatePublicRollbackTarget(rollbackTarget()).ok, true);
+      return {
+        acceptanceId: "R9-AC06",
+        layer: "unit",
+        enforcement: "phase5-immutable-attempt-history-required",
+      };
+    },
+    integration: async () => {
+      const { binaries } = await workflowBytes();
+      assert.ok(binaries.includes("Bind canonical Run 88 identity into stage package"));
+      assert.ok(binaries.includes("Verify package contains no QA fixtures or mock data"));
+      return {
+        acceptanceId: "R9-AC06",
+        layer: "integration",
+        enforcement: "authoritative-real-package-attempt-only",
+      };
+    },
+    regression: async () => {
+      const { combined } = await workflowBytes();
+      assert.ok(!combined.includes("attempts: [{ outcome: 'passed' }]"));
+      assert.ok(combined.includes('"phase5.mock"'));
+      return {
+        acceptanceId: "R9-AC06",
+        layer: "regression",
+        enforcement: "fabricated-success-history-refused",
+      };
+    },
+  }),
+  "R10-AC02": Object.freeze({
+    unit: async () => {
+      const current = validatePublicStageIdentity(stageIdentity());
+      const previous = validatePublicStageIdentity(
+        stageIdentity({
+          privateDistribution: { ...stageIdentity().privateDistribution, generation: "N-1" },
+        }),
+      );
+      assert.deepEqual(
+        [current.privateDistribution.generation, previous.privateDistribution.generation],
+        ["N", "N-1"],
+      );
+      return { acceptanceId: "R10-AC02", layer: "unit", enforcement: "n-and-n-minus-one" };
+    },
+    integration: async () => {
+      const identity = validatePublicStageIdentity(stageIdentity());
+      const target = validatePublicRollbackTarget(
+        rollbackTarget({ compatibilityGeneration: "N-1" }),
+      );
+      assert.deepEqual([identity.channel, target.channel], ["stage", "stage"]);
+      return {
+        acceptanceId: "R10-AC02",
+        layer: "integration",
+        enforcement: "package-to-rollback-window",
+      };
+    },
+    regression: async () => {
+      assert.throws(
+        () =>
+          validatePublicStageIdentity(
+            stageIdentity({
+              privateDistribution: { ...stageIdentity().privateDistribution, generation: "N+1" },
+            }),
+          ),
+        /generation/i,
+      );
+      return {
+        acceptanceId: "R10-AC02",
+        layer: "regression",
+        enforcement: "future-generation-refused",
+      };
+    },
+  }),
+  "R11-AC04": Object.freeze({
+    unit: async () => {
+      assert.doesNotThrow(() => validatePublicStageIdentity(stageIdentity()));
+      assert.throws(
+        () => validatePublicStageIdentity(stageIdentity({ channel: "production" })),
+        /stage/i,
+      );
+      return {
+        acceptanceId: "R11-AC04",
+        layer: "unit",
+        enforcement: "validator-happy-and-refusal",
+      };
+    },
+    integration: async () => {
+      assert.doesNotThrow(() => validatePublicRollbackTarget(rollbackTarget()));
+      assert.throws(() => validatePublicRollbackTarget(rollbackTarget({ ref: "bad" })), /ref/i);
+      return {
+        acceptanceId: "R11-AC04",
+        layer: "integration",
+        enforcement: "changed-boundary-tests",
+      };
+    },
+    regression: async () => {
+      for (const target of [
+        rollbackTarget({ channel: "production" }),
+        rollbackTarget({ packageSha256: "bad" }),
+        rollbackTarget({ compatibilityGeneration: "future" }),
+      ])
+        assert.throws(() => validatePublicRollbackTarget(target));
+      return { acceptanceId: "R11-AC04", layer: "regression", enforcement: "refusal-matrix" };
+    },
+  }),
+  "R11-AC09": Object.freeze({
+    unit: async () => {
+      const { ci } = await workflowBytes();
+      assert.ok(ci.includes("scripts/run88-stage-release.test.mjs"));
+      assert.ok(ci.includes("scripts/run88-stage-release-workflow.test.mjs"));
+      return { acceptanceId: "R11-AC09", layer: "unit", enforcement: "run88-ci-unit-gates" };
+    },
+    integration: async () => {
+      const source = await readFile(
+        new URL("./run88-run-focused-tests.mjs", import.meta.url),
+        "utf8",
+      );
+      assert.ok(source.includes("run88-stage-release-workflow.integration.test.mjs"));
+      assert.ok(source.includes("run88-stage-release.integration.test.ts"));
+      return {
+        acceptanceId: "R11-AC09",
+        layer: "integration",
+        enforcement: "run88-ci-integration-gates",
+      };
+    },
+    regression: async () => {
+      const [{ combined }, source] = await Promise.all([
+        workflowBytes(),
+        readFile(new URL("./run88-run-focused-tests.mjs", import.meta.url), "utf8"),
+      ]);
+      assert.ok(source.includes("run88-stage-release-workflow.regression.test.mjs"));
+      assert.ok(source.includes("run88-stage-release.regression.test.ts"));
+      assert.ok(!combined.includes("environment: production"));
+      return {
+        acceptanceId: "R11-AC09",
+        layer: "regression",
+        enforcement: "run88-ci-regression-gates",
+      };
+    },
+  }),
+  "R14-AC06": Object.freeze({
+    unit: async () => {
+      const source = await readFile(
+        new URL("./run88-run-focused-tests.mjs", import.meta.url),
+        "utf8",
+      );
+      assert.ok(source.includes('for (const layer of ["unit", "integration", "regression"])'));
+      assert.ok(source.includes("const PLANS = Object.freeze"));
+      return { acceptanceId: "R14-AC06", layer: "unit", enforcement: "versioned-layer-plan" };
+    },
+    integration: async () => {
+      const source = await readFile(
+        new URL("./run88-run-focused-tests.mjs", import.meta.url),
+        "utf8",
+      );
+      for (const surface of ["workflow", "package", "runtime"])
+        assert.ok(source.includes(`${surface}: {`));
+      return {
+        acceptanceId: "R14-AC06",
+        layer: "integration",
+        enforcement: "systematic-surface-registry",
+      };
+    },
+    regression: async () => {
+      const source = await readFile(
+        new URL("./run88-run-focused-tests.mjs", import.meta.url),
+        "utf8",
+      );
+      assert.ok(source.includes("focused GREEN failed layers"));
+      assert.ok(source.includes("focused RED unexpectedly passed every layer"));
+      return {
+        acceptanceId: "R14-AC06",
+        layer: "regression",
+        enforcement: "false-success-refusal",
+      };
+    },
+  }),
+});
+
+export async function runPublicAcceptanceProbe(acceptanceId, layer) {
+  assert.ok(new Set(["unit", "integration", "regression"]).has(layer), `invalid layer ${layer}`);
+  const probe = publicAcceptanceProbes[acceptanceId]?.[layer];
+  assert.equal(
+    typeof probe,
+    "function",
+    `no exact public acceptance probe for ${acceptanceId}/${layer}`,
+  );
+  return probe();
+}

--- a/scripts/run88-run-focused-tests.mjs
+++ b/scripts/run88-run-focused-tests.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const vitest = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
+const PLANS = Object.freeze({
+  workflow: {
+    unit: [process.execPath, ["--test", "scripts/run88-stage-release-workflow.test.mjs"]],
+    integration: [
+      process.execPath,
+      ["--test", "scripts/run88-stage-release-workflow.integration.test.mjs"],
+    ],
+    regression: [
+      process.execPath,
+      ["--test", "scripts/run88-stage-release-workflow.regression.test.mjs"],
+    ],
+  },
+  package: {
+    unit: [process.execPath, ["--test", "scripts/run88-stage-release.test.mjs"]],
+    integration: [
+      process.execPath,
+      [
+        vitest,
+        "run",
+        "--reporter=verbose",
+        "role-model-router/apps/runtime-host-bridge/test/run88-stage-release.integration.test.ts",
+      ],
+    ],
+    regression: [process.execPath, ["--test", "scripts/run88-stage-release-regression.test.mjs"]],
+  },
+  runtime: {
+    unit: [
+      process.execPath,
+      [
+        vitest,
+        "run",
+        "--reporter=verbose",
+        "role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts",
+      ],
+    ],
+    integration: [
+      process.execPath,
+      [
+        vitest,
+        "run",
+        "--reporter=verbose",
+        "role-model-router/apps/runtime-host-bridge/test/run88-stage-release.integration.test.ts",
+      ],
+    ],
+    regression: [
+      process.execPath,
+      [
+        vitest,
+        "run",
+        "--reporter=verbose",
+        "role-model-router/apps/runtime-host-bridge/test/run88-stage-release.regression.test.ts",
+      ],
+    ],
+  },
+});
+
+function executeLayer(layer, command) {
+  const [executable, args] = command;
+  return new Promise((resolve) => {
+    const child = spawn(executable, args, {
+      cwd: repoRoot,
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout = `${stdout}${chunk}`.slice(-65_536);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-65_536);
+    });
+    child.on("error", (error) =>
+      resolve({ layer, exitCode: -1, stdout, stderr: `${stderr}\n${error.message}` }),
+    );
+    child.on("close", (code) => resolve({ layer, exitCode: code ?? -1, stdout, stderr }));
+  });
+}
+
+export async function runFocusedTests({
+  surface,
+  acceptance,
+  expect,
+  cumulative = false,
+  execute,
+} = {}) {
+  const plan = PLANS[surface];
+  if (!plan || !/^R\d+-AC\d{2}$/.test(acceptance ?? "") || !new Set(["red", "green"]).has(expect))
+    throw new Error("focused runner arguments are invalid");
+  const results = [];
+  for (const layer of ["unit", "integration", "regression"]) {
+    results.push(await (execute ? execute(layer, plan[layer]) : executeLayer(layer, plan[layer])));
+  }
+  const failed = results.filter(({ exitCode }) => exitCode !== 0);
+  if (expect === "green" && failed.length)
+    throw new Error(`focused GREEN failed layers: ${failed.map(({ layer }) => layer).join(", ")}`);
+  if (expect === "red" && failed.length === 0)
+    throw new Error("focused RED unexpectedly passed every layer");
+  return Object.freeze({
+    schemaVersion: "run88-public-focused-tests.v1",
+    surface,
+    acceptance,
+    expected: expect,
+    cumulative: Boolean(cumulative),
+    results,
+    verdict: "PASS",
+  });
+}
+
+function arg(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+if (import.meta.url === pathToFileURL(path.resolve(process.argv[1] ?? "")).href) {
+  runFocusedTests({
+    surface: arg("--surface"),
+    acceptance: arg("--acceptance"),
+    expect: arg("--expect"),
+    cumulative: process.argv.includes("--cumulative"),
+  })
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}
+
+export const focusedTestPlans = PLANS;

--- a/scripts/run88-run-focused-tests.test.mjs
+++ b/scripts/run88-run-focused-tests.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { publicAcceptanceProbes } from "./run88-public-semantic-probes.mjs";
+const module = await import("./run88-run-focused-tests.mjs").catch(() => ({}));
+
+test("public package probes are criterion-specific at every required layer", () => {
+  const expected = [
+    "R1-AC03",
+    "R2-AC02",
+    "R2-AC03",
+    "R2-AC04",
+    "R3-AC01",
+    "R4-AC05",
+    "R6-AC06",
+    "R8-AC05",
+    "R9-AC01",
+    "R9-AC02",
+    "R9-AC03",
+    "R9-AC04",
+    "R9-AC05",
+    "R9-AC06",
+    "R10-AC02",
+    "R11-AC04",
+    "R11-AC09",
+    "R14-AC06",
+  ];
+  assert.deepEqual(Object.keys(publicAcceptanceProbes).sort(), expected.sort());
+  for (const layer of ["unit", "integration", "regression"]) {
+    const probes = expected.map((id) => publicAcceptanceProbes[id]?.[layer]);
+    assert.ok(
+      probes.every((probe) => typeof probe === "function"),
+      `missing ${layer} public package probe`,
+    );
+    assert.equal(
+      new Set(probes).size,
+      expected.length,
+      `${layer} public package probes reuse generic behavior`,
+    );
+  }
+});
+
+test("public criterion probes do not substitute generic delegates or fabricated readiness values", async () => {
+  const packageSource = await readFile(
+    new URL("./run88-public-semantic-probes.mjs", import.meta.url),
+    "utf8",
+  );
+  const runtimeSource = await readFile(
+    new URL(
+      "../role-model-router/apps/runtime-host-bridge/test/run88-public-runtime-probes.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.doesNotMatch(runtimeSource, /const delegate\s*=|packageR\d+Ac\d+\s*=\s*delegate/);
+  assert.doesNotMatch(packageSource, /function cloudReadiness|cloudReadiness\(\{\s*environment:/);
+  assert.match(runtimeSource, /validateRun88ProviderResponseObservation/);
+});
+
+test("RUN88-U-PUB-R11-AC04 focused runner always aggregates unit, integration, and regression layers", async () => {
+  assert.equal(typeof module.runFocusedTests, "function", "missing semantic focused-test runner");
+  const called = [];
+  const result = await module.runFocusedTests({
+    surface: "package",
+    acceptance: "R2-AC02",
+    expect: "red",
+    execute: async (layer) => {
+      called.push(layer);
+      return { layer, exitCode: layer === "unit" ? 1 : 0 };
+    },
+  });
+  assert.deepEqual(called, ["unit", "integration", "regression"]);
+  assert.equal(result.verdict, "PASS");
+  await assert.rejects(
+    () =>
+      module.runFocusedTests({
+        surface: "package",
+        acceptance: "R2-AC02",
+        expect: "green",
+        execute: async (layer) => ({ layer, exitCode: layer === "integration" ? 1 : 0 }),
+      }),
+    /integration/i,
+  );
+});
+
+test("focused runner emits individual Vitest acceptance IDs for auditable coverage", () => {
+  for (const surface of ["package", "runtime"]) {
+    for (const command of Object.values(module.focusedTestPlans[surface])) {
+      if (command[1][0].includes("vitest")) assert.ok(command[1].includes("--reporter=verbose"));
+    }
+  }
+});

--- a/scripts/run88-stage-release-regression.test.mjs
+++ b/scripts/run88-stage-release-regression.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { runPublicAcceptanceProbe } from "./run88-public-semantic-probes.mjs";
+
+const packageRegressionIds = [
+  "R2-AC02",
+  "R2-AC03",
+  "R2-AC04",
+  "R4-AC05",
+  "R6-AC06",
+  "R8-AC05",
+  "R9-AC01",
+  "R9-AC02",
+  "R9-AC03",
+  "R9-AC04",
+  "R9-AC05",
+  "R9-AC06",
+  "R10-AC02",
+  "R11-AC04",
+  "R14-AC06",
+];
+
+for (const acceptanceId of packageRegressionIds) {
+  test(`RUN88-R-PUB-${acceptanceId}`, () => runPublicAcceptanceProbe(acceptanceId, "regression"));
+}

--- a/scripts/run88-stage-release-workflow.integration.test.mjs
+++ b/scripts/run88-stage-release-workflow.integration.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { runPublicAcceptanceProbe } from "./run88-public-semantic-probes.mjs";
+
+test("public CI and binary workflow remain integrated", async () => {
+  const [ci, binaries] = await Promise.all([
+    readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"),
+    readFile(new URL("../.github/workflows/build-binaries.yml", import.meta.url), "utf8"),
+  ]);
+  assert.match(ci, /promotion-guard/);
+  assert.match(ci, /run88-stage-release/);
+  assert.match(binaries, /PRIVATE_PAIRED_SHA/);
+  assert.match(binaries, /private_distribution_sha256/);
+});
+
+for (const acceptanceId of ["R1-AC03", "R3-AC01", "R11-AC09"]) {
+  test(`RUN88-I-PUB-${acceptanceId}`, () => runPublicAcceptanceProbe(acceptanceId, "integration"));
+}

--- a/scripts/run88-stage-release-workflow.regression.test.mjs
+++ b/scripts/run88-stage-release-workflow.regression.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { runPublicAcceptanceProbe } from "./run88-public-semantic-probes.mjs";
+
+test("public workflow regression refuses production deployment authority", async () => {
+  const text = `${await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8")}\n${await readFile(new URL("../.github/workflows/build-binaries.yml", import.meta.url), "utf8")}`;
+  assert.doesNotMatch(text, /wrangler\s+deploy|environment:\s*production/i);
+  assert.match(text, /exact private stage revision|exact private paired revision/i);
+});
+
+for (const acceptanceId of ["R1-AC03", "R3-AC01", "R11-AC09"]) {
+  test(`RUN88-R-PUB-${acceptanceId}`, () => runPublicAcceptanceProbe(acceptanceId, "regression"));
+}

--- a/scripts/run88-stage-release-workflow.test.mjs
+++ b/scripts/run88-stage-release-workflow.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { runPublicAcceptanceProbe } from "./run88-public-semantic-probes.mjs";
+
+test("public workflow surfaces retain their Run 88 promotion and package gates", async () => {
+  const ci = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+  const binaries = await readFile(
+    new URL("../.github/workflows/build-binaries.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(ci, /run88-stage-release\.test\.mjs/);
+  assert.match(ci, /promotion-guard/);
+  assert.match(binaries, /manifest\.json/);
+  assert.match(binaries, /PRIVATE_PAIRED_SHA/);
+  assert.match(binaries, /manifest_sha256|private_distribution_sha256|run88/i);
+  assert.doesNotMatch(`${ci}\n${binaries}`, /wrangler\s+deploy|environment:\s*production/i);
+});
+
+for (const acceptanceId of ["R1-AC03", "R3-AC01", "R11-AC09"]) {
+  test(`RUN88-U-PUB-${acceptanceId}`, () => runPublicAcceptanceProbe(acceptanceId, "unit"));
+}
+
+test("stage package workflow requires and always binds the canonical Run 88 release identity", async () => {
+  const binaries = await readFile(
+    new URL("../.github/workflows/build-binaries.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    binaries,
+    /Validate Run 88 stage identity inputs[\s\S]*?RUN88_RELEASE_ID[\s\S]*?sha256:/,
+  );
+  assert.doesNotMatch(binaries, /Bind canonical Run 88 identity[\s\S]*?RUN88_RELEASE_ID\s*!=\s*''/);
+  assert.match(
+    binaries,
+    /if \(\$env:ROLE_MODEL_BUILD_CHANNEL -eq "stage"\)[\s\S]*?release_id[\s\S]*?private_distribution_sha256/,
+  );
+});

--- a/scripts/run88-stage-release.mjs
+++ b/scripts/run88-stage-release.mjs
@@ -1,0 +1,119 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const SHA256 = /^[0-9a-f]{64}$/;
+const GIT_REF = /^[0-9a-f]{40}$/;
+const canonical = (value) =>
+  JSON.stringify(value, (_key, candidate) =>
+    candidate && typeof candidate === "object" && !Array.isArray(candidate)
+      ? Object.fromEntries(Object.entries(candidate).sort(([a], [b]) => a.localeCompare(b)))
+      : candidate,
+  );
+
+function requireDigest(value, field) {
+  if (!SHA256.test(value ?? "")) throw new Error(`${field} must be a sha256 digest`);
+}
+
+export function validatePublicStageIdentity(input) {
+  if (input?.schemaVersion !== "run88-public-stage-identity.v1")
+    throw new Error("unsupported public stage identity schemaVersion");
+  if (input.channel !== "stage" || input.name !== "role-model-stage" || input.port !== 3457)
+    throw new Error("public release identity must target stage");
+  if (!GIT_REF.test(input.publicSource ?? "") || !GIT_REF.test(input.publicSourceTree ?? ""))
+    throw new Error("public source identity is incomplete");
+  if (!input.privateDistribution) throw new Error("private distribution identity is incomplete");
+  if (!new Set(["N", "N-1"]).has(input.privateDistribution.generation))
+    throw new Error("unsupported private distribution generation");
+  requireDigest(input.privateDistribution.manifestSha256, "private distribution manifest sha256");
+  requireDigest(input.privateDistribution.sidecarSha256, "private distribution sidecar sha256");
+  requireDigest(input.package?.executableSha256, "package executable sha256");
+  requireDigest(input.package?.corePayloadSha256, "package core payload sha256");
+  requireDigest(
+    input.package?.embeddedPrivateManifestSha256,
+    "package embedded private manifest sha256",
+  );
+  if (input.package.embeddedPrivateManifestSha256 !== input.privateDistribution.manifestSha256)
+    throw new Error("package/private distribution mismatch");
+  const identitySha256 = createHash("sha256").update(canonical(input)).digest("hex");
+  return Object.freeze({ ...input, identitySha256 });
+}
+
+export function validatePublicRollbackTarget(target) {
+  if (target?.channel !== "stage") throw new Error("public rollback target must be stage");
+  if (!GIT_REF.test(target.ref ?? "") || !GIT_REF.test(target.sourceTree ?? ""))
+    throw new Error("public rollback ref/source identity is invalid");
+  requireDigest(target.packageSha256, "public rollback package sha256");
+  if (!new Set(["N", "N-1"]).has(target.compatibilityGeneration))
+    throw new Error("public rollback generation is incompatible");
+  return Object.freeze({ ok: true, ...target });
+}
+
+export async function bindRun88StageManifest({
+  manifestPath,
+  releaseId,
+  privateDistributionSha256,
+} = {}) {
+  if (typeof manifestPath !== "string" || !path.isAbsolute(manifestPath))
+    throw new Error("absolute packaged manifest path is required");
+  if (!/^sha256:[0-9a-f]{64}$/.test(releaseId ?? ""))
+    throw new Error("Run 88 release id is invalid");
+  requireDigest(privateDistributionSha256, "private distribution sha256");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  if (
+    manifest.channel !== "stage" ||
+    manifest.name !== "role-model-stage" ||
+    manifest.host !== "127.0.0.1" ||
+    manifest.port !== 3457 ||
+    manifest.endpoint !== "http://127.0.0.1:3457" ||
+    manifest.state_root_name !== "role-model-runtime-stage" ||
+    manifest.scope_id !== "standalone-runtime-stage" ||
+    !/^[0-9a-f]{40}$/.test(manifest.source_tree ?? "") ||
+    !/^[0-9a-f]{64}$/.test(manifest.executable_sha256 ?? "") ||
+    !/^[0-9a-f]{64}$/.test(manifest.core_payload_sha256 ?? "")
+  )
+    throw new Error("only a complete isolated stage package may be Run 88-bound");
+  if (manifest.track_b_runtime?.manifest_sha256 !== privateDistributionSha256)
+    throw new Error("package/private distribution mismatch");
+  if (manifest.release_id && manifest.release_id !== releaseId)
+    throw new Error("package release identity is already bound differently");
+  if (
+    manifest.private_distribution_sha256 &&
+    manifest.private_distribution_sha256 !== privateDistributionSha256
+  )
+    throw new Error("package private distribution identity is already bound differently");
+  const bound = {
+    ...manifest,
+    release_id: releaseId,
+    private_distribution_sha256: privateDistributionSha256,
+  };
+  await writeFile(manifestPath, `${JSON.stringify(bound, null, 2)}\n`, "utf8");
+  return Object.freeze({
+    releaseId,
+    privateDistributionSha256,
+    manifestSha256: createHash("sha256")
+      .update(await readFile(manifestPath))
+      .digest("hex"),
+  });
+}
+
+function cliArg(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+if (import.meta.url === pathToFileURL(path.resolve(process.argv[1] ?? "")).href) {
+  const manifestPath = path.resolve(cliArg("--manifest") ?? "");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  bindRun88StageManifest({
+    manifestPath,
+    releaseId: cliArg("--release-id"),
+    privateDistributionSha256: manifest.track_b_runtime?.manifest_sha256,
+  })
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/run88-stage-release.test.mjs
+++ b/scripts/run88-stage-release.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { runPublicAcceptanceProbe } from "./run88-public-semantic-probes.mjs";
+const module = await import("./run88-stage-release.mjs").catch(() => ({}));
+
+const input = {
+  schemaVersion: "run88-public-stage-identity.v1",
+  channel: "stage",
+  name: "role-model-stage",
+  port: 3457,
+  publicSource: "a".repeat(40),
+  publicSourceTree: "b".repeat(40),
+  privateDistribution: {
+    generation: "N",
+    manifestSha256: "c".repeat(64),
+    sidecarSha256: "d".repeat(64),
+  },
+  package: {
+    executableSha256: "e".repeat(64),
+    corePayloadSha256: "f".repeat(64),
+    embeddedPrivateManifestSha256: "c".repeat(64),
+  },
+};
+
+test("RUN88-U-PUB-R2-AC02 public stage identity binds source, private distribution, and packaged bytes", () => {
+  assert.equal(
+    typeof module.validatePublicStageIdentity,
+    "function",
+    "missing semantic public stage identity",
+  );
+  const result = module.validatePublicStageIdentity(input);
+  assert.match(result.identitySha256, /^[0-9a-f]{64}$/);
+  assert.equal(result.channel, "stage");
+});
+
+test("source-only, wrong distribution, stale, mixed, tampered, future, and production identities fail", () => {
+  assert.equal(
+    typeof module.validatePublicStageIdentity,
+    "function",
+    "missing semantic public stage identity",
+  );
+  for (const bad of [
+    { ...input, channel: "production" },
+    { ...input, package: { ...input.package, embeddedPrivateManifestSha256: "0".repeat(64) } },
+    { ...input, privateDistribution: { ...input.privateDistribution, generation: "N+1" } },
+    { ...input, package: { ...input.package, executableSha256: "bad" } },
+    { ...input, privateDistribution: undefined },
+  ])
+    assert.throws(
+      () => module.validatePublicStageIdentity(bad),
+      /stage|distribution|generation|sha256|incomplete/i,
+    );
+});
+
+test("actual packaged manifest binding writes and verifies the canonical Run 88 release identity", async () => {
+  assert.equal(
+    typeof module.bindRun88StageManifest,
+    "function",
+    "missing actual package identity binder",
+  );
+  const root = await mkdtemp(path.join(os.tmpdir(), "run88-package-bind-"));
+  const manifestPath = path.join(root, "manifest.json");
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      channel: "stage",
+      name: "role-model-stage",
+      host: "127.0.0.1",
+      port: 3457,
+      endpoint: "http://127.0.0.1:3457",
+      state_root_name: "role-model-runtime-stage",
+      scope_id: "standalone-runtime-stage",
+      source_tree: "a".repeat(40),
+      executable_sha256: "e".repeat(64),
+      core_payload_sha256: "f".repeat(64),
+      track_b_runtime: { manifest_sha256: "c".repeat(64), compatibility_generation: "N" },
+    }),
+  );
+  const releaseId = `sha256:${"9".repeat(64)}`;
+  const result = await module.bindRun88StageManifest({
+    manifestPath,
+    releaseId,
+    privateDistributionSha256: "c".repeat(64),
+  });
+  const persisted = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(persisted.release_id, releaseId);
+  assert.equal(persisted.private_distribution_sha256, "c".repeat(64));
+  assert.equal(result.releaseId, releaseId);
+  await assert.rejects(
+    () =>
+      module.bindRun88StageManifest({
+        manifestPath,
+        releaseId: `sha256:${"8".repeat(64)}`,
+        privateDistributionSha256: "d".repeat(64),
+      }),
+    /distribution|mismatch/i,
+  );
+  await rm(root, { recursive: true, force: true });
+});
+
+const packageUnitIds = [
+  "R2-AC03",
+  "R2-AC04",
+  "R4-AC05",
+  "R6-AC06",
+  "R8-AC05",
+  "R9-AC01",
+  "R9-AC02",
+  "R9-AC03",
+  "R9-AC04",
+  "R9-AC05",
+  "R9-AC06",
+  "R10-AC02",
+  "R11-AC04",
+  "R14-AC06",
+];
+
+for (const acceptanceId of packageUnitIds) {
+  test(`RUN88-U-PUB-${acceptanceId}`, () => runPublicAcceptanceProbe(acceptanceId, "unit"));
+}


### PR DESCRIPTION
## What changed
- adds Run 88 stage release and immutable candidate controls
- binds the packaged runtime to private distribution and release identity
- adds unit, integration, regression, workflow, and formatting gates

## Why
This is the public half of the approved v1.1 stage release-candidate and soak run. It preserves stage isolation and keeps production and route-package activation out of scope.

## Validation
- Run 88 Node: 50/50
- Run 88 Vitest: 48/48
- full corepack pnpm ci:check: PASS
- runtime host build and Windows SEA validation: PASS
- affected isolated Playwright runtime-shell: 1/1