### PR TITLE
fix: release endpoint-aware Pi package

### DIFF
--- a/packages/pi-role-model/package.json
+++ b/packages/pi-role-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@try-works/pi-role-model",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Pi package for connecting Pi to an externally running Role-Model runtime.",
   "license": "BUSL-1.1",

--- a/packages/pi-role-model/test/package-manifest.test.ts
+++ b/packages/pi-role-model/test/package-manifest.test.ts
@@ -36,4 +36,12 @@ describe("pi-role-model package manifest", () => {
     expect(manifest.scripts?.test).toContain("vitest run");
     expect(manifest.scripts?.build).toContain("tsc");
   });
+
+  test("does not reuse the known-stale npm version for endpoint-aware source", async () => {
+    const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as {
+      version?: string;
+    };
+
+    expect(manifest.version).not.toBe("0.1.3");
+  });
 });


### PR DESCRIPTION
## What changed

- Bump `@try-works/pi-role-model` from `0.1.3` to `0.1.4`.
- Add a regression guard preventing reuse of the known-stale `0.1.3` npm version for the endpoint-aware source.

## Why

The repository source already resolves the runtime endpoint through `createRoleModelConfig`, so `ROLE_MODEL_ENDPOINT` works. The immutable npm `0.1.3` tarball predates that source and instead falls directly back to port 3456. Reinstalling from npm could therefore restore stale behavior even though current `dev` is correct. A new package version is required because npm package versions are immutable.

## Root cause

Source advanced after `0.1.3` was published without a new package release. The installed registry artifact and repository package consequently shared a version number but not behavior.

## Validation

- Strict TDD RED: `corepack pnpm exec vitest run test/package-manifest.test.ts` failed because the manifest was still `0.1.3`.
- GREEN: the focused manifest suite passed after the `0.1.4` bump.
- `corepack pnpm --filter @try-works/pi-role-model test` — 96/96 passed.
- `corepack pnpm --filter @try-works/pi-role-model build` — passed.
- `corepack pnpm exec biome check packages/pi-role-model/package.json packages/pi-role-model/test/package-manifest.test.ts` — passed.
- Packed artifact: `try-works-pi-role-model-0.1.4.tgz`, SHA-256 `9a99bc6ca7243a9e7226a00722034fb09d4d6e157270156cd1f6483474c33546`.
- Packed artifact inspection confirmed version `0.1.4`, the `createRoleModelConfig` endpoint resolver, and absence of the stale direct-default expression.

## Real behavior proof

Setup:

- Windows, Node.js `v24.11.0`, pnpm `10.6.5`.
- Actual local Pi CLI with the packed `@try-works/pi-role-model@0.1.4` installed without changing Pi's dependency manifest or lockfile.
- Two fresh packaged Role-Model runtimes on `http://127.0.0.1:3456` and `http://127.0.0.1:3457`.
- Both runtimes configured for `deepseek/deepseek-v4-flash` through the normal remote-only provider path.
- Pi process timeout: 90 seconds per request.

After-fix result:

- Pi invocation with only `ROLE_MODEL_ENDPOINT=http://127.0.0.1:3456`: exit 0, expected provider response observed, exactly one request persisted by the fresh 3456 runtime.
- Pi invocation with only `ROLE_MODEL_ENDPOINT=http://127.0.0.1:3457`: exit 0, expected provider response observed, exactly one request persisted by the fresh 3457 runtime.
- No stderr, no timeout, no cross-port request, and ports 3456/3457/3466 were free after cleanup.
- Privacy-safe runtime summary SHA-256: `7b9614b08aad4389a3a89c51002847386a20cc9c5843814a2c9d11d435208025`.

Not tested:

- npm publication was intentionally not performed.
- Full monorepo CI was not run locally; the focused package suite, typecheck, formatting, pack inspection, and live Pi/runtime/provider boundary were run.
