### PR TITLE
fix(release): bind production packages to tested stage

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -61,6 +61,19 @@ jobs:
             target: win32-x64
 
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve public source tree
+        id: public_source
+        shell: bash
+        run: |
+          source_tree="$(git rev-parse HEAD^{tree})"
+          if [[ ! "$source_tree" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Public source tree must be an exact 40-character Git tree."
+            exit 1
+          fi
+          echo "source_tree=$source_tree" >> "$GITHUB_OUTPUT"
+
       - name: Validate Run 88 stage identity inputs
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
         shell: bash
@@ -80,7 +93,70 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - name: Resolve tested stage candidate
+        id: stage_candidate
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $artifactName = "role-model-stage-candidate-${{ steps.public_source.outputs.source_tree }}-${{ matrix.target }}"
+          $headers = @{
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            Accept = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $listUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/artifacts?name=$artifactName&per_page=20"
+          $artifact = (Invoke-RestMethod -Headers $headers -Uri $listUrl).artifacts |
+            Where-Object { -not $_.expired } |
+            Sort-Object created_at -Descending |
+            Select-Object -First 1
+          if (-not $artifact) { throw "No tested stage candidate found for $artifactName" }
+          $outerZip = Join-Path $env:RUNNER_TEMP "stage-candidate.zip"
+          $outerDir = Join-Path $env:RUNNER_TEMP "stage-candidate"
+          $innerDir = Join-Path $env:RUNNER_TEMP "stage-package"
+          Invoke-WebRequest -Headers $headers -Uri $artifact.archive_download_url -OutFile $outerZip
+          Expand-Archive -LiteralPath $outerZip -DestinationPath $outerDir -Force
+          $archive = Get-ChildItem -LiteralPath $outerDir -File | Select-Object -First 1
+          if (-not $archive) { throw "Stage candidate artifact contains no archive" }
+          New-Item -ItemType Directory -Force -Path $innerDir | Out-Null
+          if ($archive.Extension -eq ".zip") {
+            Expand-Archive -LiteralPath $archive.FullName -DestinationPath $innerDir -Force
+          } else {
+            tar -xzf $archive.FullName -C $innerDir
+            if ($LASTEXITCODE -ne 0) { throw "Failed to extract stage candidate" }
+          }
+          $stageManifestPath = Get-ChildItem -LiteralPath $innerDir -Recurse -Filter manifest.json |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $stageManifestPath) { throw "Stage candidate contains no manifest" }
+          $stage = Get-Content -LiteralPath $stageManifestPath -Raw | ConvertFrom-Json
+          if ($stage.channel -ne "stage" -or $stage.name -ne "role-model-stage") { throw "Artifact is not a stage candidate" }
+          if ($stage.source_tree -ne "${{ steps.public_source.outputs.source_tree }}") { throw "Stage candidate public source tree mismatch" }
+          if ($stage.release_id -notmatch '^sha256:[0-9a-f]{64}$') { throw "Stage candidate release identity is invalid" }
+          if ($stage.private_source_commit -notmatch '^[0-9a-f]{40}$') { throw "Stage candidate private source identity is invalid" }
+          if ($stage.private_distribution_sha256 -ne $stage.track_b_runtime.manifest_sha256) { throw "Stage candidate private distribution binding mismatch" }
+          if ($stage.track_b_runtime.sidecar_sha256 -notmatch '^[0-9a-f]{64}$') { throw "Stage candidate sidecar identity is invalid" }
+          if ($stage.track_b_runtime.extension_count -ne 13) { throw "Stage candidate does not contain all thirteen extensions" }
+          "stage_manifest_path=$stageManifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "release_id=$($stage.release_id)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "private_source_commit=$($stage.private_source_commit)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Select exact paired release identity
+        id: release_identity
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        shell: pwsh
+        run: |
+          if ($env:ROLE_MODEL_BUILD_CHANNEL -eq "production") {
+            $privateSource = "${{ steps.stage_candidate.outputs.private_source_commit }}"
+            $releaseId = "${{ steps.stage_candidate.outputs.release_id }}"
+          } else {
+            $privateSource = $env:PRIVATE_PAIRED_SHA
+            $releaseId = $env:RUN88_RELEASE_ID
+          }
+          if ($privateSource -notmatch '^[0-9a-f]{40}$') { throw "Exact private paired commit is invalid" }
+          if ($releaseId -notmatch '^sha256:[0-9a-f]{64}$') { throw "Exact Run 88 release identity is invalid" }
+          "private_source_commit=$privateSource" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "release_id=$releaseId" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - uses: pnpm/action-setup@v4
         with:
@@ -108,26 +184,28 @@ jobs:
       - name: Build UI
         run: pnpm --filter @role-model-router/runtime-ui run build
 
-      - name: Validate exact private stage revision
-        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+      - name: Validate exact private release revision
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
         shell: bash
+        env:
+          RELEASE_PRIVATE_SHA: ${{ steps.release_identity.outputs.private_source_commit }}
         run: |
-          if [[ ! "$PRIVATE_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "ROLE_MODEL_PAIRED_PRIVATE_SHA (or private_sha) must be an exact 40-character commit."
+          if [[ ! "$RELEASE_PRIVATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Paired private revision must be an exact 40-character commit."
             exit 1
           fi
 
-      - name: Checkout exact private stage revision
-        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+      - name: Checkout exact private release revision
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
         uses: actions/checkout@v4
         with:
           repository: try-works/role-model-internal
-          ref: ${{ env.PRIVATE_PAIRED_SHA }}
+          ref: ${{ steps.release_identity.outputs.private_source_commit }}
           token: ${{ secrets.ROLE_MODEL_INTERNAL_READ_TOKEN }}
           path: _private
 
-      - name: Build exact private stage distribution
-        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+      - name: Build exact private release distribution
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
         working-directory: _private
         env:
           ROLE_MODEL_PUBLIC_WORKTREE: ${{ github.workspace }}
@@ -138,13 +216,14 @@ jobs:
 
       - name: Package SEA runtime
         env:
-          ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT: ${{ env.ROLE_MODEL_BUILD_CHANNEL == 'stage' && format('{0}/_private/dist/run00-dev', github.workspace) || '' }}
+          ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT: ${{ (env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production') && format('{0}/_private/dist/run00-dev', github.workspace) || '' }}
+          RUN88_RELEASE_ID: ${{ steps.release_identity.outputs.release_id || env.RUN88_RELEASE_ID }}
         run: pnpm run runtime:package-sea
 
-      - name: Bind canonical Run 88 identity into stage package
-        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+      - name: Bind canonical Run 88 identity into release package
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
         shell: pwsh
-        run: node scripts/run88-stage-release.mjs --manifest "${{ github.workspace }}/role-model-router/dist/release/${{ matrix.target }}/manifest.json" --release-id "$env:RUN88_RELEASE_ID"
+        run: node scripts/run88-stage-release.mjs --manifest "${{ github.workspace }}/role-model-router/dist/release/${{ matrix.target }}/manifest.json" --release-id "${{ steps.release_identity.outputs.release_id }}" --private-source "${{ steps.release_identity.outputs.private_source_commit }}"
 
       - name: Verify channel manifest identity
         id: runtime_identity
@@ -166,57 +245,25 @@ jobs:
           if ($manifest.name -ne $expectedName) {
             throw "Manifest name '$($manifest.name)' does not match '$expectedName'"
           }
-          if ($env:ROLE_MODEL_BUILD_CHANNEL -eq "stage") {
-            if (-not $manifest.track_b_runtime.manifest_sha256) { throw "Missing stage private_distribution_sha256" }
-            if ($manifest.track_b_runtime.compatibility_generation -notin @("N", "N-1")) { throw "Invalid stage private distribution generation" }
+          if ($env:ROLE_MODEL_BUILD_CHANNEL -in @("stage", "production")) {
+            if (-not $manifest.track_b_runtime.manifest_sha256) { throw "Missing release private_distribution_sha256" }
+            if ($manifest.track_b_runtime.compatibility_generation -notin @("N", "N-1")) { throw "Invalid release private distribution generation" }
+            if ($manifest.track_b_runtime.sidecar_sha256 -notmatch '^[0-9a-f]{64}$') { throw "Invalid release private sidecar identity" }
+            if ($manifest.track_b_runtime.extension_count -ne 13) { throw "Release package does not contain all thirteen extensions" }
             "private_distribution_sha256=$($manifest.track_b_runtime.manifest_sha256)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            if ($manifest.release_id -ne $env:RUN88_RELEASE_ID) { throw "Stage manifest release_id mismatch" }
-            if ($manifest.private_distribution_sha256 -ne $manifest.track_b_runtime.manifest_sha256) { throw "Stage manifest private distribution binding mismatch" }
+            if ($manifest.release_id -ne "${{ steps.release_identity.outputs.release_id }}") { throw "Release manifest release_id mismatch" }
+            if ($manifest.private_source_commit -ne "${{ steps.release_identity.outputs.private_source_commit }}") { throw "Release manifest private source mismatch" }
+            if ($manifest.private_distribution_sha256 -ne $manifest.track_b_runtime.manifest_sha256) { throw "Release manifest private distribution binding mismatch" }
           }
           $manifestSha256 = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
           "manifest_sha256=$manifestSha256" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "source_tree=$($manifest.source_tree)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "core_payload_sha256=$($manifest.core_payload_sha256)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      - name: Verify production core matches the tested stage candidate
+      - name: Verify complete production pair matches the tested stage candidate
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'production'
         shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          $artifactName = "role-model-stage-candidate-${{ steps.runtime_identity.outputs.source_tree }}-${{ matrix.target }}"
-          $headers = @{
-            Authorization = "Bearer $env:GITHUB_TOKEN"
-            Accept = "application/vnd.github+json"
-            "X-GitHub-Api-Version" = "2022-11-28"
-          }
-          $listUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/artifacts?name=$artifactName&per_page=20"
-          $artifact = (Invoke-RestMethod -Headers $headers -Uri $listUrl).artifacts |
-            Where-Object { -not $_.expired } |
-            Sort-Object created_at -Descending |
-            Select-Object -First 1
-          if (-not $artifact) { throw "No tested stage candidate found for $artifactName" }
-          $outerZip = Join-Path $env:RUNNER_TEMP "stage-candidate.zip"
-          $outerDir = Join-Path $env:RUNNER_TEMP "stage-candidate"
-          $innerDir = Join-Path $env:RUNNER_TEMP "stage-package"
-          Invoke-WebRequest -Headers $headers -Uri $artifact.archive_download_url -OutFile $outerZip
-          Expand-Archive -LiteralPath $outerZip -DestinationPath $outerDir -Force
-          $archive = Get-ChildItem -LiteralPath $outerDir -File | Select-Object -First 1
-          if (-not $archive) { throw "Stage candidate artifact contains no archive" }
-          New-Item -ItemType Directory -Force -Path $innerDir | Out-Null
-          if ($archive.Extension -eq ".zip") {
-            Expand-Archive -LiteralPath $archive.FullName -DestinationPath $innerDir -Force
-          } else {
-            tar -xzf $archive.FullName -C $innerDir
-            if ($LASTEXITCODE -ne 0) { throw "Failed to extract stage candidate" }
-          }
-          $stageManifest = Get-ChildItem -LiteralPath $innerDir -Recurse -Filter manifest.json |
-            Select-Object -First 1 |
-            Get-Content -Raw |
-            ConvertFrom-Json
-          if ($stageManifest.core_payload_sha256 -ne "${{ steps.runtime_identity.outputs.core_payload_sha256 }}") {
-            throw "Production core payload does not match the tested stage candidate"
-          }
+        run: node scripts/run88-stage-release.mjs --stage-manifest "${{ steps.stage_candidate.outputs.stage_manifest_path }}" --verify-production-manifest "${{ github.workspace }}/role-model-router/dist/release/${{ matrix.target }}/manifest.json"
 
       - name: Verify Windows standalone package
         if: matrix.target == 'win32-x64'

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -107,10 +107,26 @@ jobs:
             "X-GitHub-Api-Version" = "2022-11-28"
           }
           $listUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/artifacts?name=$artifactName&per_page=20"
-          $artifact = (Invoke-RestMethod -Headers $headers -Uri $listUrl).artifacts |
+          $artifact = $null
+          $candidates = (Invoke-RestMethod -Headers $headers -Uri $listUrl).artifacts |
             Where-Object { -not $_.expired } |
-            Sort-Object created_at -Descending |
-            Select-Object -First 1
+            Sort-Object created_at -Descending
+          foreach ($candidate in $candidates) {
+            if ($candidate.workflow_run.head_branch -ne "stage") { continue }
+            $runUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/runs/$($candidate.workflow_run.id)"
+            $run = Invoke-RestMethod -Headers $headers -Uri $runUrl
+            if (
+              $run.status -eq "completed" -and
+              $run.conclusion -eq "success" -and
+              $run.event -eq "push" -and
+              $run.head_branch -eq "stage" -and
+              $run.head_sha -eq $candidate.workflow_run.head_sha -and
+              $run.path -eq ".github/workflows/build-binaries.yml"
+            ) {
+              $artifact = $candidate
+              break
+            }
+          }
           if (-not $artifact) { throw "No tested stage candidate found for $artifactName" }
           $outerZip = Join-Path $env:RUNNER_TEMP "stage-candidate.zip"
           $outerDir = Join-Path $env:RUNNER_TEMP "stage-candidate"
@@ -203,6 +219,26 @@ jobs:
           ref: ${{ steps.release_identity.outputs.private_source_commit }}
           token: ${{ secrets.ROLE_MODEL_INTERNAL_READ_TOKEN }}
           path: _private
+          fetch-depth: 0
+
+      - name: Verify private revision passed paired promotion branch
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        working-directory: _private
+        shell: bash
+        env:
+          RELEASE_PRIVATE_SHA: ${{ steps.release_identity.outputs.private_source_commit }}
+          REQUIRED_PRIVATE_BRANCH: ${{ env.ROLE_MODEL_BUILD_CHANNEL == 'production' && 'main' || 'stage' }}
+        run: |
+          actual_private_sha="$(git rev-parse HEAD)"
+          if [[ "$actual_private_sha" != "$RELEASE_PRIVATE_SHA" ]]; then
+            echo "Private checkout does not match the paired release identity."
+            exit 1
+          fi
+          git fetch --no-tags origin "+refs/heads/${REQUIRED_PRIVATE_BRANCH}:refs/remotes/origin/${REQUIRED_PRIVATE_BRANCH}"
+          if ! git merge-base --is-ancestor "$RELEASE_PRIVATE_SHA" "origin/$REQUIRED_PRIVATE_BRANCH"; then
+            echo "Private revision must be promoted through role-model-internal/$REQUIRED_PRIVATE_BRANCH before $ROLE_MODEL_BUILD_CHANNEL packaging."
+            exit 1
+          fi
 
       - name: Build exact private release distribution
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'

--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -10,6 +10,19 @@
 forwarded to `stage` and `dev` after merge. Never force-push a promotion branch to resynchronize it; use reviewed
 merge commits and resolve conflicts in the promotion PR.
 
+## Paired private repository
+
+`role-model` remains the release orchestrator and the only repository that publishes runtime archives and version
+tags. `role-model-internal` is nevertheless part of every stage and production package: its exact commit supplies
+the private runtime distribution and all 13 canonical extensions.
+
+Promote the paired private change first. Before a public stage build, the recorded private commit must be reachable
+from `role-model-internal/stage`; before a public production tag, that same tested commit must be reachable from
+`role-model-internal/main`. Set `ROLE_MODEL_PAIRED_PRIVATE_SHA` to the exact reviewed private stage commit before
+promoting public `dev -> stage`. The public workflow checks ancestry itself and fails closed; a raw commit SHA,
+feature branch, or current private branch tip is not sufficient. The private repository does not publish a second
+binary release or an independent version tag.
+
 ## Required CI lanes
 
 `.github/workflows/ci.yml` runs on pull requests and post-merge pushes for `dev`, `stage`, and `main`. Stable check
@@ -34,8 +47,9 @@ packages are available by explicit manual dispatch. Only a `v*` tag publishes a 
 Manifests report channel, endpoint, commit, source tree, executable SHA-256, channel-neutral core payload SHA-256,
 the exact private source commit, Run 88 release identity, private distribution manifest and sidecar digests, and the
 canonical extension count. A production tag must find the matching successful stage candidate, rebuild its exact
-private commit, and prove the complete public/private pair is identical. Source-tree or core-payload equality alone
-is insufficient.
+private commit, verify that the artifact came from a successful push build of public `stage`, verify that the private
+commit has subsequently passed through private `main`, and prove the complete public/private pair is identical.
+Source-tree or core-payload equality alone is insufficient.
 
 ## Docs site exception
 

--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -31,9 +31,11 @@ packages are available by explicit manual dispatch. Only a `v*` tag publishes a 
 | Stage | `role-model-stage` | `http://127.0.0.1:3457` | `role-model-runtime-stage` | `standalone-runtime-stage` |
 | Development | `role-model-dev` | `http://127.0.0.1:3458` | `role-model-runtime-dev` | `standalone-runtime-dev` |
 
-Manifests report channel, endpoint, commit, source tree, executable SHA-256, and channel-neutral core payload
-SHA-256. A production tag must find the matching successful stage candidate and prove the core payload digest is
-identical; source-tree equality alone is insufficient.
+Manifests report channel, endpoint, commit, source tree, executable SHA-256, channel-neutral core payload SHA-256,
+the exact private source commit, Run 88 release identity, private distribution manifest and sidecar digests, and the
+canonical extension count. A production tag must find the matching successful stage candidate, rebuild its exact
+private commit, and prove the complete public/private pair is identical. Source-tree or core-payload equality alone
+is insufficient.
 
 ## Docs site exception
 

--- a/docs/operations/03-release-checklist.md
+++ b/docs/operations/03-release-checklist.md
@@ -4,7 +4,8 @@
 
 1. Confirm the intended work is merged into `dev` with all required CI lanes green.
 2. Open and review `dev -> stage`; use a merge commit and do not rewrite stage history.
-3. Confirm the stage binary matrix completed and its artifacts include `role-model-stage`, commit/SHA identity,
+3. Confirm the stage binary matrix completed and its artifacts include `role-model-stage`, public source-tree,
+   exact private source commit, Run 88 release identity, private manifest/sidecar digests, all 13 extensions,
    attestations, and `core_payload_sha256`.
 4. Run the stage package on `3457` beside production on `3456` and development on `3458`; verify isolated state.
 
@@ -13,8 +14,9 @@
 1. Open and review `stage -> main`; do not add untested product changes during promotion.
 2. Confirm all main promotion checks pass and merge with a merge commit.
 3. Create an annotated tag: `git tag -a vX.Y.Z -m "role-model vX.Y.Z"`.
-4. Push the tag. Production packaging must retrieve the matching stage candidate and verify the exact core payload
-   digest before publication.
+4. Push the tag. Production packaging must retrieve the matching stage candidate, rebuild its exact private commit,
+   and verify the complete paired identity (release, public tree/core, private manifest/sidecar, compatibility
+   generation, and 13-extension closure) before publication.
 5. Approve the protected `release` environment when requested.
 
 ## Published assets

--- a/docs/operations/03-release-checklist.md
+++ b/docs/operations/03-release-checklist.md
@@ -2,22 +2,27 @@
 
 ## Stage candidate
 
-1. Confirm the intended work is merged into `dev` with all required CI lanes green.
-2. Open and review `dev -> stage`; use a merge commit and do not rewrite stage history.
-3. Confirm the stage binary matrix completed and its artifacts include `role-model-stage`, public source-tree,
+1. Confirm the intended work is merged into both repositories' `dev` branches with all available CI lanes green.
+2. Promote the exact paired private commit through reviewed `role-model-internal` `dev -> stage`, then set the public
+   `ROLE_MODEL_PAIRED_PRIVATE_SHA` variable to that private stage commit.
+3. Open and review public `dev -> stage`; use a merge commit and do not rewrite stage history.
+4. Confirm the stage binary matrix completed and its artifacts include `role-model-stage`, public source-tree,
    exact private source commit, Run 88 release identity, private manifest/sidecar digests, all 13 extensions,
    attestations, and `core_payload_sha256`.
-4. Run the stage package on `3457` beside production on `3456` and development on `3458`; verify isolated state.
+5. Run the stage package on `3457` beside production on `3456` and development on `3458`; verify isolated state.
 
 ## Production promotion
 
-1. Open and review `stage -> main`; do not add untested product changes during promotion.
-2. Confirm all main promotion checks pass and merge with a merge commit.
-3. Create an annotated tag: `git tag -a vX.Y.Z -m "role-model vX.Y.Z"`.
-4. Push the tag. Production packaging must retrieve the matching stage candidate, rebuild its exact private commit,
+1. Promote private `stage -> main` with a reviewed merge commit; the exact private commit recorded by the tested
+   stage package must be an ancestor of private `main`.
+2. Open and review public `stage -> main`; do not add untested product changes during promotion.
+3. Confirm all main promotion checks pass and merge with a merge commit.
+4. Create an annotated public tag: `git tag -a vX.Y.Z -m "role-model vX.Y.Z"`. The private repository does not
+   receive a separate release tag.
+5. Push the tag. Production packaging must retrieve an artifact from a successful public `stage` push, rebuild its exact private commit,
    and verify the complete paired identity (release, public tree/core, private manifest/sidecar, compatibility
    generation, and 13-extension closure) before publication.
-5. Approve the protected `release` environment when requested.
+6. Approve the protected `release` environment when requested.
 
 ## Published assets
 

--- a/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/package-sea.ts
@@ -46,6 +46,28 @@ export interface StandaloneReleaseCopy {
   readonly destinationRelativePath: string;
 }
 
+export function validatePairedReleasePackagingInputs<
+  T extends Readonly<{ manifestSha256: string }>,
+>({
+  channel,
+  releaseId,
+  trackBRuntime,
+}: Readonly<{
+  channel: "production" | "stage" | "development";
+  releaseId: string | undefined;
+  trackBRuntime: T | null;
+}>): Readonly<{ releaseId: string | undefined; trackBRuntime: T | null }> {
+  if (channel === "stage" || channel === "production") {
+    if (!/^sha256:[0-9a-f]{64}$/.test(releaseId ?? "")) {
+      throw new Error(`${channel} packaging requires an exact Run 88 release identity`);
+    }
+    if (!trackBRuntime || !/^[0-9a-f]{64}$/.test(trackBRuntime.manifestSha256)) {
+      throw new Error(`${channel} packaging requires the exact private distribution`);
+    }
+  }
+  return Object.freeze({ releaseId, trackBRuntime });
+}
+
 const NODE_SEA_FUSE = "NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -619,12 +641,11 @@ export async function packageSeaRuntime(): Promise<{
   }
   const sourceTree = sourceTreeResult.stdout.trim();
   const run88ReleaseId = process.env.RUN88_RELEASE_ID?.trim();
-  if (
-    profile.channel === "stage" &&
-    (!/^sha256:[0-9a-f]{64}$/.test(run88ReleaseId ?? "") || !trackBRuntime)
-  ) {
-    throw new Error("Stage packaging requires an exact RUN88_RELEASE_ID and private distribution");
-  }
+  validatePairedReleasePackagingInputs({
+    channel: profile.channel,
+    releaseId: run88ReleaseId,
+    trackBRuntime,
+  });
   await writeFile(
     path.join(releaseDir, "manifest.json"),
     JSON.stringify(
@@ -642,7 +663,7 @@ export async function packageSeaRuntime(): Promise<{
         build_date: versionInfo.build_date,
         ...profile,
         endpoint: `http://${profile.host}:${profile.port}`,
-        ...(profile.channel === "stage"
+        ...(profile.channel === "stage" || profile.channel === "production"
           ? {
               release_id: run88ReleaseId,
               private_distribution_sha256: trackBRuntime?.manifestSha256,

--- a/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run88-stage-release.unit.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { validateRun88PrivateDistributionIdentity } from "../src/kw-private-loader.js";
+import { validatePairedReleasePackagingInputs } from "../src/package-sea.js";
 import * as runtimeVersion from "../src/runtime-version.js";
 import * as trackBRuntime from "../src/track-b-runtime.js";
 import {
@@ -23,6 +24,39 @@ afterEach(async () =>
 );
 
 describe("Run 88 stage release boundary", () => {
+  it("requires the private distribution and release identity for stage and production packaging", () => {
+    const trackB = { manifestSha256: "a".repeat(64) };
+    for (const channel of ["stage", "production"] as const) {
+      expect(
+        validatePairedReleasePackagingInputs({
+          channel,
+          releaseId: `sha256:${"b".repeat(64)}`,
+          trackBRuntime: trackB,
+        }),
+      ).toEqual({ releaseId: `sha256:${"b".repeat(64)}`, trackBRuntime: trackB });
+      expect(() =>
+        validatePairedReleasePackagingInputs({
+          channel,
+          releaseId: undefined,
+          trackBRuntime: trackB,
+        }),
+      ).toThrow(/release/i);
+      expect(() =>
+        validatePairedReleasePackagingInputs({
+          channel,
+          releaseId: `sha256:${"b".repeat(64)}`,
+          trackBRuntime: null,
+        }),
+      ).toThrow(/private distribution/i);
+    }
+    expect(
+      validatePairedReleasePackagingInputs({
+        channel: "development",
+        releaseId: undefined,
+        trackBRuntime: null,
+      }),
+    ).toEqual({ releaseId: undefined, trackBRuntime: null });
+  });
   it("public runtime probes are criterion-specific at every required layer", () => {
     const expected = [
       "R2-AC02",

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -36,3 +36,13 @@ test("production artifacts include the exact private runtime tested at stage", (
   assert.match(workflow, /private_distribution_sha256/);
   assert.match(workflow, /--verify-production-manifest/);
 });
+
+test("the public release orchestrator enforces paired private promotion", () => {
+  assert.match(workflow, /workflow_run\.head_branch -ne "stage"/);
+  assert.match(workflow, /run\.conclusion -eq "success"/);
+  assert.match(workflow, /run\.event -eq "push"/);
+  assert.match(workflow, /fetch-depth: 0/);
+  assert.match(workflow, /Verify private revision passed paired promotion branch/);
+  assert.match(workflow, /REQUIRED_PRIVATE_BRANCH:[\s\S]*?'main'[\s\S]*?'stage'/);
+  assert.match(workflow, /git merge-base --is-ancestor/);
+});

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -28,3 +28,11 @@ test("build-binaries produces stage candidates, manual dev builds, and tag-only 
   assert.match(workflow, /role-model-stage/);
   assert.match(workflow, /role-model-dev/);
 });
+
+test("production artifacts include the exact private runtime tested at stage", () => {
+  assert.match(workflow, /private_source_commit/);
+  assert.match(workflow, /extension_count/);
+  assert.match(workflow, /sidecar_sha256/);
+  assert.match(workflow, /private_distribution_sha256/);
+  assert.match(workflow, /--verify-production-manifest/);
+});

--- a/scripts/run88-stage-release-workflow.test.mjs
+++ b/scripts/run88-stage-release-workflow.test.mjs
@@ -33,6 +33,23 @@ test("stage package workflow requires and always binds the canonical Run 88 rele
   assert.doesNotMatch(binaries, /Bind canonical Run 88 identity[\s\S]*?RUN88_RELEASE_ID\s*!=\s*''/);
   assert.match(
     binaries,
-    /if \(\$env:ROLE_MODEL_BUILD_CHANNEL -eq "stage"\)[\s\S]*?release_id[\s\S]*?private_distribution_sha256/,
+    /if \(\$env:ROLE_MODEL_BUILD_CHANNEL -in @\("stage", "production"\)\)[\s\S]*?release_id[\s\S]*?private_distribution_sha256/,
   );
+});
+
+test("production packaging rebuilds and verifies the complete tested stage pair", async () => {
+  const binaries = await readFile(
+    new URL("../.github/workflows/build-binaries.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(binaries, /Resolve tested stage candidate/);
+  assert.match(binaries, /private_source_commit/);
+  assert.match(
+    binaries,
+    /Checkout exact private release revision[\s\S]*?ROLE_MODEL_BUILD_CHANNEL == 'stage' \|\| env\.ROLE_MODEL_BUILD_CHANNEL == 'production'/,
+  );
+  assert.match(binaries, /ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT:[\s\S]*?production/);
+  assert.match(binaries, /Verify complete production pair matches the tested stage candidate/);
+  assert.match(binaries, /validateRun88ProductionPromotion|--verify-production-manifest/);
+  assert.doesNotMatch(binaries, /Verify production core matches the tested stage candidate/);
 });

--- a/scripts/run88-stage-release.mjs
+++ b/scripts/run88-stage-release.mjs
@@ -50,30 +50,64 @@ export function validatePublicRollbackTarget(target) {
   return Object.freeze({ ok: true, ...target });
 }
 
-export async function bindRun88StageManifest({
+const RELEASE_PROFILES = Object.freeze({
+  stage: Object.freeze({
+    name: "role-model-stage",
+    host: "127.0.0.1",
+    port: 3457,
+    endpoint: "http://127.0.0.1:3457",
+    stateRootName: "role-model-runtime-stage",
+    scopeId: "standalone-runtime-stage",
+  }),
+  production: Object.freeze({
+    name: "role-model",
+    host: "127.0.0.1",
+    port: 3456,
+    endpoint: "http://127.0.0.1:3456",
+    stateRootName: "role-model-runtime",
+    scopeId: "standalone-runtime",
+  }),
+});
+
+function validateReleasePackage(manifest) {
+  const profile = RELEASE_PROFILES[manifest?.channel];
+  if (
+    !profile ||
+    manifest.name !== profile.name ||
+    manifest.host !== profile.host ||
+    manifest.port !== profile.port ||
+    manifest.endpoint !== profile.endpoint ||
+    manifest.state_root_name !== profile.stateRootName ||
+    manifest.scope_id !== profile.scopeId ||
+    !GIT_REF.test(manifest.source_tree ?? "") ||
+    !SHA256.test(manifest.executable_sha256 ?? "") ||
+    !SHA256.test(manifest.core_payload_sha256 ?? "")
+  )
+    throw new Error("only a complete isolated stage or production package may be Run 88-bound");
+  const trackB = manifest.track_b_runtime;
+  requireDigest(trackB?.manifest_sha256, "private distribution manifest sha256");
+  requireDigest(trackB?.sidecar_sha256, "private distribution sidecar sha256");
+  if (!new Set(["N", "N-1"]).has(trackB?.compatibility_generation))
+    throw new Error("private distribution compatibility generation is invalid");
+  if (trackB?.extension_count !== 13)
+    throw new Error("complete thirteen-extension private distribution is required");
+  return manifest;
+}
+
+export async function bindRun88ReleaseManifest({
   manifestPath,
   releaseId,
+  privateSourceCommit,
   privateDistributionSha256,
 } = {}) {
   if (typeof manifestPath !== "string" || !path.isAbsolute(manifestPath))
     throw new Error("absolute packaged manifest path is required");
   if (!/^sha256:[0-9a-f]{64}$/.test(releaseId ?? ""))
     throw new Error("Run 88 release id is invalid");
+  if (!GIT_REF.test(privateSourceCommit ?? ""))
+    throw new Error("exact private source commit is required");
   requireDigest(privateDistributionSha256, "private distribution sha256");
-  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
-  if (
-    manifest.channel !== "stage" ||
-    manifest.name !== "role-model-stage" ||
-    manifest.host !== "127.0.0.1" ||
-    manifest.port !== 3457 ||
-    manifest.endpoint !== "http://127.0.0.1:3457" ||
-    manifest.state_root_name !== "role-model-runtime-stage" ||
-    manifest.scope_id !== "standalone-runtime-stage" ||
-    !/^[0-9a-f]{40}$/.test(manifest.source_tree ?? "") ||
-    !/^[0-9a-f]{64}$/.test(manifest.executable_sha256 ?? "") ||
-    !/^[0-9a-f]{64}$/.test(manifest.core_payload_sha256 ?? "")
-  )
-    throw new Error("only a complete isolated stage package may be Run 88-bound");
+  const manifest = validateReleasePackage(JSON.parse(await readFile(manifestPath, "utf8")));
   if (manifest.track_b_runtime?.manifest_sha256 !== privateDistributionSha256)
     throw new Error("package/private distribution mismatch");
   if (manifest.release_id && manifest.release_id !== releaseId)
@@ -83,18 +117,81 @@ export async function bindRun88StageManifest({
     manifest.private_distribution_sha256 !== privateDistributionSha256
   )
     throw new Error("package private distribution identity is already bound differently");
+  if (manifest.private_source_commit && manifest.private_source_commit !== privateSourceCommit)
+    throw new Error("package private source identity is already bound differently");
   const bound = {
     ...manifest,
     release_id: releaseId,
+    private_source_commit: privateSourceCommit,
     private_distribution_sha256: privateDistributionSha256,
   };
   await writeFile(manifestPath, `${JSON.stringify(bound, null, 2)}\n`, "utf8");
   return Object.freeze({
     releaseId,
+    privateSourceCommit,
     privateDistributionSha256,
     manifestSha256: createHash("sha256")
       .update(await readFile(manifestPath))
       .digest("hex"),
+  });
+}
+
+export async function bindRun88StageManifest(input = {}) {
+  return bindRun88ReleaseManifest(input);
+}
+
+export function validateRun88ProductionPromotion({ stage, production } = {}) {
+  validateReleasePackage(stage);
+  validateReleasePackage(production);
+  if (stage.channel !== "stage" || production.channel !== "production")
+    throw new Error("promotion requires one stage and one production package");
+  if (!/^sha256:[0-9a-f]{64}$/.test(stage.release_id ?? ""))
+    throw new Error("tested stage release identity is invalid");
+  if (!GIT_REF.test(stage.private_source_commit ?? ""))
+    throw new Error("tested stage private source identity is invalid");
+  const comparisons = [
+    ["source tree", stage.source_tree, production.source_tree],
+    ["core payload", stage.core_payload_sha256, production.core_payload_sha256],
+    ["release id", stage.release_id, production.release_id],
+    ["private source", stage.private_source_commit, production.private_source_commit],
+    [
+      "private distribution",
+      stage.private_distribution_sha256,
+      production.private_distribution_sha256,
+    ],
+    [
+      "private manifest",
+      stage.track_b_runtime.manifest_sha256,
+      production.track_b_runtime.manifest_sha256,
+    ],
+    [
+      "private sidecar",
+      stage.track_b_runtime.sidecar_sha256,
+      production.track_b_runtime.sidecar_sha256,
+    ],
+    [
+      "private compatibility generation",
+      stage.track_b_runtime.compatibility_generation,
+      production.track_b_runtime.compatibility_generation,
+    ],
+    [
+      "extension count",
+      stage.track_b_runtime.extension_count,
+      production.track_b_runtime.extension_count,
+    ],
+  ];
+  for (const [field, expected, actual] of comparisons) {
+    if (expected !== actual)
+      throw new Error(`production ${field} does not match the tested stage candidate`);
+  }
+  if (production.private_distribution_sha256 !== production.track_b_runtime.manifest_sha256)
+    throw new Error("production private distribution binding is inconsistent");
+  return Object.freeze({
+    ok: true,
+    releaseId: production.release_id,
+    privateSourceCommit: production.private_source_commit,
+    privateDistributionSha256: production.private_distribution_sha256,
+    extensionCount: production.track_b_runtime.extension_count,
   });
 }
 
@@ -104,13 +201,28 @@ function cliArg(name) {
 }
 
 if (import.meta.url === pathToFileURL(path.resolve(process.argv[1] ?? "")).href) {
-  const manifestPath = path.resolve(cliArg("--manifest") ?? "");
-  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
-  bindRun88StageManifest({
-    manifestPath,
-    releaseId: cliArg("--release-id"),
-    privateDistributionSha256: manifest.track_b_runtime?.manifest_sha256,
-  })
+  const productionManifestPath = cliArg("--verify-production-manifest");
+  const operation = productionManifestPath
+    ? Promise.all([
+        readFile(path.resolve(cliArg("--stage-manifest") ?? ""), "utf8"),
+        readFile(path.resolve(productionManifestPath), "utf8"),
+      ]).then(([stage, production]) =>
+        validateRun88ProductionPromotion({
+          stage: JSON.parse(stage),
+          production: JSON.parse(production),
+        }),
+      )
+    : (async () => {
+        const manifestPath = path.resolve(cliArg("--manifest") ?? "");
+        const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+        return bindRun88ReleaseManifest({
+          manifestPath,
+          releaseId: cliArg("--release-id"),
+          privateSourceCommit: cliArg("--private-source"),
+          privateDistributionSha256: manifest.track_b_runtime?.manifest_sha256,
+        });
+      })();
+  operation
     .then((result) => console.log(JSON.stringify(result, null, 2)))
     .catch((error) => {
       console.error(error.message);

--- a/scripts/run88-stage-release.test.mjs
+++ b/scripts/run88-stage-release.test.mjs
@@ -76,17 +76,24 @@ test("actual packaged manifest binding writes and verifies the canonical Run 88 
       source_tree: "a".repeat(40),
       executable_sha256: "e".repeat(64),
       core_payload_sha256: "f".repeat(64),
-      track_b_runtime: { manifest_sha256: "c".repeat(64), compatibility_generation: "N" },
+      track_b_runtime: {
+        manifest_sha256: "c".repeat(64),
+        sidecar_sha256: "d".repeat(64),
+        compatibility_generation: "N",
+        extension_count: 13,
+      },
     }),
   );
   const releaseId = `sha256:${"9".repeat(64)}`;
   const result = await module.bindRun88StageManifest({
     manifestPath,
     releaseId,
+    privateSourceCommit: "7".repeat(40),
     privateDistributionSha256: "c".repeat(64),
   });
   const persisted = JSON.parse(await readFile(manifestPath, "utf8"));
   assert.equal(persisted.release_id, releaseId);
+  assert.equal(persisted.private_source_commit, "7".repeat(40));
   assert.equal(persisted.private_distribution_sha256, "c".repeat(64));
   assert.equal(result.releaseId, releaseId);
   await assert.rejects(
@@ -94,9 +101,93 @@ test("actual packaged manifest binding writes and verifies the canonical Run 88 
       module.bindRun88StageManifest({
         manifestPath,
         releaseId: `sha256:${"8".repeat(64)}`,
+        privateSourceCommit: "6".repeat(40),
         privateDistributionSha256: "d".repeat(64),
       }),
     /distribution|mismatch/i,
+  );
+  await rm(root, { recursive: true, force: true });
+});
+
+test("production promotion preserves the complete tested stage pair, not only the public executable", async () => {
+  assert.equal(
+    typeof module.bindRun88ReleaseManifest,
+    "function",
+    "missing stage/production package identity binder",
+  );
+  assert.equal(
+    typeof module.validateRun88ProductionPromotion,
+    "function",
+    "missing full paired production promotion validator",
+  );
+  const root = await mkdtemp(path.join(os.tmpdir(), "run88-production-bind-"));
+  const privateSourceCommit = "7".repeat(40);
+  const releaseId = `sha256:${"9".repeat(64)}`;
+  const privateDistributionSha256 = "c".repeat(64);
+  const base = {
+    host: "127.0.0.1",
+    source_tree: "a".repeat(40),
+    executable_sha256: "e".repeat(64),
+    core_payload_sha256: "f".repeat(64),
+    track_b_runtime: {
+      manifest_sha256: privateDistributionSha256,
+      sidecar_sha256: "d".repeat(64),
+      compatibility_generation: "N",
+      extension_count: 13,
+    },
+  };
+  const manifests = {
+    stage: {
+      ...base,
+      channel: "stage",
+      name: "role-model-stage",
+      port: 3457,
+      endpoint: "http://127.0.0.1:3457",
+      state_root_name: "role-model-runtime-stage",
+      scope_id: "standalone-runtime-stage",
+    },
+    production: {
+      ...base,
+      channel: "production",
+      name: "role-model",
+      port: 3456,
+      endpoint: "http://127.0.0.1:3456",
+      state_root_name: "role-model-runtime",
+      scope_id: "standalone-runtime",
+    },
+  };
+  const persisted = {};
+  for (const [channel, manifest] of Object.entries(manifests)) {
+    const manifestPath = path.join(root, `${channel}.json`);
+    await writeFile(manifestPath, JSON.stringify(manifest));
+    await module.bindRun88ReleaseManifest({
+      manifestPath,
+      releaseId,
+      privateSourceCommit,
+      privateDistributionSha256,
+    });
+    persisted[channel] = JSON.parse(await readFile(manifestPath, "utf8"));
+  }
+  assert.deepEqual(module.validateRun88ProductionPromotion(persisted), {
+    ok: true,
+    releaseId,
+    privateSourceCommit,
+    privateDistributionSha256,
+    extensionCount: 13,
+  });
+  assert.throws(
+    () =>
+      module.validateRun88ProductionPromotion({
+        ...persisted,
+        production: {
+          ...persisted.production,
+          track_b_runtime: {
+            ...persisted.production.track_b_runtime,
+            sidecar_sha256: "0".repeat(64),
+          },
+        },
+      }),
+    /sidecar|tested stage|promotion/i,
   );
   await rm(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
Hardens the documented Run 88 release path so the public repository remains the sole release orchestrator while the private repository is an explicit immutable package input.

The workflow now:
- requires the exact private commit to be reachable from private stage before a public stage build;
- requires that same tested private commit to be reachable from private main before a public production tag;
- accepts a production candidate only from a successful push run of the public build-binaries workflow on stage;
- rebuilds the exact private source commit and compares the complete public/private executable, sidecar, manifest, and 13-extension identity before publishing;
- documents the private-before-public promotion sequence without introducing a second private tag or binary release.

Verification:
- full local pnpm ci:check PASS;
- focused release workflow tests: 28/28 PASS;
- runtime-host suite: 692 PASS, 3 skipped;
- critical UI tests: 124/124 PASS;
- critical runtime-host tests: 89/89 PASS;
- Rust tests and gateway smoke PASS;
- diff check PASS.