### PR TITLE
chore(stage): promote Run 88 Candidate J

### DIFF
--- a/packages/pi-role-model/package.json
+++ b/packages/pi-role-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@try-works/pi-role-model",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Pi package for connecting Pi to an externally running Role-Model runtime.",
   "license": "BUSL-1.1",

--- a/packages/pi-role-model/test/package-manifest.test.ts
+++ b/packages/pi-role-model/test/package-manifest.test.ts
@@ -36,4 +36,12 @@ describe("pi-role-model package manifest", () => {
     expect(manifest.scripts?.test).toContain("vitest run");
     expect(manifest.scripts?.build).toContain("tsc");
   });
+
+  test("does not reuse the known-stale npm version for endpoint-aware source", async () => {
+    const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as {
+      version?: string;
+    };
+
+    expect(manifest.version).not.toBe("0.1.3");
+  });
 });

--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -101,6 +101,10 @@ const standaloneReleaseCopies = [
     destinationRelativePath: "role-model-router/packages/catalog/data/normalized-catalog.json",
   },
   {
+    sourceRelativePath: "packages/protocol-types/generated/product-contracts.json",
+    destinationRelativePath: "packages/protocol-types/generated/product-contracts.json",
+  },
+  {
     sourceRelativePath: "role-model-router/packages/core/data/taxonomy",
     destinationRelativePath: "role-model-router/packages/core/data/taxonomy",
   },

--- a/role-model-router/apps/runtime-host-bridge/src/validate-packaging.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/validate-packaging.ts
@@ -502,6 +502,23 @@ async function exercisePackagedTaxonomyValidation(input: {
   };
 }
 
+async function exercisePackagedExtensionCatalogValidation(input: {
+  readonly baseUrl: string;
+}): Promise<{ readonly extensionCount: number }> {
+  const extensions = await fetchJson<
+    readonly {
+      readonly id?: unknown;
+    }[]
+  >(`${input.baseUrl}/api/role-model/extensions`);
+  if (!Array.isArray(extensions)) {
+    throw new Error("packaged extension catalog must be an array");
+  }
+  if (!extensions.some((extension) => extension.id === "evaluation-core")) {
+    throw new Error("packaged extension catalog is missing evaluation-core");
+  }
+  return { extensionCount: extensions.length };
+}
+
 export async function runRuntimePackagingValidation(): Promise<{
   readonly packagedExecutable: string;
   readonly healthStatus: string;
@@ -511,6 +528,7 @@ export async function runRuntimePackagingValidation(): Promise<{
   readonly taxonomyVersion: string;
   readonly contentRevision: string;
   readonly securityTaskCount: number;
+  readonly extensionCount: number;
   readonly endpointId: string;
   readonly chatOutputText: string;
   readonly responsesOutputText: string;
@@ -570,6 +588,7 @@ export async function runRuntimePackagingValidation(): Promise<{
         readonly taxonomyVersion: string;
         readonly contentRevision: string;
         readonly securityTaskCount: number;
+        readonly extensionCount: number;
         readonly endpointId: string;
         readonly chatOutputText: string;
         readonly responsesOutputText: string;
@@ -589,6 +608,9 @@ export async function runRuntimePackagingValidation(): Promise<{
     const packagedTaxonomy = await exercisePackagedTaxonomyValidation({
       baseUrl: `http://127.0.0.1:${port}`,
     });
+    const packagedExtensions = await exercisePackagedExtensionCatalogValidation({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
     return {
       packagedExecutable: packaged.outputPath,
       healthStatus: healthJson.status,
@@ -598,6 +620,7 @@ export async function runRuntimePackagingValidation(): Promise<{
       taxonomyVersion: packagedTaxonomy.taxonomyVersion,
       contentRevision: packagedTaxonomy.contentRevision,
       securityTaskCount: packagedTaxonomy.securityTaskCount,
+      extensionCount: packagedExtensions.extensionCount,
       endpointId: packagedExecution.endpointId,
       chatOutputText: packagedExecution.chatOutputText,
       responsesOutputText: packagedExecution.responsesOutputText,

--- a/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/executable.test.ts
@@ -276,6 +276,10 @@ describe("runtime-host-bridge executable packaging", () => {
             "role-model-router/packages/catalog/data/normalized-catalog.json",
         },
         {
+          sourceRelativePath: "packages/protocol-types/generated/product-contracts.json",
+          destinationRelativePath: "packages/protocol-types/generated/product-contracts.json",
+        },
+        {
           sourceRelativePath: "role-model-router/packages/extension-host/index.mjs",
           destinationRelativePath: "role-model-router/packages/extension-host/index.mjs",
         },
@@ -458,6 +462,21 @@ describe("runtime-host-bridge executable packaging", () => {
     expect(validatePackagingText).toContain("contentRevision");
     expect(validatePackagingText).toContain("entryCounts");
     expect(validatePackagingText).toContain("security.audit");
+  });
+
+  test("packaged runtime validation exercises the extension catalog from packaged contracts", async () => {
+    const validatePackagingPath = path.join(
+      repoRoot,
+      "role-model-router",
+      "apps",
+      "runtime-host-bridge",
+      "src",
+      "validate-packaging.ts",
+    );
+    const validatePackagingText = await readFile(validatePackagingPath, "utf8");
+
+    expect(validatePackagingText).toContain("/api/role-model/extensions");
+    expect(validatePackagingText).toContain("evaluation-core");
   });
 
   test("packaged runtime validation tears down the packaged process tree before cleaning release artifacts", async () => {


### PR DESCRIPTION
Promotes the reviewed Run 88 Candidate J package from dev to stage. Candidate source commit f8f82d1933f089b879e054f1d226ad90b5608dba is preserved in ancestry. Feature-to-dev PR #113 passed all nine required checks. No new soak or application traffic is part of this promotion; the Run 88 evidence decision remains based on the operator-authorized 58 recorded requests.