### PR TITLE
chore(release): promote v0.0.10 launcher hotfix to stage

### DIFF
--- a/role-model-router/apps/launcher/main.go
+++ b/role-model-router/apps/launcher/main.go
@@ -183,7 +183,8 @@ func waitForServerReady(baseURL string, attempts int, interval time.Duration) bo
 		}
 		decodeErr := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&health)
 		_ = resp.Body.Close()
-		if resp.StatusCode == http.StatusOK && decodeErr == nil && health.SessionBootstrap.Status == "ready" {
+		bootstrapOperational := health.SessionBootstrap.Status == "ready" || health.SessionBootstrap.Status == "degraded"
+		if resp.StatusCode == http.StatusOK && decodeErr == nil && bootstrapOperational {
 			return true
 		}
 	}

--- a/role-model-router/apps/launcher/main_test.go
+++ b/role-model-router/apps/launcher/main_test.go
@@ -213,6 +213,22 @@ func TestWaitForServerReadyReturnsWhenBackendBootstrapBecomesReady(t *testing.T)
 	}
 }
 
+func TestWaitForServerReadyAllowsOperationalDegradedBootstrap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/healthz" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("content-type", "application/json")
+		_, _ = writer.Write([]byte(`{"status":"degraded","sessionBootstrap":{"status":"degraded"}}`))
+	}))
+	defer server.Close()
+
+	if !waitForServerReady(server.URL, 2, 5*time.Millisecond) {
+		t.Fatal("expected operational degraded backend to be launchable")
+	}
+}
+
 func TestWaitForServerReadyReturnsFalseWhenHealthEndpointNeverResponds(t *testing.T) {
 	start := time.Now()
 	if waitForServerReady("http://127.0.0.1:1", 2, 20*time.Millisecond) {


### PR DESCRIPTION
Promote the v0.0.10 launcher readiness hotfix from `dev` to `stage` after main and dev integration.

The change allows a completed operational `degraded` bootstrap while preserving fatal handling for `blocked`, pending, malformed, and unreachable startup states. PR #128 passed all required CI.