### PR TITLE
fix(launcher): allow operational degraded startup

### DIFF
--- a/role-model-router/apps/launcher/main.go
+++ b/role-model-router/apps/launcher/main.go
@@ -183,7 +183,8 @@ func waitForServerReady(baseURL string, attempts int, interval time.Duration) bo
 		}
 		decodeErr := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&health)
 		_ = resp.Body.Close()
-		if resp.StatusCode == http.StatusOK && decodeErr == nil && health.SessionBootstrap.Status == "ready" {
+		bootstrapOperational := health.SessionBootstrap.Status == "ready" || health.SessionBootstrap.Status == "degraded"
+		if resp.StatusCode == http.StatusOK && decodeErr == nil && bootstrapOperational {
 			return true
 		}
 	}

--- a/role-model-router/apps/launcher/main_test.go
+++ b/role-model-router/apps/launcher/main_test.go
@@ -213,6 +213,22 @@ func TestWaitForServerReadyReturnsWhenBackendBootstrapBecomesReady(t *testing.T)
 	}
 }
 
+func TestWaitForServerReadyAllowsOperationalDegradedBootstrap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/healthz" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("content-type", "application/json")
+		_, _ = writer.Write([]byte(`{"status":"degraded","sessionBootstrap":{"status":"degraded"}}`))
+	}))
+	defer server.Close()
+
+	if !waitForServerReady(server.URL, 2, 5*time.Millisecond) {
+		t.Fatal("expected operational degraded backend to be launchable")
+	}
+}
+
 func TestWaitForServerReadyReturnsFalseWhenHealthEndpointNeverResponds(t *testing.T) {
 	start := time.Now()
 	if waitForServerReady("http://127.0.0.1:1", 2, 20*time.Millisecond) {


### PR DESCRIPTION
## Summary

- allow the packaged launcher to open when bootstrap completes in the operational `degraded` state
- continue rejecting `blocked`, pending, malformed, and unreachable bootstrap states
- retain the `/healthz` semantic readiness requirement introduced in v0.0.9

## Live diagnosis

The v0.0.9 backend successfully provisioned and reused the managed Message Graph keys, returned 200 for router summary and telemetry, and had one healthy DeepSeek endpoint. Its bootstrap was `degraded` only because an optional Kimi endpoint lacked credentials. The launcher incorrectly killed this operational backend after 30 seconds.

## Verification

- `GO111MODULE=off go test` in `role-model-router/apps/launcher`
- `corepack pnpm --filter @role-model/schema-tools test`
- `corepack pnpm run ci:check`

The first full local CI attempt hit an unrelated 5-second schema-generation timeout under parallel load; the isolated suite passed, and the warm full CI rerun passed end to end.