### PR TITLE
fix(runtime): wire stage identity into backend

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -19,7 +19,7 @@ import {
 import { validateRun88PrivateDistributionIdentity } from "./kw-private-loader.js";
 import { readPackagedRuntimeProfile } from "./runtime-channel.js";
 import { migrateLegacyProductionState } from "./runtime-state-migration.js";
-import { validateRun88PackagedStageIdentity } from "./runtime-version.js";
+import { resolveRun88StageRuntimeIdentity } from "./runtime-version.js";
 import {
   createOwnedTrackBSidecarSpec,
   createPackagedProductionRuntime,
@@ -763,17 +763,14 @@ export async function main(): Promise<void> {
         readFileSync(path.join(path.dirname(process.execPath), "manifest.json"), "utf8"),
       ) as Record<string, unknown>)
     : null;
-  const packagedReleaseId =
-    typeof packagedManifestRecord?.release_id === "string"
-      ? packagedManifestRecord.release_id
-      : undefined;
-  const loadRun88PiInvocationProvenance =
-    packagedProfile?.channel === "stage"
-      ? () => readRun88PiInvocationProvenance(process.env, packagedReleaseId)
-      : null;
-  if (packagedProfile?.channel === "stage") {
-    validateRun88PackagedStageIdentity(packagedManifestRecord ?? {});
-  }
+  const run88StageIdentity = resolveRun88StageRuntimeIdentity(
+    packagedProfile?.channel ?? "development",
+    packagedManifestRecord,
+  );
+  const packagedReleaseId = run88StageIdentity?.releaseId;
+  const loadRun88PiInvocationProvenance = run88StageIdentity
+    ? () => readRun88PiInvocationProvenance(process.env, run88StageIdentity.releaseId)
+    : null;
   if (packagedProfile?.channel === "production" && !args.values["runtime-state-root"]) {
     const migration = await migrateLegacyProductionState({
       legacyRoot: path.join(process.env.LOCALAPPDATA || os.tmpdir(), "Role Model Runtime"),
@@ -825,15 +822,7 @@ export async function main(): Promise<void> {
         staticRoot,
         runtimeStateRoot: options.runtimeStateRoot,
         runtimeChannel: packagedProfile?.channel ?? "development",
-        ...(packagedProfile?.channel === "stage"
-          ? {
-              run88StageIdentity: {
-                releaseId: String(packagedManifestRecord?.release_id ?? ""),
-                sourceId: String(packagedManifestRecord?.source_tree ?? ""),
-                executableSha256: String(packagedManifestRecord?.executable_sha256 ?? ""),
-              },
-            }
-          : {}),
+        ...(run88StageIdentity ? { run88StageIdentity } : {}),
       },
       {
         getBackend: () => backend,
@@ -950,6 +939,7 @@ export async function main(): Promise<void> {
         runtimeStateRoot: options.runtimeStateRoot,
         scopeId: options.scopeId,
         runtimeChannel: packagedProfile?.channel ?? "development",
+        ...(run88StageIdentity ? { run88StageIdentity } : {}),
         unifiedRuntimeConfigPath: options.unifiedRuntimeConfigPath,
         ...(trackBOperationsEndpoint ? { trackBOperationsEndpoint } : {}),
         ...(trackBOperationsToken ? { trackBOperationsToken } : {}),
@@ -986,21 +976,20 @@ export async function main(): Promise<void> {
           ? {
               trackBPostObservation: async (observation: Readonly<Record<string, unknown>>) => {
                 const run88PiInvocationProvenance = loadRun88PiInvocationProvenance?.() ?? null;
-                const correlatedObservation =
-                  packagedProfile?.channel === "stage"
-                    ? createRun88StagePostObservation({
-                        observation,
-                        piInvocationProvenance: run88PiInvocationProvenance,
-                        proofRequired: Boolean(
-                          process.env.RUN88_PI_INVOCATION_PROOF_PATH ||
-                            process.env.RUN88_PI_PROOF_AUTHORITY_PUBLIC_KEY_PATH,
-                        ),
-                        releaseId: String(packagedManifestRecord?.release_id ?? ""),
-                        sourceId: String(packagedManifestRecord?.source_tree ?? ""),
-                        executableSha256: String(packagedManifestRecord?.executable_sha256 ?? ""),
-                        scope: options.scopeId,
-                      })
-                    : observation;
+                const correlatedObservation = run88StageIdentity
+                  ? createRun88StagePostObservation({
+                      observation,
+                      piInvocationProvenance: run88PiInvocationProvenance,
+                      proofRequired: Boolean(
+                        process.env.RUN88_PI_INVOCATION_PROOF_PATH ||
+                          process.env.RUN88_PI_PROOF_AUTHORITY_PUBLIC_KEY_PATH,
+                      ),
+                      releaseId: run88StageIdentity.releaseId,
+                      sourceId: run88StageIdentity.sourceId,
+                      executableSha256: run88StageIdentity.executableSha256,
+                      scope: options.scopeId,
+                    })
+                  : observation;
                 await postObservationOutbox.enqueue(correlatedObservation);
                 const runtime = extensionRuntimeRef.current;
                 if (!runtime) return { status: "queued_for_extension_runtime" };

--- a/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/runtime-version.ts
@@ -97,6 +97,25 @@ export function validateRun88PackagedStageIdentity(
   return Object.freeze({ ...manifest });
 }
 
+export interface Run88StageRuntimeIdentity {
+  readonly releaseId: string;
+  readonly sourceId: string;
+  readonly executableSha256: string;
+}
+
+export function resolveRun88StageRuntimeIdentity(
+  channel: "development" | "stage" | "production",
+  manifest: Readonly<Record<string, unknown>> | null,
+): Run88StageRuntimeIdentity | undefined {
+  if (channel !== "stage") return undefined;
+  const validated = validateRun88PackagedStageIdentity(manifest ?? {});
+  return Object.freeze({
+    releaseId: validated.release_id as string,
+    sourceId: validated.source_tree as string,
+    executableSha256: validated.executable_sha256 as string,
+  });
+}
+
 function normalizeTaggedVersion(value: string | null | undefined): string | null {
   const trimmed = readNonEmptyString(value);
   if (!trimmed) {

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -348,6 +348,18 @@ describe("runtime-host-bridge executable packaging", () => {
     expect(cliText).toContain('"readVersionInfo"');
   });
 
+  test("RUN88-I-PUB-R8-AC04 wires packaged candidate identity into the runtime backend", async () => {
+    const cliText = await readFile(
+      path.join(repoRoot, "role-model-router", "apps", "runtime-host-bridge", "src", "cli.ts"),
+      "utf8",
+    );
+    const createBackendBody = cliText.match(
+      /const createBackend = async \([\s\S]*?const created = await createRuntimeBridgeBackend\(\{([\s\S]*?)\n\s*\}\);/,
+    )?.[1];
+    expect(createBackendBody).toBeDefined();
+    expect(createBackendBody).toContain("run88StageIdentity");
+  });
+
   test("wires latest-request-id startup parity into every non-QA runtime launch path", async () => {
     const cliPath = path.join(
       repoRoot,

--- a/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
@@ -158,6 +158,41 @@ describe("Run 88 stage release boundary", () => {
     }
   });
 
+  it("RUN88-U-PUB-R8-AC04 derives one immutable backend identity from the validated package", () => {
+    const manifest = {
+      channel: "stage",
+      name: "role-model-stage",
+      host: "127.0.0.1",
+      port: 3457,
+      endpoint: "http://127.0.0.1:3457",
+      state_root_name: "role-model-runtime-stage",
+      scope_id: "standalone-runtime-stage",
+      source_tree: "1".repeat(40),
+      executable_sha256: "2".repeat(64),
+      core_payload_sha256: "3".repeat(64),
+      release_id: `sha256:${"4".repeat(64)}`,
+      private_distribution_sha256: "5".repeat(64),
+      track_b_runtime: { manifest_sha256: "5".repeat(64) },
+    };
+    const identity = runtimeVersion.resolveRun88StageRuntimeIdentity("stage", manifest);
+    expect(identity).toEqual({
+      releaseId: manifest.release_id,
+      sourceId: manifest.source_tree,
+      executableSha256: manifest.executable_sha256,
+    });
+    expect(Object.isFrozen(identity)).toBe(true);
+    expect(runtimeVersion.resolveRun88StageRuntimeIdentity("production", manifest)).toBeUndefined();
+  });
+
+  it("RUN88-R-PUB-R8-AC04 refuses to derive a stage backend identity from incomplete metadata", () => {
+    expect(() =>
+      runtimeVersion.resolveRun88StageRuntimeIdentity("stage", {
+        channel: "stage",
+        release_id: `sha256:${"4".repeat(64)}`,
+      }),
+    ).toThrow(/stage|identity|endpoint|state|scope/i);
+  });
+
   it("RUN88-U-PUB-R7-AC03 refuses provider success without signed Pi CLI process proof", () => {
     const validate = (
       trackBRuntime as unknown as {


### PR DESCRIPTION
## Summary
- derive one immutable Run 88 stage runtime identity from the validated packaged manifest
- pass that exact identity into both the CLI server and the real runtime backend
- reuse the validated identity for Pi provenance, observation correlation, and private-distribution binding

## TDD and verification
- RED: `RUN88-I-PUB-R8-AC04` proved `createBackend` omitted `run88StageIdentity`
- GREEN: 92/92 targeted unit, integration, regression, executable, and Track B API tests
- runtime-host-bridge TypeScript build passed
- Biome check passed on all changed files
- `git diff --check` passed

## Live Phase 5 defect
Repair 5 reached the stage recommendation worker but the local backend returned HTTP 400: `stage recommendation correlation identity is not configured`. The earlier HTTP-server wiring did not reach the backend instance that performs the recommendation download. This patch closes that exact seam and preserves fail-closed stage identity validation.