### PR TITLE
fix(ci): require semantic runtime readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,9 +224,8 @@ jobs:
             > track-b-runtime.log 2>&1 &
           runtime_pid=$!
           trap 'kill "$runtime_pid" "$recommendation_pid" 2>/dev/null || true' EXIT
-          for attempt in {1..120}; do
-            curl --fail --silent http://127.0.0.1:3462/healthz >/dev/null && break
-            sleep 1
-          done
-          curl --fail http://127.0.0.1:3462/healthz
+          node scripts/track-b/wait-for-runtime-readiness.mjs \
+            --url http://127.0.0.1:3462/healthz \
+            --timeout-ms 120000 \
+            --poll-interval-ms 1000
           pnpm --filter @role-model-router/runtime-ui exec playwright test --grep @recursive:87-direct-track-b-semantic-completion

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "runtime:test-full": "corepack pnpm run runtime:test-critical && corepack pnpm run runtime:test-browser",
     "build": "corepack pnpm run types:generate && corepack pnpm -r --if-present build",
     "test": "corepack pnpm run test:release-workflows && corepack pnpm -r --if-present --filter=./** --filter=!@role-model-router/runtime-host-bridge --filter=!@try-works/pi-role-model test && corepack pnpm --filter @role-model-router/runtime-host-bridge test && corepack pnpm --filter @try-works/pi-role-model test",
-    "test:release-workflows": "node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs",
+    "test:release-workflows": "node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs scripts/track-b/wait-for-runtime-readiness.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs",
     "test:track-b-product-state": "node scripts/track-b/run-command-test.mjs TB00-CMD-03",
     "test:extension-host-unit": "node scripts/track-b/run-command-test.mjs TB01-CMD-01",
     "test:extension-boundary-contract": "node scripts/track-b/run-command-test.mjs TB01-CMD-02",

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -60,6 +60,25 @@ test("Track B CI is always-on, explicit, and runs the tagged browser contract", 
   }
 });
 
+test("Track B browser gate waits for semantic readiness without weakening exact private pairing", () => {
+  const trackBJob = workflow.slice(workflow.indexOf("  track-b-runtime:"));
+  const privateValidation = trackBJob.indexOf("Validate exact private paired revision");
+  const privateCheckout = trackBJob.indexOf("Checkout exact private paired repository");
+  const readinessGate = trackBJob.indexOf("wait-for-runtime-readiness.mjs");
+  const browserGate = trackBJob.indexOf(
+    "playwright test --grep @recursive:87-direct-track-b-semantic-completion",
+  );
+
+  assert.match(trackBJob, /if \[\[ ! "\$PRIVATE_PAIRED_SHA" =~ \^\[0-9a-f\]\{40\}\$ \]\]/);
+  assert.match(trackBJob, /ref: \$\{\{ env\.PRIVATE_PAIRED_SHA \}\}/);
+  assert.ok(privateValidation >= 0, "the exact private SHA validation must remain present");
+  assert.ok(privateCheckout > privateValidation, "the private checkout must follow SHA validation");
+  assert.ok(readinessGate > privateCheckout, "semantic readiness must run after paired checkout");
+  assert.ok(browserGate > readinessGate, "Playwright must run only after semantic readiness");
+  assert.match(trackBJob, /--timeout-ms\s+120000/);
+  assert.match(trackBJob, /--poll-interval-ms\s+1000/);
+});
+
 test("promotion guard encodes dev to stage to main with a hotfix exception", () => {
   assert.match(workflow, /BASE_REF.*stage[\s\S]*HEAD_REF.*dev/);
   assert.match(workflow, /BASE_REF.*main[\s\S]*HEAD_REF.*stage/);

--- a/scripts/track-b/wait-for-runtime-readiness.mjs
+++ b/scripts/track-b/wait-for-runtime-readiness.mjs
@@ -1,0 +1,185 @@
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeField(value) {
+  return typeof value === "string" ? value : "missing";
+}
+
+function describeRuntimeHealth(health) {
+  if (!isRecord(health)) {
+    return "health response is not a JSON object";
+  }
+
+  const authority = isRecord(health.credentialLifecycleAuthority)
+    ? health.credentialLifecycleAuthority
+    : {};
+  const sessionBootstrap = isRecord(health.sessionBootstrap) ? health.sessionBootstrap : {};
+
+  return [
+    `status=${describeField(health.status)}`,
+    `credentialLifecycleAuthority.state=${describeField(authority.state)}`,
+    `credentialLifecycleAuthority.bootstrapStatus=${describeField(authority.bootstrapStatus)}`,
+    `sessionBootstrap=${describeField(sessionBootstrap.status)}`,
+  ].join(", ");
+}
+
+export function isSemanticRuntimeReady(health) {
+  if (!isRecord(health)) {
+    return false;
+  }
+
+  const authority = health.credentialLifecycleAuthority;
+  const sessionBootstrap = health.sessionBootstrap;
+  return (
+    health.status === "healthy" &&
+    isRecord(authority) &&
+    authority.state === "authoritative" &&
+    authority.bootstrapStatus === "ready" &&
+    isRecord(sessionBootstrap) &&
+    sessionBootstrap.status === "ready"
+  );
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function inspectHealth(url, requestTimeoutMs, fetchFn) {
+  try {
+    const response = await fetchFn(url, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    });
+    if (!response.ok) {
+      return { diagnostic: `HTTP ${response.status}`, ready: false };
+    }
+
+    let health;
+    try {
+      health = await response.json();
+    } catch (error) {
+      return { diagnostic: `malformed JSON: ${errorMessage(error)}`, ready: false };
+    }
+
+    if (isSemanticRuntimeReady(health)) {
+      return { health, ready: true };
+    }
+
+    return { diagnostic: describeRuntimeHealth(health), ready: false };
+  } catch (error) {
+    return { diagnostic: `request failed: ${errorMessage(error)}`, ready: false };
+  }
+}
+
+export async function waitForSemanticRuntimeReadiness({
+  fetchFn = fetch,
+  now = Date.now,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  sleepFn = sleep,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  url,
+} = {}) {
+  const deadline = now() + timeoutMs;
+  let lastDiagnostic = "no health response received";
+
+  while (true) {
+    const remainingBeforeRequest = deadline - now();
+    if (remainingBeforeRequest <= 0) {
+      break;
+    }
+
+    const observation = await inspectHealth(
+      url,
+      Math.max(1, Math.min(5_000, remainingBeforeRequest)),
+      fetchFn,
+    );
+    if (observation.ready) {
+      return observation.health;
+    }
+    lastDiagnostic = observation.diagnostic;
+
+    const remainingBeforeSleep = deadline - now();
+    if (remainingBeforeSleep <= 0) {
+      break;
+    }
+    await sleepFn(Math.min(pollIntervalMs, remainingBeforeSleep));
+  }
+
+  throw new Error(
+    `Timed out waiting for semantic runtime readiness after ${timeoutMs}ms; last observation: ${lastDiagnostic}`,
+  );
+}
+
+function parsePositiveInteger(value, flag) {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseOptions(args) {
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    if (!["--url", "--timeout-ms", "--poll-interval-ms"].includes(flag)) {
+      throw new Error(`Unknown option: ${flag}`);
+    }
+
+    const value = args[index + 1];
+    if (!value || value.startsWith("--") || values.has(flag)) {
+      throw new Error(`Expected one value for ${flag}`);
+    }
+    values.set(flag, value);
+    index += 1;
+  }
+
+  const url = values.get("--url");
+  if (!url) {
+    throw new Error("--url is required");
+  }
+  const parsedUrl = new URL(url);
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    throw new Error("--url must use http or https");
+  }
+
+  return {
+    pollIntervalMs: parsePositiveInteger(
+      values.get("--poll-interval-ms") ?? String(DEFAULT_POLL_INTERVAL_MS),
+      "--poll-interval-ms",
+    ),
+    timeoutMs: parsePositiveInteger(
+      values.get("--timeout-ms") ?? String(DEFAULT_TIMEOUT_MS),
+      "--timeout-ms",
+    ),
+    url: parsedUrl.toString(),
+  };
+}
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const health = await waitForSemanticRuntimeReadiness(options);
+  console.log(`Semantic runtime readiness: ready (${describeRuntimeHealth(health)})`);
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/track-b/wait-for-runtime-readiness.test.mjs
+++ b/scripts/track-b/wait-for-runtime-readiness.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const helperPath = path.join(repoRoot, "scripts", "track-b", "wait-for-runtime-readiness.mjs");
+
+function runReadinessCli(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [helperPath, ...args], {
+      cwd: repoRoot,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function withHealthServer(handler, callback) {
+  const server = createServer(async (request, response) => {
+    if (request.url !== "/healthz") {
+      response.writeHead(404).end();
+      return;
+    }
+    const next = await handler();
+    response.writeHead(next.status ?? 200, {
+      "content-type": next.contentType ?? "application/json",
+    });
+    response.end(next.body);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object", "health server must bind a TCP port");
+  const url = `http://127.0.0.1:${address.port}/healthz`;
+  try {
+    await callback(url);
+  } finally {
+    await new Promise((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+function readinessArgs(url) {
+  return ["--url", url, "--timeout-ms", "500", "--poll-interval-ms", "20"];
+}
+
+test("refuses an HTTP-200 health response while runtime bootstrap is degraded and pending", async () => {
+  await withHealthServer(
+    () => ({
+      body: JSON.stringify({
+        status: "degraded",
+        credentialLifecycleAuthority: { state: "provisional", bootstrapStatus: "pending" },
+        sessionBootstrap: { status: "pending" },
+      }),
+    }),
+    async (url) => {
+      const result = await runReadinessCli(readinessArgs(url));
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /timed out waiting for semantic runtime readiness/i);
+      assert.match(result.stderr, /status=degraded/i);
+      assert.match(result.stderr, /sessionBootstrap=pending/i);
+    },
+  );
+});
+
+test("accepts only healthy, authoritative, bootstrap-ready runtime health", async () => {
+  await withHealthServer(
+    () => ({
+      body: JSON.stringify({
+        status: "healthy",
+        credentialLifecycleAuthority: { state: "authoritative", bootstrapStatus: "ready" },
+        sessionBootstrap: { status: "ready" },
+      }),
+    }),
+    async (url) => {
+      const result = await runReadinessCli(readinessArgs(url));
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /semantic runtime readiness: ready/i);
+    },
+  );
+});
+
+test("fails closed when health responds with malformed JSON", async () => {
+  await withHealthServer(
+    () => ({ body: "not-json", contentType: "application/json" }),
+    async (url) => {
+      const result = await runReadinessCli(readinessArgs(url));
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /timed out waiting for semantic runtime readiness/i);
+      assert.match(result.stderr, /malformed JSON/i);
+    },
+  );
+});
+
+test("fails closed with bounded diagnostics when health never becomes ready", async () => {
+  await withHealthServer(
+    () => ({ status: 503, body: "unavailable", contentType: "text/plain" }),
+    async (url) => {
+      const result = await runReadinessCli(readinessArgs(url));
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /timed out waiting for semantic runtime readiness/i);
+      assert.match(result.stderr, /HTTP 503/i);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- wait for healthy, authoritative, bootstrap-ready runtime health before Playwright
- fail closed with bounded diagnostics for degraded, malformed, or unavailable health
- preserve exact paired-private validation and checkout ordering

## Verification
- release workflow tests: 13/13, repeated twice
- focused readiness/workflow tests: 9/9
- Biome changed-scope check
- git diff --check

## Incident evidence
Repairs the startup-readiness race observed in stage CI run 31247496997, where HTTP 200 with degraded/pending bootstrap launched Playwright prematurely.