### PR TITLE
rollback(run88): restore public stage after failed soak

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -1574,7 +1574,6 @@ export function createOwnedTrackBSidecarSpec(options: {
 
       const operationsToken = randomBytes(32).toString("hex");
       const nodeExecutable = resolveTrackBNodeExecutable();
-      const sidecarChannel = options.channel === "stage" ? "staging" : options.channel;
       const child = spawn(
         nodeExecutable,
         [
@@ -1582,7 +1581,7 @@ export function createOwnedTrackBSidecarSpec(options: {
           "--state-root",
           options.stateRoot,
           "--channel",
-          sidecarChannel,
+          options.channel,
           "--host",
           "127.0.0.1",
           "--port",

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -144,34 +144,6 @@ describe("production Track B composition", () => {
     ).toThrow(/managed artifact keys/i);
   });
 
-  test("translates the public stage channel to the sidecar staging protocol", async () => {
-    const stateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-track-b-stage-channel-"));
-    roots.push(stateRoot);
-    const artifactPath = path.join(stateRoot, "fake-stage-sidecar.mjs");
-    const source = [
-      'import http from "node:http";',
-      'const channelIndex=process.argv.indexOf("--channel");',
-      'if(channelIndex<0 || process.argv[channelIndex+1]!=="staging"){console.error("expected staging sidecar channel");process.exit(4)}',
-      'const server=http.createServer((_req,res)=>{res.end("ok")});',
-      'server.listen(0,"127.0.0.1",()=>{',
-      " const address=server.address();",
-      ' process.stdout.write(JSON.stringify({type:"ready",endpoint:`http://127.0.0.1:${address.port}`})+"\\n");',
-      "});",
-      'process.on("SIGTERM",()=>server.close(()=>process.exit(0)));',
-    ].join("\n");
-    await writeFile(artifactPath, source, "utf8");
-
-    const sidecar = createOwnedTrackBSidecarSpec({
-      artifactPath,
-      artifactSha256: createHash("sha256").update(source).digest("hex"),
-      stateRoot,
-      channel: "stage",
-    });
-    const child = await sidecar.launch();
-    expect(child.endpoint).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
-    await child.stop();
-  });
-
   test("passes cloud contribution trust and aggregate destination into the launcher-owned sidecar", async () => {
     const stateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-track-b-sidecar-cloud-"));
     roots.push(stateRoot);


### PR DESCRIPTION
Reverts the Run 88 dev-to-stage N-1 merge after the immutable repair8 soak reached rollback_required. The resulting tree exactly matches known-good public stage commit af765b0f22f18cc4b7ef303cdb24d0cb6edc3560. Public dev remains at the merged Run 89 tree, and the active Run 90 draft worktree is untouched.