### PR TITLE
fix(release): pin reproducible Node toolchain

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -180,7 +180,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: "24.19.0"
           cache: pnpm
 
       - uses: actions/setup-go@v5
@@ -462,7 +462,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: "24.19.0"
 
       - name: Download release archives
         uses: actions/download-artifact@v4

--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -51,6 +51,9 @@ private commit, verify that the artifact came from a successful push build of pu
 commit has subsequently passed through private `main`, and prove the complete public/private pair is identical.
 Source-tree or core-payload equality alone is insufficient.
 
+Run 88's `v0.0.8` release-toolchain recovery and the exact stage/production payload diagnosis are recorded in
+[`run88-v0.0.8-release-toolchain.addendum.md`](run88-v0.0.8-release-toolchain.addendum.md).
+
 ## Docs site exception
 
 The docs site is intentionally simpler than the runtime pipeline. Relevant pull requests build it without deploy

--- a/docs/operations/run88-v0.0.8-release-toolchain.addendum.md
+++ b/docs/operations/run88-v0.0.8-release-toolchain.addendum.md
@@ -1,0 +1,37 @@
+# Run 88 `v0.0.8` release-toolchain addendum
+
+Status: active release recovery
+Date: 2026-08-14
+
+This addendum records a release-process correction for the existing Run 88 candidate. It does not create a new
+repair package, soak epoch, or product candidate.
+
+## Failure and root cause
+
+Production workflow run `31759167117` failed its Windows complete-pair comparison before any GitHub Release was
+published. The public source tree and paired private commit matched, but the SEA executable did not:
+
+| Build | Node patch | Executable SHA-256 | Length |
+| --- | --- | --- | --- |
+| Earlier tested stage (`31757270477`) | `24.19.0` | `747fac49a4b272d4d0289e56b6e8b19815a56a42516a047c4d499c1aa3a42874` | `103273984` |
+| Reconciled stage (`31758760193`) | `24.18.1` | `8de6bdb5aa472b040d96d75b4e276550e20b4a74b504bb16bccc3a87c6137dc8` | `102988800` |
+| Failed production (`31759167117`) | `24.19.0` | `747fac49a4b272d4d0289e56b6e8b19815a56a42516a047c4d499c1aa3a42874` | `103273984` |
+
+`.github/workflows/build-binaries.yml` requested only Node major `24`. `actions/setup-node` therefore selected
+different available patch releases on different runners. `scripts/package-sea.ts` copies `process.execPath` into the
+SEA package, so a Node patch difference necessarily changes the executable and `core_payload_sha256`.
+
+## Decision
+
+- Pin every release-workflow `actions/setup-node` use to exact Node `24.19.0`.
+- Keep the existing Run 88 candidate, private revision, and release identity; do not send new runtime/LLM requests.
+- Promote this workflow-only correction through the normal `dev -> stage -> main` chain.
+- Require the rebuilt stage and production matrices to prove the complete public/private pair again.
+- Treat the first `v0.0.8` tag as an unpublished failed release attempt. Do not publish it from mismatched artifacts;
+  recover the same version only after the corrected candidate passes the guarded chain.
+
+## Pull-request and branch audit
+
+At the time of this correction both the public and private repositories had zero open pull requests. Run 88 PRs
+were merged. Remaining remote feature-branch names are stale merged/squash sources, except for an unrelated old
+public Run 03 branch with no PR and the intentionally closed private setup PR #2; neither is release input.

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -16,6 +16,12 @@ test("build-binaries retries release attestation before failing", () => {
   assert.match(workflow, /steps\.attest_release_archive_attempt_2\.outcome == 'failure'/);
 });
 
+test("build-binaries pins one exact Node patch for reproducible SEA payloads", () => {
+  const exactPins = workflow.match(/node-version: "24\.19\.0"/g) ?? [];
+  assert.equal(exactPins.length, 2);
+  assert.doesNotMatch(workflow, /node-version:\s*24(?:\s|$)/);
+});
+
 test("build-binaries produces stage candidates, manual dev builds, and tag-only releases", () => {
   assert.match(workflow, /branches:\s*\n\s*- stage/);
   assert.match(workflow, /ROLE_MODEL_BUILD_CHANNEL/);

--- a/scripts/run88-public-semantic-probes.mjs
+++ b/scripts/run88-public-semantic-probes.mjs
@@ -62,8 +62,8 @@ export const publicAcceptanceProbes = Object.freeze({
     integration: async () => {
       const { ci, binaries } = await workflowBytes();
       assert.ok(ci.includes("ROLE_MODEL_PAIRED_PRIVATE_SHA"));
-      assert.ok(binaries.includes("Validate exact private stage revision"));
-      assert.ok(binaries.includes("Bind canonical Run 88 identity into stage package"));
+      assert.ok(binaries.includes("Verify private revision passed paired promotion branch"));
+      assert.ok(binaries.includes("Bind canonical Run 88 identity into release package"));
       return {
         acceptanceId: "R1-AC03",
         layer: "integration",
@@ -180,7 +180,7 @@ export const publicAcceptanceProbes = Object.freeze({
     integration: async () => {
       const { ci, binaries } = await workflowBytes();
       assert.ok(ci.includes("promotion-guard"));
-      assert.ok(binaries.includes("Validate exact private stage revision"));
+      assert.ok(binaries.includes("Verify private revision passed paired promotion branch"));
       assert.ok(binaries.includes("ROLE_MODEL_PAIRED_PRIVATE_SHA"));
       return {
         acceptanceId: "R3-AC01",
@@ -471,7 +471,7 @@ export const publicAcceptanceProbes = Object.freeze({
     },
     integration: async () => {
       const { binaries } = await workflowBytes();
-      assert.ok(binaries.includes("Bind canonical Run 88 identity into stage package"));
+      assert.ok(binaries.includes("Bind canonical Run 88 identity into release package"));
       assert.ok(binaries.includes("Verify package contains no QA fixtures or mock data"));
       return {
         acceptanceId: "R9-AC06",


### PR DESCRIPTION
## What changed

- pin both release-workflow Node setup steps to exact Node 24.19.0
- assert the exact patch pin in the workflow contract test
- update stale Run 88 semantic probes to the current paired-promotion step names
- document the failed unpublished v0.0.8 attempt and recovery decision in the existing release guide/addendum

## Root cause

The release workflow requested only Node major 24. The final stage Windows runner selected 24.18.1 while production selected 24.19.0. Because the SEA packager embeds process.execPath, the executable and core payload hashes differed despite an identical public source tree and private revision.

## Impact

Stage and production now build from one exact Node executable patch, making complete-pair comparison deterministic. No runtime behavior, private source revision, request evidence, or package identity changed.

## Validation

- `node --test scripts/build-binaries-workflow.test.mjs scripts/run88-stage-release.test.mjs scripts/run88-stage-release-workflow.test.mjs scripts/run88-stage-release-workflow.integration.test.mjs scripts/run88-stage-release-workflow.regression.test.mjs` — 37/37 passed
- `corepack pnpm run ci:check` — passed end-to-end after redirecting npm temp/cache to D:
- `git diff --cached --check` — passed before commit

## Real behavior proof

- Setup: Windows, Node v24.11.0, pnpm 10.6.5
- Compared manifests from stage runs 31757270477 and 31758760193 with production run 31759167117.
- Stage Node 24.18.1 produced executable SHA 8de6bdb5..., while stage/production Node 24.19.0 produced 747fac49..., confirming toolchain patch selection as the payload boundary.
- No new LLM/runtime/Cloudflare traffic was sent. The corrected GitHub stage and production matrices are the remaining release proof.