### PR TITLE
fix(runtime): correlate stage recommendation downloads

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -825,6 +825,15 @@ export async function main(): Promise<void> {
         staticRoot,
         runtimeStateRoot: options.runtimeStateRoot,
         runtimeChannel: packagedProfile?.channel ?? "development",
+        ...(packagedProfile?.channel === "stage"
+          ? {
+              run88StageIdentity: {
+                releaseId: String(packagedManifestRecord?.release_id ?? ""),
+                sourceId: String(packagedManifestRecord?.source_tree ?? ""),
+                executableSha256: String(packagedManifestRecord?.executable_sha256 ?? ""),
+              },
+            }
+          : {}),
       },
       {
         getBackend: () => backend,

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -127,6 +127,7 @@ import {
 import { readPackagedRuntimeProfile, resolveRuntimeChannelProfile } from "./runtime-channel.js";
 import { type RuntimeVersionInfoRecord, resolveRuntimeVersionInfo } from "./runtime-version.js";
 import { createTrackBOperations as createTrackBOperationsFromState } from "./track-b-operations.js";
+import { createRun88RuntimeCorrelation } from "./track-b-runtime.js";
 
 import {
   type ProviderRequestCapture,
@@ -3129,6 +3130,11 @@ export interface CreateRuntimeBridgeBackendOptions {
   readonly scopeId: string;
   /** Runtime deployment channel used by every durable storage authority check. */
   readonly runtimeChannel?: "development" | "stage" | "production";
+  readonly run88StageIdentity?: {
+    readonly releaseId: string;
+    readonly sourceId: string;
+    readonly executableSha256: string;
+  };
   readonly unifiedRuntimeConfigPath?: string;
   readonly networkFetcher?: typeof fetch;
   readonly fixtureRoot?: string;
@@ -22844,11 +22850,32 @@ export async function createRuntimeBridgeBackend(
       const contribution = (await operations.readContributionState()) as {
         readonly recommendationTier?: string;
       };
+      let run88CorrelationHeader: Record<string, string> = {};
+      if (runtimeChannel === "stage") {
+        const identity = options.run88StageIdentity;
+        if (!identity)
+          throw new Error("stage recommendation correlation identity is not configured");
+        const requestId = `recommendation-resolve-${randomUUID()}`;
+        const correlation = createRun88RuntimeCorrelation({
+          requestId,
+          routingDecisionId: requestId,
+          releaseId: identity.releaseId,
+          sourceId: identity.sourceId,
+          deploymentId: `local-stage:${identity.executableSha256}`,
+          scope: options.scopeId,
+          operation: "recommendation.resolve",
+          outcome: "requested",
+        });
+        run88CorrelationHeader = {
+          "x-role-model-correlation": JSON.stringify(correlation),
+        };
+      }
       const headers = {
         "content-type": "application/json",
         ...(process.env.ROLE_MODEL_RECOMMENDATION_SERVICE_TOKEN
           ? { authorization: `Bearer ${process.env.ROLE_MODEL_RECOMMENDATION_SERVICE_TOKEN}` }
           : {}),
+        ...run88CorrelationHeader,
       };
       const response = await fetch(new URL("api/role-model/recommendations/resolve", baseUrl), {
         method: "POST",

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -356,6 +356,9 @@ export function createRun88RuntimeCorrelation(input: {
   readonly scope: string;
   readonly endpointId?: string;
   readonly timestamp?: string;
+  readonly service?: string;
+  readonly operation?: string;
+  readonly outcome?: string;
 }): Record<string, unknown> {
   for (const field of [
     "requestId",
@@ -382,8 +385,8 @@ export function createRun88RuntimeCorrelation(input: {
       traceId: hex("trace", 32),
       spanId: hex("span", 16),
       causalParentId: input.routingDecisionId,
-      service: "runtime-host-bridge",
-      operation: "track-b.post-observation",
+      service: input.service ?? "runtime-host-bridge",
+      operation: input.operation ?? "track-b.post-observation",
       runtimeChannel: "staging",
       scopeHash: `sha256:${createHash("sha256").update(input.scope).digest("hex")}`,
       cohort: "stage-1pct",
@@ -391,7 +394,7 @@ export function createRun88RuntimeCorrelation(input: {
       sourceId: input.sourceId,
       deploymentId: input.deploymentId,
       attempt: 1,
-      outcome: "observed",
+      outcome: input.outcome ?? "observed",
       timestamp,
       durationMs: 0,
     },

--- a/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
@@ -11,7 +11,11 @@ import {
 } from "./run88-public-runtime-probes.js";
 
 const { resolveRuntimeVersionInfo } = runtimeVersion;
-const { createTrackBPostObservationOutbox, normalizeRun88RuntimeCorrelation } = trackBRuntime;
+const {
+  createRun88RuntimeCorrelation,
+  createTrackBPostObservationOutbox,
+  normalizeRun88RuntimeCorrelation,
+} = trackBRuntime;
 
 const roots: string[] = [];
 afterEach(async () =>
@@ -217,6 +221,28 @@ describe("Run 88 stage release boundary", () => {
         new RegExp(field, "i"),
       );
     }
+  });
+
+  it("RUN88-U-PUB-R8-AC04 constructs recommendation-specific stage correlation", () => {
+    expect(
+      createRun88RuntimeCorrelation({
+        requestId: "recommendation-request-1",
+        routingDecisionId: "recommendation-resolve-1",
+        releaseId: `sha256:${"a".repeat(64)}`,
+        sourceId: "b".repeat(40),
+        deploymentId: `local-stage:${"c".repeat(64)}`,
+        scope: "run88-stage-scope",
+        timestamp: "2026-08-02T00:00:00.000Z",
+        operation: "recommendation.resolve",
+        outcome: "requested",
+      }),
+    ).toMatchObject({
+      schemaVersion: "run88-correlation.v1",
+      service: "runtime-host-bridge",
+      operation: "recommendation.resolve",
+      runtimeChannel: "staging",
+      outcome: "requested",
+    });
   });
 
   it("stage runtime constructs correlation at actual ingress and the durable outbox preserves it", async () => {

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -998,6 +998,98 @@ describe("Track B operations APIs", () => {
     expect(process.env.ROLE_MODEL_RECOMMENDATION_SERVICE_TOKEN).toBe("service-token-fixture");
   });
 
+  test("RUN88-I-PUB-R8-AC04 stage recommendation downloads propagate candidate correlation", async () => {
+    const runtimeStateRoot = path.join(
+      os.tmpdir(),
+      `run88-stage-recommendation-correlation-${Date.now()}`,
+    );
+    roots.push(runtimeStateRoot);
+    const releaseId = `sha256:${"a".repeat(64)}`;
+    const sourceId = "b".repeat(40);
+    const executableSha256 = "c".repeat(64);
+    const scopeId = "run88-stage-1pct";
+    const backend = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot,
+      runtimeStateRoot,
+      scopeId,
+      runtimeChannel: "stage",
+      run88StageIdentity: { releaseId, sourceId, executableSha256 },
+    });
+    process.env.ROLE_MODEL_RECOMMENDATION_SERVICE_URL = "https://recommendations-stage.example";
+    process.env.ROLE_MODEL_RECOMMENDATION_VERIFICATION_KEY = "verification-key-fixture";
+    process.env.ROLE_MODEL_RECOMMENDATION_CHANNEL = "staging";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input, init) => {
+        expect(String(input)).toBe(
+          "https://recommendations-stage.example/api/role-model/recommendations/resolve",
+        );
+        const encoded = new Headers(init?.headers).get("x-role-model-correlation");
+        expect(encoded).not.toBeNull();
+        expect(JSON.parse(encoded ?? "null")).toMatchObject({
+          schemaVersion: "run88-correlation.v1",
+          service: "runtime-host-bridge",
+          operation: "recommendation.resolve",
+          runtimeChannel: "staging",
+          releaseId,
+          sourceId,
+          deploymentId: `local-stage:${executableSha256}`,
+          outcome: "requested",
+        });
+        return new Response(
+          JSON.stringify({
+            contract: "RecommendationResolveResponseV1",
+            channel: "staging",
+            status: "not_eligible",
+            channelSequence: 0,
+            runtimeChannel: "staging",
+            scopeId,
+            boundaryProtocolVersion: "1.1",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+    try {
+      await expect(backend.downloadRecommendations()).resolves.toEqual([]);
+    } finally {
+      await backend.shutdown();
+    }
+  });
+
+  test("RUN88-R-PUB-R8-AC04 stage recommendation downloads fail closed without candidate identity", async () => {
+    const runtimeStateRoot = path.join(
+      os.tmpdir(),
+      `run88-stage-recommendation-missing-identity-${Date.now()}`,
+    );
+    roots.push(runtimeStateRoot);
+    const backend = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot,
+      runtimeStateRoot,
+      scopeId: "run88-stage-1pct",
+      runtimeChannel: "stage",
+    });
+    process.env.ROLE_MODEL_RECOMMENDATION_SERVICE_URL = "https://recommendations-stage.example";
+    process.env.ROLE_MODEL_RECOMMENDATION_VERIFICATION_KEY = "verification-key-fixture";
+    process.env.ROLE_MODEL_RECOMMENDATION_CHANNEL = "staging";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network must not be called without candidate identity");
+      }),
+    );
+    try {
+      await expect(backend.downloadRecommendations()).rejects.toThrow(
+        /stage recommendation correlation identity/i,
+      );
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      await backend.shutdown();
+    }
+  });
+
   test("run79 mutateExtension upserts catalog rows absent from bridge state", async () => {
     const root = path.join(os.tmpdir(), `track-b-mutate-upsert-${Date.now()}`);
     roots.push(root);


### PR DESCRIPTION
## Summary
- propagate the packaged Run 88 candidate identity on stage recommendation resolve requests
- fail closed before network I/O when a stage runtime lacks candidate identity
- preserve existing post-observation correlation defaults while supporting operation-specific correlation

## TDD and verification
- RED: exact integration test observed a missing x-role-model-correlation header
- GREEN: unit, integration, and regression set passed (69/69)
- full package run passed the changed tests and stopped at the pre-existing fresh-worktree packaging precondition: unbuilt dependency dist outputs
- runtime-host-bridge TypeScript build passed
- Biome check passed on all five changed files
- git diff --check passed

## Live Phase 5 defect
The packaged stage runtime received HTTP 400 while resolving an otherwise valid controlled recommendation because the stage worker correctly rejected a missing mandatory correlation header. This patch sends only hashed/immutable candidate identity fields and no raw prompt or response data.