### PR TITLE
chore(release): forward-merge v0.0.10 launcher hotfix to dev

### DIFF
--- a/role-model-router/apps/launcher/main.go
+++ b/role-model-router/apps/launcher/main.go
@@ -183,7 +183,8 @@ func waitForServerReady(baseURL string, attempts int, interval time.Duration) bo
 		}
 		decodeErr := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&health)
 		_ = resp.Body.Close()
-		if resp.StatusCode == http.StatusOK && decodeErr == nil && health.SessionBootstrap.Status == "ready" {
+		bootstrapOperational := health.SessionBootstrap.Status == "ready" || health.SessionBootstrap.Status == "degraded"
+		if resp.StatusCode == http.StatusOK && decodeErr == nil && bootstrapOperational {
 			return true
 		}
 	}

--- a/role-model-router/apps/launcher/main_test.go
+++ b/role-model-router/apps/launcher/main_test.go
@@ -213,6 +213,22 @@ func TestWaitForServerReadyReturnsWhenBackendBootstrapBecomesReady(t *testing.T)
 	}
 }
 
+func TestWaitForServerReadyAllowsOperationalDegradedBootstrap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/healthz" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("content-type", "application/json")
+		_, _ = writer.Write([]byte(`{"status":"degraded","sessionBootstrap":{"status":"degraded"}}`))
+	}))
+	defer server.Close()
+
+	if !waitForServerReady(server.URL, 2, 5*time.Millisecond) {
+		t.Fatal("expected operational degraded backend to be launchable")
+	}
+}
+
 func TestWaitForServerReadyReturnsFalseWhenHealthEndpointNeverResponds(t *testing.T) {
 	start := time.Now()
 	if waitForServerReady("http://127.0.0.1:1", 2, 20*time.Millisecond) {


### PR DESCRIPTION
Forward-merge the v0.0.10 launcher readiness hotfix after its protected merge to `main`.

This keeps `dev` aligned with the production fix. The exact hotfix commit is `9fff0aa2846ae61aff7a94cebd5858c904d7d0cf` and all PR/local CI checks passed on PR #128.