### PR TITLE
fix(runtime): ship standalone extension host closure

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -104,6 +104,22 @@ const standaloneReleaseCopies = [
     sourceRelativePath: "role-model-router/packages/core/data/taxonomy",
     destinationRelativePath: "role-model-router/packages/core/data/taxonomy",
   },
+  {
+    sourceRelativePath: "role-model-router/packages/extension-host/index.mjs",
+    destinationRelativePath: "role-model-router/packages/extension-host/index.mjs",
+  },
+  {
+    sourceRelativePath: "packages/extension-host/index.mjs",
+    destinationRelativePath: "packages/extension-host/index.mjs",
+  },
+  {
+    sourceRelativePath: "packages/extension-host/worker-runtime.mjs",
+    destinationRelativePath: "packages/extension-host/worker-runtime.mjs",
+  },
+  {
+    sourceRelativePath: "packages/extension-sdk/index.mjs",
+    destinationRelativePath: "packages/extension-sdk/index.mjs",
+  },
 ] as const satisfies readonly StandaloneReleaseCopy[];
 
 const forbiddenProductionReleasePathFragments = [

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -275,6 +275,22 @@ describe("runtime-host-bridge executable packaging", () => {
           destinationRelativePath:
             "role-model-router/packages/catalog/data/normalized-catalog.json",
         },
+        {
+          sourceRelativePath: "role-model-router/packages/extension-host/index.mjs",
+          destinationRelativePath: "role-model-router/packages/extension-host/index.mjs",
+        },
+        {
+          sourceRelativePath: "packages/extension-host/index.mjs",
+          destinationRelativePath: "packages/extension-host/index.mjs",
+        },
+        {
+          sourceRelativePath: "packages/extension-host/worker-runtime.mjs",
+          destinationRelativePath: "packages/extension-host/worker-runtime.mjs",
+        },
+        {
+          sourceRelativePath: "packages/extension-sdk/index.mjs",
+          destinationRelativePath: "packages/extension-sdk/index.mjs",
+        },
       ]),
     );
     expect(copies).not.toEqual(


### PR DESCRIPTION
## What changed

- stage the packaged extension-host resolver shim in the standalone SEA release
- stage its complete runtime dependency closure: the top-level host, worker runtime, and extension SDK
- add a regression contract covering all four required release paths

## Root cause

The Windows SEA could load its executable, taxonomy, UI, catalog, and private Track B distribution, but the standalone release builder omitted the public extension-host modules. Existing packaged restart coverage passed a source checkout through `--repo-root`, which masked the missing standalone files.

## Validation

- RED: `executable.test.ts` failed only because the extension-host dependency closure was absent
- GREEN: `corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/executable.test.ts test/track-b-runtime-composition.test.ts` — 34/34 passed
- `corepack pnpm exec biome check role-model-router/apps/runtime-host-bridge/src/package-sea.ts role-model-router/apps/runtime-host-bridge/test/executable.test.ts`
- `corepack pnpm --filter @role-model-router/runtime-host-bridge build`
- full Windows stage SEA rebuild with the exact private Track B distribution

## Real behavior proof

- Setup: Windows, Node.js 24.11.0, pnpm 10.6.5, stage-channel SEA, exact Run88 private Track B distribution
- Before fix: the standalone executable emitted the `127.0.0.1:3457` listener and then exited with `Track B extension host module could not be resolved from packaged runtime repo root`
- After fix: the rebuilt stage executable launched from its own release directory, stayed alive for the bounded eight-second smoke window, and emitted no module-resolution exception
- Cleanup: the owned process tree was terminated; the root PID was absent and port 3457 had zero listeners afterward
- Not tested in this PR: Pi/provider traffic and Cloudflare contribution traffic; those remain in the Run88 Phase 5 candidate gate after this packaging fix is promoted and rebuilt from the final stage commit
