### PR TITLE
test(ci): stabilize semantic readiness diagnostics

### DIFF
--- a/scripts/track-b/wait-for-runtime-readiness.mjs
+++ b/scripts/track-b/wait-for-runtime-readiness.mjs
@@ -59,23 +59,31 @@ async function inspectHealth(url, requestTimeoutMs, fetchFn) {
       signal: AbortSignal.timeout(requestTimeoutMs),
     });
     if (!response.ok) {
-      return { diagnostic: `HTTP ${response.status}`, ready: false };
+      return { diagnostic: `HTTP ${response.status}`, diagnosticPriority: 2, ready: false };
     }
 
     let health;
     try {
       health = await response.json();
     } catch (error) {
-      return { diagnostic: `malformed JSON: ${errorMessage(error)}`, ready: false };
+      return {
+        diagnostic: `malformed JSON: ${errorMessage(error)}`,
+        diagnosticPriority: 2,
+        ready: false,
+      };
     }
 
     if (isSemanticRuntimeReady(health)) {
       return { health, ready: true };
     }
 
-    return { diagnostic: describeRuntimeHealth(health), ready: false };
+    return { diagnostic: describeRuntimeHealth(health), diagnosticPriority: 3, ready: false };
   } catch (error) {
-    return { diagnostic: `request failed: ${errorMessage(error)}`, ready: false };
+    return {
+      diagnostic: `request failed: ${errorMessage(error)}`,
+      diagnosticPriority: 1,
+      ready: false,
+    };
   }
 }
 
@@ -89,6 +97,7 @@ export async function waitForSemanticRuntimeReadiness({
 } = {}) {
   const deadline = now() + timeoutMs;
   let lastDiagnostic = "no health response received";
+  let lastDiagnosticPriority = 0;
 
   while (true) {
     const remainingBeforeRequest = deadline - now();
@@ -104,7 +113,10 @@ export async function waitForSemanticRuntimeReadiness({
     if (observation.ready) {
       return observation.health;
     }
-    lastDiagnostic = observation.diagnostic;
+    if (observation.diagnosticPriority >= lastDiagnosticPriority) {
+      lastDiagnostic = observation.diagnostic;
+      lastDiagnosticPriority = observation.diagnosticPriority;
+    }
 
     const remainingBeforeSleep = deadline - now();
     if (remainingBeforeSleep <= 0) {

--- a/scripts/track-b/wait-for-runtime-readiness.test.mjs
+++ b/scripts/track-b/wait-for-runtime-readiness.test.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { waitForSemanticRuntimeReadiness } from "./wait-for-runtime-readiness.mjs";
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const helperPath = path.join(repoRoot, "scripts", "track-b", "wait-for-runtime-readiness.mjs");
 
@@ -55,25 +57,73 @@ async function withHealthServer(handler, callback) {
 }
 
 function readinessArgs(url) {
-  return ["--url", url, "--timeout-ms", "500", "--poll-interval-ms", "20"];
+  return ["--url", url, "--timeout-ms", "2000", "--poll-interval-ms", "20"];
+}
+
+function healthResponse(body, { ok = true, status = 200 } = {}) {
+  return { json: async () => body, ok, status };
+}
+
+async function assertBoundedFailure(fetchFn, expected) {
+  let currentTime = 0;
+  await assert.rejects(
+    waitForSemanticRuntimeReadiness({
+      fetchFn,
+      now: () => currentTime,
+      pollIntervalMs: 10,
+      sleepFn: async (durationMs) => {
+        currentTime += durationMs;
+      },
+      timeoutMs: 50,
+      url: "http://127.0.0.1:1/healthz",
+    }),
+    expected,
+  );
 }
 
 test("refuses an HTTP-200 health response while runtime bootstrap is degraded and pending", async () => {
-  await withHealthServer(
-    () => ({
-      body: JSON.stringify({
+  await assertBoundedFailure(
+    async () =>
+      healthResponse({
         status: "degraded",
         credentialLifecycleAuthority: { state: "provisional", bootstrapStatus: "pending" },
         sessionBootstrap: { status: "pending" },
       }),
-    }),
-    async (url) => {
-      const result = await runReadinessCli(readinessArgs(url));
-      assert.notEqual(result.code, 0);
-      assert.match(result.stderr, /timed out waiting for semantic runtime readiness/i);
-      assert.match(result.stderr, /status=degraded/i);
-      assert.match(result.stderr, /sessionBootstrap=pending/i);
+    (error) => {
+      assert.match(error.message, /timed out waiting for semantic runtime readiness/i);
+      assert.match(error.message, /status=degraded/i);
+      assert.match(error.message, /sessionBootstrap=pending/i);
+      return true;
     },
+  );
+});
+
+test("retains the last semantic observation when a near-deadline request aborts", async () => {
+  let currentTime = 0;
+  let requestCount = 0;
+  await assert.rejects(
+    waitForSemanticRuntimeReadiness({
+      fetchFn: async () => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          return healthResponse({
+            status: "degraded",
+            credentialLifecycleAuthority: { state: "provisional", bootstrapStatus: "pending" },
+            sessionBootstrap: { status: "pending" },
+          });
+        }
+        currentTime = 50;
+        throw new Error("The operation was aborted due to timeout");
+      },
+      now: () => currentTime,
+      pollIntervalMs: 10,
+      sleepFn: async (durationMs) => {
+        currentTime += durationMs;
+      },
+      timeoutMs: 50,
+      url: "http://127.0.0.1:1/healthz",
+    }),
+    /status=degraded/i,
   );
 });
 
@@ -95,25 +145,21 @@ test("accepts only healthy, authoritative, bootstrap-ready runtime health", asyn
 });
 
 test("fails closed when health responds with malformed JSON", async () => {
-  await withHealthServer(
-    () => ({ body: "not-json", contentType: "application/json" }),
-    async (url) => {
-      const result = await runReadinessCli(readinessArgs(url));
-      assert.notEqual(result.code, 0);
-      assert.match(result.stderr, /timed out waiting for semantic runtime readiness/i);
-      assert.match(result.stderr, /malformed JSON/i);
-    },
+  await assertBoundedFailure(
+    async () => ({
+      json: async () => {
+        throw new SyntaxError("fixture is not JSON");
+      },
+      ok: true,
+      status: 200,
+    }),
+    /malformed JSON/i,
   );
 });
 
 test("fails closed with bounded diagnostics when health never becomes ready", async () => {
-  await withHealthServer(
-    () => ({ status: 503, body: "unavailable", contentType: "text/plain" }),
-    async (url) => {
-      const result = await runReadinessCli(readinessArgs(url));
-      assert.notEqual(result.code, 0);
-      assert.match(result.stderr, /timed out waiting for semantic runtime readiness/i);
-      assert.match(result.stderr, /HTTP 503/i);
-    },
+  await assertBoundedFailure(
+    async () => healthResponse(null, { ok: false, status: 503 }),
+    /HTTP 503/i,
   );
 });


### PR DESCRIPTION
Fixes the timing-sensitive negative readiness assertion found by PR #106. Negative semantic cases now use injected time and fetch boundaries; a real CLI/server integration remains. The runtime helper also retains a higher-value semantic health observation when a final near-deadline request aborts. RED reproduced the diagnostic overwrite; GREEN passed 10 focused repetitions, 14/14 release-workflow tests, Biome, and diff-check.