### PR TITLE
fix(runtime): promote Run 88 packaged extension catalog

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -101,6 +101,10 @@ const standaloneReleaseCopies = [
     destinationRelativePath: "role-model-router/packages/catalog/data/normalized-catalog.json",
   },
   {
+    sourceRelativePath: "packages/protocol-types/generated/product-contracts.json",
+    destinationRelativePath: "packages/protocol-types/generated/product-contracts.json",
+  },
+  {
     sourceRelativePath: "role-model-router/packages/core/data/taxonomy",
     destinationRelativePath: "role-model-router/packages/core/data/taxonomy",
   },

--- a/role-model-router/apps/runtime-host-bridge/src/validate-packaging.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/validate-packaging.ts
@@ -502,6 +502,23 @@ async function exercisePackagedTaxonomyValidation(input: {
   };
 }
 
+async function exercisePackagedExtensionCatalogValidation(input: {
+  readonly baseUrl: string;
+}): Promise<{ readonly extensionCount: number }> {
+  const extensions = await fetchJson<
+    readonly {
+      readonly id?: unknown;
+    }[]
+  >(`${input.baseUrl}/api/role-model/extensions`);
+  if (!Array.isArray(extensions)) {
+    throw new Error("packaged extension catalog must be an array");
+  }
+  if (!extensions.some((extension) => extension.id === "evaluation-core")) {
+    throw new Error("packaged extension catalog is missing evaluation-core");
+  }
+  return { extensionCount: extensions.length };
+}
+
 export async function runRuntimePackagingValidation(): Promise<{
   readonly packagedExecutable: string;
   readonly healthStatus: string;
@@ -511,6 +528,7 @@ export async function runRuntimePackagingValidation(): Promise<{
   readonly taxonomyVersion: string;
   readonly contentRevision: string;
   readonly securityTaskCount: number;
+  readonly extensionCount: number;
   readonly endpointId: string;
   readonly chatOutputText: string;
   readonly responsesOutputText: string;
@@ -570,6 +588,7 @@ export async function runRuntimePackagingValidation(): Promise<{
         readonly taxonomyVersion: string;
         readonly contentRevision: string;
         readonly securityTaskCount: number;
+        readonly extensionCount: number;
         readonly endpointId: string;
         readonly chatOutputText: string;
         readonly responsesOutputText: string;
@@ -589,6 +608,9 @@ export async function runRuntimePackagingValidation(): Promise<{
     const packagedTaxonomy = await exercisePackagedTaxonomyValidation({
       baseUrl: `http://127.0.0.1:${port}`,
     });
+    const packagedExtensions = await exercisePackagedExtensionCatalogValidation({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
     return {
       packagedExecutable: packaged.outputPath,
       healthStatus: healthJson.status,
@@ -598,6 +620,7 @@ export async function runRuntimePackagingValidation(): Promise<{
       taxonomyVersion: packagedTaxonomy.taxonomyVersion,
       contentRevision: packagedTaxonomy.contentRevision,
       securityTaskCount: packagedTaxonomy.securityTaskCount,
+      extensionCount: packagedExtensions.extensionCount,
       endpointId: packagedExecution.endpointId,
       chatOutputText: packagedExecution.chatOutputText,
       responsesOutputText: packagedExecution.responsesOutputText,

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -276,6 +276,10 @@ describe("runtime-host-bridge executable packaging", () => {
             "role-model-router/packages/catalog/data/normalized-catalog.json",
         },
         {
+          sourceRelativePath: "packages/protocol-types/generated/product-contracts.json",
+          destinationRelativePath: "packages/protocol-types/generated/product-contracts.json",
+        },
+        {
           sourceRelativePath: "role-model-router/packages/extension-host/index.mjs",
           destinationRelativePath: "role-model-router/packages/extension-host/index.mjs",
         },
@@ -458,6 +462,21 @@ describe("runtime-host-bridge executable packaging", () => {
     expect(validatePackagingText).toContain("contentRevision");
     expect(validatePackagingText).toContain("entryCounts");
     expect(validatePackagingText).toContain("security.audit");
+  });
+
+  test("packaged runtime validation exercises the extension catalog from packaged contracts", async () => {
+    const validatePackagingPath = path.join(
+      repoRoot,
+      "role-model-router",
+      "apps",
+      "runtime-host-bridge",
+      "src",
+      "validate-packaging.ts",
+    );
+    const validatePackagingText = await readFile(validatePackagingPath, "utf8");
+
+    expect(validatePackagingText).toContain("/api/role-model/extensions");
+    expect(validatePackagingText).toContain("evaluation-core");
   });
 
   test("packaged runtime validation tears down the packaged process tree before cleaning release artifacts", async () => {


### PR DESCRIPTION
## What changed

- Packages the extension catalog contracts required by the already-verified Run 88 Candidate J runtime.
- Validates the packaged catalog before release assembly.
- Adds the focused packaging regression.

## Why

Run 88 identified that Candidate J's immutable public source commit had not entered the protected `dev` promotion history. This PR promotes that exact commit without rebuilding the candidate or sending any additional runtime/soak requests.

## Validation

- `corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/executable.test.ts`
- 22 tests passed, 0 failed.

No Worker deployment, production mutation, or application request is part of this PR.
