### PR TITLE
chore(release): promote dev to stage

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -104,6 +104,22 @@ const standaloneReleaseCopies = [
     sourceRelativePath: "role-model-router/packages/core/data/taxonomy",
     destinationRelativePath: "role-model-router/packages/core/data/taxonomy",
   },
+  {
+    sourceRelativePath: "role-model-router/packages/extension-host/index.mjs",
+    destinationRelativePath: "role-model-router/packages/extension-host/index.mjs",
+  },
+  {
+    sourceRelativePath: "packages/extension-host/index.mjs",
+    destinationRelativePath: "packages/extension-host/index.mjs",
+  },
+  {
+    sourceRelativePath: "packages/extension-host/worker-runtime.mjs",
+    destinationRelativePath: "packages/extension-host/worker-runtime.mjs",
+  },
+  {
+    sourceRelativePath: "packages/extension-sdk/index.mjs",
+    destinationRelativePath: "packages/extension-sdk/index.mjs",
+  },
 ] as const satisfies readonly StandaloneReleaseCopy[];
 
 const forbiddenProductionReleasePathFragments = [

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -275,6 +275,22 @@ describe("runtime-host-bridge executable packaging", () => {
           destinationRelativePath:
             "role-model-router/packages/catalog/data/normalized-catalog.json",
         },
+        {
+          sourceRelativePath: "role-model-router/packages/extension-host/index.mjs",
+          destinationRelativePath: "role-model-router/packages/extension-host/index.mjs",
+        },
+        {
+          sourceRelativePath: "packages/extension-host/index.mjs",
+          destinationRelativePath: "packages/extension-host/index.mjs",
+        },
+        {
+          sourceRelativePath: "packages/extension-host/worker-runtime.mjs",
+          destinationRelativePath: "packages/extension-host/worker-runtime.mjs",
+        },
+        {
+          sourceRelativePath: "packages/extension-sdk/index.mjs",
+          destinationRelativePath: "packages/extension-sdk/index.mjs",
+        },
       ]),
     );
     expect(copies).not.toEqual(


### PR DESCRIPTION
## Promotion scope

Promote reviewed public `dev` into `stage` for the Run88 Repair13 candidate rebuild.

Included integration delta since the current stage tip:

- PR #110: standalone SEA releases now include the complete extension-host runtime dependency closure
- strict-TDD regression coverage for the resolver shim, host, worker runtime, and SDK paths

## Verification

- PR #110 required checks: CLA, promotion guard, quality, build-test, runtime-critical, runtime-router, Rust, smoke, and track-b-runtime all passed
- local focused tests: 34/34 passed
- local formatter and TypeScript build passed
- rebuilt Windows stage SEA launched from its own release directory, stayed alive for the bounded smoke, and cleaned its PID/listener afterward

## Release boundary

This promotion does not touch `main` or production. After merge, Run88 will rebuild and rebind the exact stage package/private distribution/cloud candidate before any Pi or contribution journey.
