### PR TITLE
fix(release): preserve clean paired package provenance

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -262,12 +262,14 @@ jobs:
           repository: try-works/role-model-internal
           ref: ${{ steps.release_identity.outputs.private_source_commit }}
           token: ${{ secrets.ROLE_MODEL_INTERNAL_READ_TOKEN }}
-          path: _private
+          # Keep the paired source outside the public Git worktree.  SEA
+          # packaging deliberately rejects any untracked public source file.
+          path: .cache/paired-private
           fetch-depth: 0
 
       - name: Verify private revision passed paired promotion branch
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
-        working-directory: _private
+        working-directory: .cache/paired-private
         shell: bash
         env:
           RELEASE_PRIVATE_SHA: ${{ steps.release_identity.outputs.private_source_commit }}
@@ -286,7 +288,7 @@ jobs:
 
       - name: Build exact private release distribution
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
-        working-directory: _private
+        working-directory: .cache/paired-private
         env:
           ROLE_MODEL_PUBLIC_WORKTREE: ${{ github.workspace }}
           NODE_OPTIONS: --conditions=runtime
@@ -296,7 +298,7 @@ jobs:
 
       - name: Package SEA runtime
         env:
-          ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT: ${{ (env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production') && format('{0}/_private/dist/run00-dev', github.workspace) || '' }}
+          ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT: ${{ (env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production') && format('{0}/.cache/paired-private/dist/run00-dev', github.workspace) || '' }}
           RUN88_RELEASE_ID: ${{ steps.release_identity.outputs.release_id || env.RUN88_RELEASE_ID }}
         run: pnpm run runtime:package-sea
 

--- a/.recursive/run/93-variant-admission-model-pool-integrity/addenda/02-to-be-plan.stage-package-worktree-cleanliness.addendum-10.md
+++ b/.recursive/run/93-variant-admission-model-pool-integrity/addenda/02-to-be-plan.stage-package-worktree-cleanliness.addendum-10.md
@@ -1,0 +1,69 @@
+Run: `/.recursive/run/93-variant-admission-model-pool-integrity/`
+Phase: `2-to-be-plan`
+Artifact: `02-to-be-plan.md`
+Addendum: `10`
+Status: `LOCKED`
+LockedAt: `2026-08-22T14:24:15Z`
+LockHash: `1641221f993cb08aa99ebb9fe165cbb61e1ea34daa5d8699748cf4b32411c06c`
+
+# Stage package worktree-cleanliness repair
+
+## Finding
+
+The Run 93 `stage` promotion at public commit `e50f1ccc` reached the mandatory
+release packager, but all platform jobs failed before an archive was emitted.
+The package provenance guard correctly rejected a dirty public checkout. The
+workflow itself had created the dirt by checking the exact paired private
+repository out at `${GITHUB_WORKSPACE}/_private`; that untracked directory is
+not ignored. This is a workflow-topology defect, not a reason to weaken the
+source provenance rule.
+
+## Requirements
+
+1. The stage/production binary workflow must check the paired private release
+   revision out only under an ignored workspace path and must pass its exact
+   `dist/run00-dev` path to `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT`.
+2. `package-sea.ts` must retain its existing fail-closed response to any
+   tracked or untracked public source change. No status-path filtering,
+   bypass environment variable, or source-tree identity relaxation is allowed.
+3. The same workflow path must be used for the private build, private ancestry
+   verification, and Track B distribution root. A stale `_private` reference
+   is a release-contract failure.
+4. Strict TDD is required: a workflow-contract RED must fail against the
+   `_private` implementation; GREEN must prove an ignored paired checkout and
+   exact distribution path; the existing dirty-public-worktree regression must
+   remain green.
+5. Verification includes local workflow-contract tests, `pnpm ci:check`, and
+   a new GitHub stage package run that passes all CI lanes, creates the
+   `stage-rc-<12-sha>` prerelease, and binds all 13 Track B extensions.
+
+## Scope
+
+Only the public binary workflow and its workflow-contract test may change.
+No release artifact will be accepted until the rebuilt paired Stage RC passes
+the release workflow; no credentials are read or included in artifacts.
+
+## Implementation and verification record
+
+- RED: the added workflow-contract assertion failed against the original
+  `path: _private` topology, which made the paired checkout an untracked file
+  inside the public source tree and caused the strict SEA provenance guard to
+  fail.
+- GREEN: `.github/workflows/build-binaries.yml` now checks the paired private
+  source out to `.cache/paired-private`, and uses that exact path for private
+  branch verification, the private Track B build, and
+  `ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT`.
+- The packager's public-worktree cleanliness check is unchanged. The workflow
+  therefore still rejects actual public source drift before packaging.
+- Focused release workflow tests passed: 28/28.
+- `corepack pnpm ci:check` passed locally, including lint, schema validation,
+  all builds/tests, rebuilt-runtime critical validation, Rust, and smoke.
+
+## GitHub release gate
+
+The prior stage CI run `32577358303` passed, while its paired binary workflow
+`32577358384` failed only because the old workflow dirtied the public checkout
+with `_private/`. The repaired workflow must pass GitHub CI and the next stage
+binary build must publish a fresh `stage-rc-<12-sha>` prerelease before this
+release path is considered complete. Its manifest must retain the mandatory
+Track B runtime binding and extension count of 13.

--- a/.recursive/run/93-variant-admission-model-pool-integrity/evidence/addenda/stage-package-worktree-cleanliness/green-workflow-contract.log
+++ b/.recursive/run/93-variant-admission-model-pool-integrity/evidence/addenda/stage-package-worktree-cleanliness/green-workflow-contract.log
@@ -1,0 +1,17 @@
+✔ build-binaries retries release attestation before failing (1.7601ms)
+✔ build-binaries pins one exact Node patch for reproducible SEA payloads (0.4479ms)
+✔ build-binaries produces stage candidates, manual dev builds, and tag-only releases (0.336ms)
+✔ production artifacts include the exact private runtime tested at stage (0.2706ms)
+✔ the public release orchestrator enforces paired private promotion (0.3543ms)
+✔ paired private checkout never dirties the public package provenance worktree (0.4394ms)
+✔ stage pushes publish downloadable prereleases before stable promotion (0.4362ms)
+✔ stable tags require a manually accepted exact stage candidate (0.2616ms)
+✔ release candidate acceptance is explicit, checksum-bound, and manual only (0.4419ms)
+ℹ tests 9
+ℹ suites 0
+ℹ pass 9
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 169.2429

--- a/.recursive/run/93-variant-admission-model-pool-integrity/evidence/addenda/stage-package-worktree-cleanliness/local-ci.log
+++ b/.recursive/run/93-variant-admission-model-pool-integrity/evidence/addenda/stage-package-worktree-cleanliness/local-ci.log
@@ -1,0 +1,2110 @@
+
+> role-model@0.0.0 ci:check D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm run lint && corepack pnpm run schemas:validate && corepack pnpm run build && corepack pnpm run test && corepack pnpm run runtime:test-critical && corepack pnpm run test:rust && corepack pnpm run smoke
+
+
+> role-model@0.0.0 lint D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> biome check . && corepack pnpm run lint:rust
+
+Checked 1021 files in 2s. No fixes applied.
+
+> role-model@0.0.0 lint:rust D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> cargo fmt --manifest-path role-model-router/rust/Cargo.toml --all --check && cargo clippy --manifest-path role-model-router/rust/Cargo.toml --workspace --all-targets -- -D warnings
+
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
+
+> role-model@0.0.0 schemas:validate D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm --filter @role-model/schema-tools exec tsx src/validate-schemas.ts validate
+
+Validated 37 schema file(s).
+Validated 30 fixture file(s).
+
+> role-model@0.0.0 build D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm run types:generate && corepack pnpm -r --if-present build
+
+
+> role-model@0.0.0 types:generate D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm --filter @role-model/schema-tools exec tsx src/validate-schemas.ts generate-types
+
+Generated types for benchmark-run.schema.json
+Generated types for benchmark-suite.schema.json
+Generated types for capability-taxonomy.schema.json
+Generated types for declared-capability-profile.schema.json
+Generated types for downstream-openai-discovery.schema.json
+Generated types for endpoint-identity.schema.json
+Generated types for judge-score.schema.json
+Generated types for model-pack-manifest.schema.json
+Generated types for observed-performance-profile.schema.json
+Generated types for package-manifest.schema.json
+Generated types for planspec.schema.json
+Generated types for role-binding.schema.json
+Generated types for role-definition.schema.json
+Generated types for router-decision.schema.json
+Generated types for routing-policy.schema.json
+Generated types for task-definition.schema.json
+Generated types for task-execution-profile.schema.json
+Generated types for trace-event.schema.json
+Generated types for trace-span.schema.json
+Generated types for usage-event.schema.json
+Formatted 1 file in 34ms. Fixed 1 file.
+Scope: 45 of 46 workspace projects
+apps/docs-site build$ react-router build && npm run types:check && node ./scripts/materialize-search-index.mjs
+packages/packaging build$ tsc -p tsconfig.json
+packages/codex-role-model build$ tsc -p tsconfig.build.json
+packages/pi-role-model build$ tsc --noEmit -p tsconfig.json
+packages/packaging build: Done
+packages/protocol-types build$ tsc -p tsconfig.json
+packages/protocol-types build: Done
+packages/schema-tools build$ tsc -p tsconfig.json
+packages/codex-role-model build: Done
+packages/store-contract build$ tsc -p tsconfig.json
+apps/docs-site build: [MDX] generated files in 7.392499999999927ms
+apps/docs-site build: [MDX] generated files in 3.3791000000001077ms
+apps/docs-site build: [MDX] generated files in 6.161000000000058ms
+apps/docs-site build: vite v8.0.10 building client environment for production...
+apps/docs-site build: [MDX] generated files in 4.50630000000001ms
+apps/docs-site build: [2K
+packages/store-contract build: Done
+role-model-router/packages/bench-core build$ tsc -p tsconfig.json
+packages/schema-tools build: Done
+role-model-router/packages/bench-judge build$ tsc -p tsconfig.json
+role-model-router/packages/bench-core build: Done
+role-model-router/packages/catalog build$ tsc -p tsconfig.json
+role-model-router/packages/bench-judge build: Done
+.../packages/process-supervisor build$ tsc -p tsconfig.json
+packages/pi-role-model build: Done
+role-model-router/packages/runtime-web build$ tsc -p tsconfig.json
+role-model-router/packages/catalog build: Done
+role-model-router/packages/tool-registry build$ tsc -p tsconfig.json
+role-model-router/packages/runtime-web build: Done
+.../packages/vendor-abstraction build$ tsc -p tsconfig.json
+.../packages/process-supervisor build: Done
+role-model-router/packages/tool-registry build: Done
+.../packages/vendor-abstraction build: Done
+apps/docs-site build: transforming...✓ 2247 modules transformed.
+apps/docs-site build: rendering chunks...
+apps/docs-site build: computing gzip size...
+apps/docs-site build: build/client/.vite/manifest.json                                       29.14 kB │ gzip:  3.15 kB
+apps/docs-site build: build/client/assets/runtime-overview-DGXvmefE.png                     660.26 kB
+apps/docs-site build: build/client/assets/root-BjmB36fm.css                                  80.30 kB │ gzip: 13.37 kB
+apps/docs-site build: build/client/assets/full-ZUGm99_m.js                                    0.00 kB │ gzip:  0.02 kB
+apps/docs-site build: build/client/assets/index-BeW4qblQ.js                                   0.00 kB │ gzip:  0.02 kB
+apps/docs-site build: build/client/assets/mdx-BNRw8oVt.js                                     0.00 kB │ gzip:  0.02 kB
+apps/docs-site build: build/client/assets/search-CSZo5aTn.js                                  0.00 kB │ gzip:  0.02 kB
+apps/docs-site build: build/client/assets/remove-undefined-CTqT55E9-CIrOzrkz.js               0.20 kB │ gzip:  0.16 kB
+apps/docs-site build: build/client/assets/jsx-runtime-B37CQREX.js                             0.42 kB │ gzip:  0.29 kB
+apps/docs-site build: build/client/assets/fetch-fEPcja4T.js                                   0.44 kB │ gzip:  0.29 kB
+apps/docs-site build: build/client/assets/chunk-bqFK08oC.js                                   0.69 kB │ gzip:  0.42 kB
+apps/docs-site build: build/client/assets/algolia-7wa-q8Iw.js                                 0.77 kB │ gzip:  0.49 kB
+apps/docs-site build: build/client/assets/search-BVbLjbd5.js                                  0.99 kB │ gzip:  0.53 kB
+apps/docs-site build: build/client/assets/orama-cloud-legacy-C3qR2mMQ.js                      1.11 kB │ gzip:  0.58 kB
+apps/docs-site build: build/client/assets/search-default-BZqR9XCe.js                          1.15 kB │ gzip:  0.63 kB
+apps/docs-site build: build/client/assets/orama-cloud-BcQrifaa.js                             1.17 kB │ gzip:  0.60 kB
+apps/docs-site build: build/client/assets/policy-and-observability-BhOZSXix.js                5.63 kB │ gzip:  1.31 kB
+apps/docs-site build: build/client/assets/roles-tasks-and-capabilities-QKjZM8Ms.js            6.33 kB │ gzip:  1.44 kB
+apps/docs-site build: build/client/assets/overview-B6tuSF0_.js                                6.65 kB │ gzip:  1.42 kB
+apps/docs-site build: build/client/assets/endpoints-and-profiles-DZ-ej84O.js                  6.65 kB │ gzip:  1.44 kB
+apps/docs-site build: build/client/assets/install-hAjN9fao.js                                 6.91 kB │ gzip:  1.81 kB
+apps/docs-site build: build/client/assets/first-request-and-decision-QJ0LImHg.js              8.31 kB │ gzip:  1.69 kB
+apps/docs-site build: build/client/assets/quickstart-C20_Lwul.js                              8.37 kB │ gzip:  1.93 kB
+apps/docs-site build: build/client/assets/protocol-lifecycle-0Mkr0V8t.js                      9.15 kB │ gzip:  2.05 kB
+apps/docs-site build: build/client/assets/runtime-ui-tour-Dwp1JDQP.js                        10.09 kB │ gzip:  2.11 kB
+apps/docs-site build: build/client/assets/run-full-benchmark-AWxdNziL.js                     11.24 kB │ gzip:  2.23 kB
+apps/docs-site build: build/client/assets/models-and-role-activation-BhWGW0ZB.js             11.78 kB │ gzip:  2.36 kB
+apps/docs-site build: build/client/assets/mixedbread-CtlHB2p3.js                             11.95 kB │ gzip:  5.37 kB
+apps/docs-site build: build/client/assets/first-launch-and-connect-models-WWce-kQc.js        11.95 kB │ gzip:  2.62 kB
+apps/docs-site build: build/client/assets/provider-connections-RYSYtFhy.js                   12.17 kB │ gzip:  2.27 kB
+apps/docs-site build: build/client/assets/preload-helper-CzZtDwiq.js                         12.18 kB │ gzip:  4.43 kB
+apps/docs-site build: build/client/assets/observe-and-telemetry-analytics-BUJWgUcE.js        12.39 kB │ gzip:  2.37 kB
+apps/docs-site build: build/client/assets/overview-BA9tk48q.js                               12.39 kB │ gzip:  2.35 kB
+apps/docs-site build: build/client/assets/trace-and-usage-artifacts-BUB0Z7Ds.js              12.52 kB │ gzip:  2.17 kB
+apps/docs-site build: build/client/assets/capability-taxonomy-BaM3Ajcx.js                    12.65 kB │ gzip:  2.33 kB
+apps/docs-site build: build/client/assets/protocol-C60H4KEM.js                               13.37 kB │ gzip:  2.43 kB
+apps/docs-site build: build/client/assets/router-decision-artifact-DFUSfcxi.js               13.37 kB │ gzip:  2.41 kB
+apps/docs-site build: build/client/assets/declared-capability-profiles-z7Gj9wSR.js           13.60 kB │ gzip:  2.43 kB
+apps/docs-site build: build/client/assets/downstream-openai-discovery-CS4f30ft.js            14.07 kB │ gzip:  2.61 kB
+apps/docs-site build: build/client/assets/benchmarks-and-evaluation-Cd_OclIP.js              14.68 kB │ gzip:  2.70 kB
+apps/docs-site build: build/client/assets/routing-controls-and-decision-review-Bjj0D5Py.js   15.33 kB │ gzip:  2.79 kB
+apps/docs-site build: build/client/assets/protocol-to-router-mapping-OvRVmPe4.js             15.40 kB │ gzip:  2.79 kB
+apps/docs-site build: build/client/assets/routing-policy-CwlsBEJM.js                         15.60 kB │ gzip:  2.80 kB
+apps/docs-site build: build/client/assets/how-routing-works-end-to-end-okeGzBHi.js           16.81 kB │ gzip:  3.13 kB
+apps/docs-site build: build/client/assets/install-BD7LNwDd.js                                16.90 kB │ gzip:  3.23 kB
+apps/docs-site build: build/client/assets/protocol-object-model-DVL4aVSr.js                  17.59 kB │ gzip:  3.09 kB
+apps/docs-site build: build/client/assets/reason-codes-and-rejection-taxonomy-BjAzL4M1.js    18.10 kB │ gzip:  2.72 kB
+apps/docs-site build: build/client/assets/canonical-schemas-reference-ChQRvYyZ.js            18.29 kB │ gzip:  2.80 kB
+apps/docs-site build: build/client/assets/routing-overview-DWSudOB8.js                       18.41 kB │ gzip:  3.33 kB
+apps/docs-site build: build/client/assets/how-role-model-works-daDm3pug.js                   18.53 kB │ gzip:  3.34 kB
+apps/docs-site build: build/client/assets/core-vocabulary-DwS9D1GS.js                        18.63 kB │ gzip:  3.17 kB
+apps/docs-site build: build/client/assets/protocol-overview-DwqH9oFq.js                      19.05 kB │ gzip:  3.41 kB
+apps/docs-site build: build/client/assets/observed-performance-profiles-BSG0xHj7.js          19.57 kB │ gzip:  3.26 kB
+apps/docs-site build: build/client/assets/docs-D75Oxghc.js                                   21.02 kB │ gzip:  3.90 kB
+apps/docs-site build: build/client/assets/endpoint-identity-CheeOp7E.js                      22.26 kB │ gzip:  3.45 kB
+apps/docs-site build: build/client/assets/root-D67GHWHl.js                                   24.91 kB │ gzip:  8.39 kB
+apps/docs-site build: build/client/assets/codex-BjY6lkOq.js                                  25.98 kB │ gzip:  3.87 kB
+apps/docs-site build: build/client/assets/choose-routing-strategy-B92PTyf6.js                26.41 kB │ gzip:  4.25 kB
+apps/docs-site build: build/client/assets/fallbacks-failures-and-observability-BLuOEWi3.js   27.78 kB │ gzip:  4.61 kB
+apps/docs-site build: build/client/assets/pi-DkUevMQ3.js                                     27.96 kB │ gzip:  4.83 kB
+apps/docs-site build: build/client/assets/candidate-selection-and-eligibility-DeOCkwpD.js    29.06 kB │ gzip:  4.44 kB
+apps/docs-site build: build/client/assets/introduction-BObzjhyr.js                           29.46 kB │ gzip:  4.86 kB
+apps/docs-site build: build/client/assets/scoring-tie-breaks-and-decisions-lbWGJVAa.js       30.07 kB │ gzip:  4.87 kB
+apps/docs-site build: build/client/assets/routing-modes-locality-and-execution-KNAthTvr.js   39.32 kB │ gzip:  5.65 kB
+apps/docs-site build: build/client/assets/strategy-modes-and-tradeoffs-C4SzkmZM.js           48.70 kB │ gzip:  7.07 kB
+apps/docs-site build: build/client/assets/es2015-B692ofsD.js                                 61.65 kB │ gzip: 21.10 kB
+apps/docs-site build: build/client/assets/orama-static-DJT9Y1zT.js                           62.73 kB │ gzip: 21.59 kB
+apps/docs-site build: build/client/assets/docs-CELqNXFW.js                                   64.34 kB │ gzip: 21.78 kB
+apps/docs-site build: build/client/assets/dist-D-xxxXck.js                                   82.94 kB │ gzip: 27.42 kB
+apps/docs-site build: build/client/assets/remark-CW-4A0sf.js                                 89.89 kB │ gzip: 25.74 kB
+apps/docs-site build: build/client/assets/chunk-EVOBXE3Y-BVHgNXQf.js                        118.01 kB │ gzip: 38.59 kB
+apps/docs-site build: build/client/assets/entry.client-Ci5FUk0_.js                          183.20 kB │ gzip: 58.03 kB
+apps/docs-site build: build/client/assets/search-ZCm9ESaD.js                                227.67 kB │ gzip: 70.51 kB
+apps/docs-site build: build/client/assets/roles-and-tasks-C29KTDwl.js                       705.50 kB │ gzip: 88.81 kB
+apps/docs-site build: [plugin builtin:vite-reporter] 
+apps/docs-site build: (!) Some chunks are larger than 500 kB after minification. Consider:
+apps/docs-site build: - Using dynamic import() to code-split the application
+apps/docs-site build: - Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
+apps/docs-site build: - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
+apps/docs-site build: [33m[PLUGIN_TIMINGS] Warning:[0m Your build spent significant time in plugins. Here is a breakdown:
+apps/docs-site build:   - react-router:dot-server (38%)
+apps/docs-site build:   - react-router:virtual-modules (16%)
+apps/docs-site build:   - react-router:hmr-runtime (14%)
+apps/docs-site build:   - react-router:inject-hmr-runtime (13%)
+apps/docs-site build:   - react-router:route-exports (6%)
+apps/docs-site build: See https://rolldown.rs/options/checks#plugintimings for more details.
+apps/docs-site build: ✓ built in 12.34s
+apps/docs-site build: [MDX] generated files in 3.3761000000013155ms
+apps/docs-site build: vite v8.0.10 building ssr environment for production...
+apps/docs-site build: [MDX] generated files in 2.720899999996618ms
+apps/docs-site build: [2K
+apps/docs-site build: transforming...✓ 485 modules transformed.
+apps/docs-site build: rendering chunks...
+apps/docs-site build: ✓ 2 assets cleaned from React Router server build.
+apps/docs-site build: build\client\assets\runtime-overview-DGXvmefE.png
+apps/docs-site build: build\server\assets\server-build-BjmB36fm.css
+apps/docs-site build: Prerender (data): / -> build\client\_root.data
+apps/docs-site build: Prerender (html): / -> build\client\index.html
+apps/docs-site build: Prerender (data): /api/search -> build\client\api\search.data
+apps/docs-site build: Prerender (resource): /api/search -> build\client\api\search
+apps/docs-site build: Prerender (data): /llms.txt -> build\client\llms.txt.data
+apps/docs-site build: Prerender (resource): /llms.txt -> build\client\llms.txt
+apps/docs-site build: Prerender (data): /llms-full.txt -> build\client\llms-full.txt.data
+apps/docs-site build: Prerender (resource): /llms-full.txt -> build\client\llms-full.txt
+apps/docs-site build: Prerender (data): /core-vocabulary -> build\client\core-vocabulary.data
+apps/docs-site build: Prerender (html): /core-vocabulary -> build\client\core-vocabulary\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/core-vocabulary/content.md -> build\client\llms.mdx\docs\core-vocabulary\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/core-vocabulary/content.md -> build\client\llms.mdx\docs\core-vocabulary\content.md
+apps/docs-site build: Prerender (data): / -> build\client\_root.data
+apps/docs-site build: Prerender (html): / -> build\client\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/content.md -> build\client\llms.mdx\docs\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/content.md -> build\client\llms.mdx\docs\content.md
+apps/docs-site build: Prerender (data): /install -> build\client\install.data
+apps/docs-site build: Prerender (html): /install -> build\client\install\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/install/content.md -> build\client\llms.mdx\docs\install\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/install/content.md -> build\client\llms.mdx\docs\install\content.md
+apps/docs-site build: Prerender (data): /introduction -> build\client\introduction.data
+apps/docs-site build: Prerender (html): /introduction -> build\client\introduction\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/introduction/content.md -> build\client\llms.mdx\docs\introduction\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/introduction/content.md -> build\client\llms.mdx\docs\introduction\content.md
+apps/docs-site build: Prerender (data): /protocol-lifecycle -> build\client\protocol-lifecycle.data
+apps/docs-site build: Prerender (html): /protocol-lifecycle -> build\client\protocol-lifecycle\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol-lifecycle/content.md -> build\client\llms.mdx\docs\protocol-lifecycle\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol-lifecycle/content.md -> build\client\llms.mdx\docs\protocol-lifecycle\content.md
+apps/docs-site build: Prerender (data): /protocol-object-model -> build\client\protocol-object-model.data
+apps/docs-site build: Prerender (html): /protocol-object-model -> build\client\protocol-object-model\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol-object-model/content.md -> build\client\llms.mdx\docs\protocol-object-model\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol-object-model/content.md -> build\client\llms.mdx\docs\protocol-object-model\content.md
+apps/docs-site build: Prerender (data): /quickstart -> build\client\quickstart.data
+apps/docs-site build: Prerender (html): /quickstart -> build\client\quickstart\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/quickstart/content.md -> build\client\llms.mdx\docs\quickstart\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/quickstart/content.md -> build\client\llms.mdx\docs\quickstart\content.md
+apps/docs-site build: Prerender (data): /runtime/benchmarks-and-evaluation -> build\client\runtime\benchmarks-and-evaluation.data
+apps/docs-site build: Prerender (html): /runtime/benchmarks-and-evaluation -> build\client\runtime\benchmarks-and-evaluation\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/runtime/benchmarks-and-evaluation/content.md -> build\client\llms.mdx\docs\runtime\benchmarks-and-evaluation\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/runtime/benchmarks-and-evaluation/content.md -> build\client\llms.mdx\docs\runtime\benchmarks-and-evaluation\content.md
+apps/docs-site build: Prerender (data): /runtime/models-and-role-activation -> build\client\runtime\models-and-role-activation.data
+apps/docs-site build: Prerender (html): /runtime/models-and-role-activation -> build\client\runtime\models-and-role-activation\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/runtime/models-and-role-activation/content.md -> build\client\llms.mdx\docs\runtime\models-and-role-activation\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/runtime/models-and-role-activation/content.md -> build\client\llms.mdx\docs\runtime\models-and-role-activation\content.md
+apps/docs-site build: Prerender (data): /runtime/observe-and-telemetry-analytics -> build\client\runtime\observe-and-telemetry-analytics.data
+apps/docs-site build: Prerender (html): /runtime/observe-and-telemetry-analytics -> build\client\runtime\observe-and-telemetry-analytics\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/runtime/observe-and-telemetry-analytics/content.md -> build\client\llms.mdx\docs\runtime\observe-and-telemetry-analytics\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/runtime/observe-and-telemetry-analytics/content.md -> build\client\llms.mdx\docs\runtime\observe-and-telemetry-analytics\content.md
+apps/docs-site build: Prerender (data): /runtime/provider-connections -> build\client\runtime\provider-connections.data
+apps/docs-site build: Prerender (html): /runtime/provider-connections -> build\client\runtime\provider-connections\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/runtime/provider-connections/content.md -> build\client\llms.mdx\docs\runtime\provider-connections\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/runtime/provider-connections/content.md -> build\client\llms.mdx\docs\runtime\provider-connections\content.md
+apps/docs-site build: Prerender (data): /runtime/routing-controls-and-decision-review -> build\client\runtime\routing-controls-and-decision-review.data
+apps/docs-site build: Prerender (html): /runtime/routing-controls-and-decision-review -> build\client\runtime\routing-controls-and-decision-review\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/runtime/routing-controls-and-decision-review/content.md -> build\client\llms.mdx\docs\runtime\routing-controls-and-decision-review\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/runtime/routing-controls-and-decision-review/content.md -> build\client\llms.mdx\docs\runtime\routing-controls-and-decision-review\content.md
+apps/docs-site build: Prerender (data): /runtime/runtime-ui-tour -> build\client\runtime\runtime-ui-tour.data
+apps/docs-site build: Prerender (html): /runtime/runtime-ui-tour -> build\client\runtime\runtime-ui-tour\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/runtime/runtime-ui-tour/content.md -> build\client\llms.mdx\docs\runtime\runtime-ui-tour\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/runtime/runtime-ui-tour/content.md -> build\client\llms.mdx\docs\runtime\runtime-ui-tour\content.md
+apps/docs-site build: Prerender (data): /router/candidate-selection-and-eligibility -> build\client\router\candidate-selection-and-eligibility.data
+apps/docs-site build: Prerender (html): /router/candidate-selection-and-eligibility -> build\client\router\candidate-selection-and-eligibility\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/candidate-selection-and-eligibility/content.md -> build\client\llms.mdx\docs\router\candidate-selection-and-eligibility\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/candidate-selection-and-eligibility/content.md -> build\client\llms.mdx\docs\router\candidate-selection-and-eligibility\content.md
+apps/docs-site build: Prerender (data): /router/fallbacks-failures-and-observability -> build\client\router\fallbacks-failures-and-observability.data
+apps/docs-site build: Prerender (html): /router/fallbacks-failures-and-observability -> build\client\router\fallbacks-failures-and-observability\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/fallbacks-failures-and-observability/content.md -> build\client\llms.mdx\docs\router\fallbacks-failures-and-observability\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/fallbacks-failures-and-observability/content.md -> build\client\llms.mdx\docs\router\fallbacks-failures-and-observability\content.md
+apps/docs-site build: Prerender (data): /router/how-routing-works-end-to-end -> build\client\router\how-routing-works-end-to-end.data
+apps/docs-site build: Prerender (html): /router/how-routing-works-end-to-end -> build\client\router\how-routing-works-end-to-end\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/how-routing-works-end-to-end/content.md -> build\client\llms.mdx\docs\router\how-routing-works-end-to-end\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/how-routing-works-end-to-end/content.md -> build\client\llms.mdx\docs\router\how-routing-works-end-to-end\content.md
+apps/docs-site build: Prerender (data): /router/overview -> build\client\router\overview.data
+apps/docs-site build: Prerender (html): /router/overview -> build\client\router\overview\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/overview/content.md -> build\client\llms.mdx\docs\router\overview\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/overview/content.md -> build\client\llms.mdx\docs\router\overview\content.md
+apps/docs-site build: Prerender (data): /router/protocol-to-router-mapping -> build\client\router\protocol-to-router-mapping.data
+apps/docs-site build: Prerender (html): /router/protocol-to-router-mapping -> build\client\router\protocol-to-router-mapping\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/protocol-to-router-mapping/content.md -> build\client\llms.mdx\docs\router\protocol-to-router-mapping\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/protocol-to-router-mapping/content.md -> build\client\llms.mdx\docs\router\protocol-to-router-mapping\content.md
+apps/docs-site build: Prerender (data): /router/routing-modes-locality-and-execution -> build\client\router\routing-modes-locality-and-execution.data
+apps/docs-site build: Prerender (html): /router/routing-modes-locality-and-execution -> build\client\router\routing-modes-locality-and-execution\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/routing-modes-locality-and-execution/content.md -> build\client\llms.mdx\docs\router\routing-modes-locality-and-execution\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/routing-modes-locality-and-execution/content.md -> build\client\llms.mdx\docs\router\routing-modes-locality-and-execution\content.md
+apps/docs-site build: Prerender (data): /router/scoring-tie-breaks-and-decisions -> build\client\router\scoring-tie-breaks-and-decisions.data
+apps/docs-site build: Prerender (html): /router/scoring-tie-breaks-and-decisions -> build\client\router\scoring-tie-breaks-and-decisions\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/scoring-tie-breaks-and-decisions/content.md -> build\client\llms.mdx\docs\router\scoring-tie-breaks-and-decisions\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/scoring-tie-breaks-and-decisions/content.md -> build\client\llms.mdx\docs\router\scoring-tie-breaks-and-decisions\content.md
+apps/docs-site build: Prerender (data): /router/strategy-modes-and-tradeoffs -> build\client\router\strategy-modes-and-tradeoffs.data
+apps/docs-site build: Prerender (html): /router/strategy-modes-and-tradeoffs -> build\client\router\strategy-modes-and-tradeoffs\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/router/strategy-modes-and-tradeoffs/content.md -> build\client\llms.mdx\docs\router\strategy-modes-and-tradeoffs\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/router/strategy-modes-and-tradeoffs/content.md -> build\client\llms.mdx\docs\router\strategy-modes-and-tradeoffs\content.md
+apps/docs-site build: Prerender (data): /reference/canonical-schemas-reference -> build\client\reference\canonical-schemas-reference.data
+apps/docs-site build: Prerender (html): /reference/canonical-schemas-reference -> build\client\reference\canonical-schemas-reference\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/reference/canonical-schemas-reference/content.md -> build\client\llms.mdx\docs\reference\canonical-schemas-reference\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/reference/canonical-schemas-reference/content.md -> build\client\llms.mdx\docs\reference\canonical-schemas-reference\content.md
+apps/docs-site build: Prerender (data): /reference/overview -> build\client\reference\overview.data
+apps/docs-site build: Prerender (html): /reference/overview -> build\client\reference\overview\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/reference/overview/content.md -> build\client\llms.mdx\docs\reference\overview\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/reference/overview/content.md -> build\client\llms.mdx\docs\reference\overview\content.md
+apps/docs-site build: Prerender (data): /reference/reason-codes-and-rejection-taxonomy -> build\client\reference\reason-codes-and-rejection-taxonomy.data
+apps/docs-site build: Prerender (html): /reference/reason-codes-and-rejection-taxonomy -> build\client\reference\reason-codes-and-rejection-taxonomy\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/reference/reason-codes-and-rejection-taxonomy/content.md -> build\client\llms.mdx\docs\reference\reason-codes-and-rejection-taxonomy\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/reference/reason-codes-and-rejection-taxonomy/content.md -> build\client\llms.mdx\docs\reference\reason-codes-and-rejection-taxonomy\content.md
+apps/docs-site build: Prerender (data): /protocol/capability-taxonomy -> build\client\protocol\capability-taxonomy.data
+apps/docs-site build: Prerender (html): /protocol/capability-taxonomy -> build\client\protocol\capability-taxonomy\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/capability-taxonomy/content.md -> build\client\llms.mdx\docs\protocol\capability-taxonomy\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/capability-taxonomy/content.md -> build\client\llms.mdx\docs\protocol\capability-taxonomy\content.md
+apps/docs-site build: Prerender (data): /protocol/declared-capability-profiles -> build\client\protocol\declared-capability-profiles.data
+apps/docs-site build: Prerender (html): /protocol/declared-capability-profiles -> build\client\protocol\declared-capability-profiles\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/declared-capability-profiles/content.md -> build\client\llms.mdx\docs\protocol\declared-capability-profiles\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/declared-capability-profiles/content.md -> build\client\llms.mdx\docs\protocol\declared-capability-profiles\content.md
+apps/docs-site build: Prerender (data): /protocol/endpoint-identity -> build\client\protocol\endpoint-identity.data
+apps/docs-site build: Prerender (html): /protocol/endpoint-identity -> build\client\protocol\endpoint-identity\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/endpoint-identity/content.md -> build\client\llms.mdx\docs\protocol\endpoint-identity\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/endpoint-identity/content.md -> build\client\llms.mdx\docs\protocol\endpoint-identity\content.md
+apps/docs-site build: Prerender (data): /protocol -> build\client\protocol.data
+apps/docs-site build: Prerender (html): /protocol -> build\client\protocol\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/content.md -> build\client\llms.mdx\docs\protocol\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/content.md -> build\client\llms.mdx\docs\protocol\content.md
+apps/docs-site build: Prerender (data): /protocol/observed-performance-profiles -> build\client\protocol\observed-performance-profiles.data
+apps/docs-site build: Prerender (html): /protocol/observed-performance-profiles -> build\client\protocol\observed-performance-profiles\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/observed-performance-profiles/content.md -> build\client\llms.mdx\docs\protocol\observed-performance-profiles\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/observed-performance-profiles/content.md -> build\client\llms.mdx\docs\protocol\observed-performance-profiles\content.md
+apps/docs-site build: Prerender (data): /protocol/roles-and-tasks -> build\client\protocol\roles-and-tasks.data
+apps/docs-site build: Prerender (html): /protocol/roles-and-tasks -> build\client\protocol\roles-and-tasks\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/roles-and-tasks/content.md -> build\client\llms.mdx\docs\protocol\roles-and-tasks\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/roles-and-tasks/content.md -> build\client\llms.mdx\docs\protocol\roles-and-tasks\content.md
+apps/docs-site build: Prerender (data): /protocol/router-decision-artifact -> build\client\protocol\router-decision-artifact.data
+apps/docs-site build: Prerender (html): /protocol/router-decision-artifact -> build\client\protocol\router-decision-artifact\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/router-decision-artifact/content.md -> build\client\llms.mdx\docs\protocol\router-decision-artifact\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/router-decision-artifact/content.md -> build\client\llms.mdx\docs\protocol\router-decision-artifact\content.md
+apps/docs-site build: Prerender (data): /protocol/routing-policy -> build\client\protocol\routing-policy.data
+apps/docs-site build: Prerender (html): /protocol/routing-policy -> build\client\protocol\routing-policy\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/routing-policy/content.md -> build\client\llms.mdx\docs\protocol\routing-policy\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/routing-policy/content.md -> build\client\llms.mdx\docs\protocol\routing-policy\content.md
+apps/docs-site build: Prerender (data): /protocol/trace-and-usage-artifacts -> build\client\protocol\trace-and-usage-artifacts.data
+apps/docs-site build: Prerender (html): /protocol/trace-and-usage-artifacts -> build\client\protocol\trace-and-usage-artifacts\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/protocol/trace-and-usage-artifacts/content.md -> build\client\llms.mdx\docs\protocol\trace-and-usage-artifacts\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/protocol/trace-and-usage-artifacts/content.md -> build\client\llms.mdx\docs\protocol\trace-and-usage-artifacts\content.md
+apps/docs-site build: Prerender (data): /integrations/codex -> build\client\integrations\codex.data
+apps/docs-site build: Prerender (html): /integrations/codex -> build\client\integrations\codex\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/integrations/codex/content.md -> build\client\llms.mdx\docs\integrations\codex\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/integrations/codex/content.md -> build\client\llms.mdx\docs\integrations\codex\content.md
+apps/docs-site build: Prerender (data): /integrations/downstream-openai-discovery -> build\client\integrations\downstream-openai-discovery.data
+apps/docs-site build: Prerender (html): /integrations/downstream-openai-discovery -> build\client\integrations\downstream-openai-discovery\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/integrations/downstream-openai-discovery/content.md -> build\client\llms.mdx\docs\integrations\downstream-openai-discovery\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/integrations/downstream-openai-discovery/content.md -> build\client\llms.mdx\docs\integrations\downstream-openai-discovery\content.md
+apps/docs-site build: Prerender (data): /integrations/pi -> build\client\integrations\pi.data
+apps/docs-site build: Prerender (html): /integrations/pi -> build\client\integrations\pi\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/integrations/pi/content.md -> build\client\llms.mdx\docs\integrations\pi\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/integrations/pi/content.md -> build\client\llms.mdx\docs\integrations\pi\content.md
+apps/docs-site build: Prerender (data): /get-started/choose-routing-strategy -> build\client\get-started\choose-routing-strategy.data
+apps/docs-site build: Prerender (html): /get-started/choose-routing-strategy -> build\client\get-started\choose-routing-strategy\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/get-started/choose-routing-strategy/content.md -> build\client\llms.mdx\docs\get-started\choose-routing-strategy\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/get-started/choose-routing-strategy/content.md -> build\client\llms.mdx\docs\get-started\choose-routing-strategy\content.md
+apps/docs-site build: Prerender (data): /get-started/first-launch-and-connect-models -> build\client\get-started\first-launch-and-connect-models.data
+apps/docs-site build: Prerender (html): /get-started/first-launch-and-connect-models -> build\client\get-started\first-launch-and-connect-models\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/get-started/first-launch-and-connect-models/content.md -> build\client\llms.mdx\docs\get-started\first-launch-and-connect-models\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/get-started/first-launch-and-connect-models/content.md -> build\client\llms.mdx\docs\get-started\first-launch-and-connect-models\content.md
+apps/docs-site build: Prerender (data): /get-started/first-request-and-decision -> build\client\get-started\first-request-and-decision.data
+apps/docs-site build: Prerender (html): /get-started/first-request-and-decision -> build\client\get-started\first-request-and-decision\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/get-started/first-request-and-decision/content.md -> build\client\llms.mdx\docs\get-started\first-request-and-decision\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/get-started/first-request-and-decision/content.md -> build\client\llms.mdx\docs\get-started\first-request-and-decision\content.md
+apps/docs-site build: Prerender (data): /get-started/install -> build\client\get-started\install.data
+apps/docs-site build: Prerender (html): /get-started/install -> build\client\get-started\install\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/get-started/install/content.md -> build\client\llms.mdx\docs\get-started\install\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/get-started/install/content.md -> build\client\llms.mdx\docs\get-started\install\content.md
+apps/docs-site build: Prerender (data): /get-started/run-full-benchmark -> build\client\get-started\run-full-benchmark.data
+apps/docs-site build: Prerender (html): /get-started/run-full-benchmark -> build\client\get-started\run-full-benchmark\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/get-started/run-full-benchmark/content.md -> build\client\llms.mdx\docs\get-started\run-full-benchmark\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/get-started/run-full-benchmark/content.md -> build\client\llms.mdx\docs\get-started\run-full-benchmark\content.md
+apps/docs-site build: Prerender (data): /concepts/endpoints-and-profiles -> build\client\concepts\endpoints-and-profiles.data
+apps/docs-site build: Prerender (html): /concepts/endpoints-and-profiles -> build\client\concepts\endpoints-and-profiles\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/concepts/endpoints-and-profiles/content.md -> build\client\llms.mdx\docs\concepts\endpoints-and-profiles\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/concepts/endpoints-and-profiles/content.md -> build\client\llms.mdx\docs\concepts\endpoints-and-profiles\content.md
+apps/docs-site build: Prerender (data): /concepts/how-role-model-works -> build\client\concepts\how-role-model-works.data
+apps/docs-site build: Prerender (html): /concepts/how-role-model-works -> build\client\concepts\how-role-model-works\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/concepts/how-role-model-works/content.md -> build\client\llms.mdx\docs\concepts\how-role-model-works\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/concepts/how-role-model-works/content.md -> build\client\llms.mdx\docs\concepts\how-role-model-works\content.md
+apps/docs-site build: Prerender (data): /concepts/policy-and-observability -> build\client\concepts\policy-and-observability.data
+apps/docs-site build: Prerender (html): /concepts/policy-and-observability -> build\client\concepts\policy-and-observability\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/concepts/policy-and-observability/content.md -> build\client\llms.mdx\docs\concepts\policy-and-observability\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/concepts/policy-and-observability/content.md -> build\client\llms.mdx\docs\concepts\policy-and-observability\content.md
+apps/docs-site build: Prerender (data): /concepts/protocol-overview -> build\client\concepts\protocol-overview.data
+apps/docs-site build: Prerender (html): /concepts/protocol-overview -> build\client\concepts\protocol-overview\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/concepts/protocol-overview/content.md -> build\client\llms.mdx\docs\concepts\protocol-overview\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/concepts/protocol-overview/content.md -> build\client\llms.mdx\docs\concepts\protocol-overview\content.md
+apps/docs-site build: Prerender (data): /concepts/roles-tasks-and-capabilities -> build\client\concepts\roles-tasks-and-capabilities.data
+apps/docs-site build: Prerender (html): /concepts/roles-tasks-and-capabilities -> build\client\concepts\roles-tasks-and-capabilities\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/concepts/roles-tasks-and-capabilities/content.md -> build\client\llms.mdx\docs\concepts\roles-tasks-and-capabilities\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/concepts/roles-tasks-and-capabilities/content.md -> build\client\llms.mdx\docs\concepts\roles-tasks-and-capabilities\content.md
+apps/docs-site build: Prerender (data): /concepts/routing-overview -> build\client\concepts\routing-overview.data
+apps/docs-site build: Prerender (html): /concepts/routing-overview -> build\client\concepts\routing-overview\index.html
+apps/docs-site build: Prerender (data): /llms.mdx/docs/concepts/routing-overview/content.md -> build\client\llms.mdx\docs\concepts\routing-overview\content.md.data
+apps/docs-site build: Prerender (resource): /llms.mdx/docs/concepts/routing-overview/content.md -> build\client\llms.mdx\docs\concepts\routing-overview\content.md
+apps/docs-site build: Prerender (html): SPA Fallback -> build\client\__spa-fallback.html
+apps/docs-site build: Removing the server build in D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\apps\docs-site\build\server due to ssr:false
+apps/docs-site build: computing gzip size...
+apps/docs-site build: build/server/.vite/manifest.json                                       34.86 kB │ gzip:   3.87 kB
+apps/docs-site build: build/server/assets/runtime-overview-DGXvmefE.png                     660.26 kB
+apps/docs-site build: build/server/assets/server-build-BjmB36fm.css                          80.30 kB │ gzip:  13.37 kB
+apps/docs-site build: build/server/assets/pi-CS8mIPqE.js                                      0.19 kB │ gzip:   0.14 kB
+apps/docs-site build: build/server/assets/docs-BWVUEXCV.js                                    0.19 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/codex-BfX9z16o.js                                   0.19 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/install-CDy_k22D.js                                 0.20 kB │ gzip:   0.14 kB
+apps/docs-site build: build/server/assets/install-DryAn5l8.js                                 0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/overview-CilwGXOL.js                                0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/overview-Db1rLrli.js                                0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/protocol-cxFAtRHc.js                                0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/quickstart-DguZapZC.js                              0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/introduction-DwYCAeyl.js                            0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/routing-policy-qHhEdJo-.js                          0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/core-vocabulary-CFVE6Ji_.js                         0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/roles-and-tasks-B8aHTY8r.js                         0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/runtime-ui-tour-kBrnBnIn.js                         0.20 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/routing-overview-BxwzsZ01.js                        0.21 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/endpoint-identity-BS2-9VKD.js                       0.21 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/protocol-overview-uOuFlIHt.js                       0.21 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/protocol-lifecycle-YDXWsXJq.js                      0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/run-full-benchmark-BPIlcsi_.js                      0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/capability-taxonomy-CFKPiKvY.js                     0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/how-role-model-works-BpVCN--F.js                    0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/provider-connections-DUdIAH2l.js                    0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/protocol-object-model-CM9QP8X2.js                   0.21 kB │ gzip:   0.15 kB
+apps/docs-site build: build/server/assets/endpoints-and-profiles-CZ5MZANL.js                  0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/choose-routing-strategy-WrCfbkqs.js                 0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/policy-and-observability-urw6o3YH.js                0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/router-decision-artifact-zTycBP7d.js                0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/benchmarks-and-evaluation-BCy3-Dv1.js               0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/trace-and-usage-artifacts-C5ZbVTM_.js               0.21 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/first-request-and-decision-oYgSt0o-.js              0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/models-and-role-activation-CG56rLTB.js              0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/protocol-to-router-mapping-BXasSreg.js              0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/canonical-schemas-reference-39VnjPjh.js             0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/downstream-openai-discovery-C4RSvpLj.js             0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/declared-capability-profiles-CEEF2tfd.js            0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/how-routing-works-end-to-end-DVHor_30.js            0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/roles-tasks-and-capabilities-50o4CUJx.js            0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/strategy-modes-and-tradeoffs-DIBeMd77.js            0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/observed-performance-profiles-CRh0okxR.js           0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/first-launch-and-connect-models-DiMzi8DE.js         0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/observe-and-telemetry-analytics-rZsGrgdY.js         0.22 kB │ gzip:   0.17 kB
+apps/docs-site build: build/server/assets/scoring-tie-breaks-and-decisions-Bq09iMHn.js        0.22 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/candidate-selection-and-eligibility-6jS4kMQn.js     0.22 kB │ gzip:   0.17 kB
+apps/docs-site build: build/server/assets/reason-codes-and-rejection-taxonomy-Cs5YdMBq.js     0.22 kB │ gzip:   0.17 kB
+apps/docs-site build: build/server/assets/fallbacks-failures-and-observability-CIvo6Z-8.js    0.23 kB │ gzip:   0.17 kB
+apps/docs-site build: build/server/assets/routing-controls-and-decision-review-IusRbxAI.js    0.23 kB │ gzip:   0.16 kB
+apps/docs-site build: build/server/assets/routing-modes-locality-and-execution-VZ6BN650.js    0.23 kB │ gzip:   0.17 kB
+apps/docs-site build: build/server/assets/remove-undefined-CTqT55E9-Mjo5GQTv.js               0.59 kB │ gzip:   0.35 kB
+apps/docs-site build: build/server/assets/fetch-DpoRhiDB.js                                   0.89 kB │ gzip:   0.51 kB
+apps/docs-site build: build/server/assets/chunk-CYJPkc-J-CaR72aXN.js                          1.25 kB │ gzip:   0.65 kB
+apps/docs-site build: build/server/assets/chunk-BGC-wIje.js                                   1.40 kB │ gzip:   0.66 kB
+apps/docs-site build: build/server/assets/algolia-2VLBWPe9.js                                 1.55 kB │ gzip:   0.78 kB
+apps/docs-site build: build/server/assets/search-PWBiRfYs.js                                  2.15 kB │ gzip:   0.94 kB
+apps/docs-site build: build/server/assets/search-default-Dr82VNWl.js                          2.18 kB │ gzip:   0.90 kB
+apps/docs-site build: build/server/assets/orama-cloud-legacy-BQDDH83P.js                      2.28 kB │ gzip:   0.91 kB
+apps/docs-site build: build/server/assets/orama-cloud-r83vNU35.js                             2.33 kB │ gzip:   0.92 kB
+apps/docs-site build: build/server/assets/orama-static-8YBdgJ26.js                            3.90 kB │ gzip:   1.56 kB
+apps/docs-site build: build/server/assets/policy-and-observability-DqsFsLRD.js                7.25 kB │ gzip:   1.57 kB
+apps/docs-site build: build/server/assets/roles-tasks-and-capabilities-D6Fc5b80.js            8.14 kB │ gzip:   1.73 kB
+apps/docs-site build: build/server/assets/overview-BzNWFjU_.js                                8.29 kB │ gzip:   1.70 kB
+apps/docs-site build: build/server/assets/endpoints-and-profiles-D1vz45RN.js                  8.37 kB │ gzip:   1.72 kB
+apps/docs-site build: build/server/assets/install-BujL4KeW.js                                 8.77 kB │ gzip:   2.13 kB
+apps/docs-site build: build/server/assets/first-request-and-decision-BdQ-plYY.js             10.29 kB │ gzip:   1.98 kB
+apps/docs-site build: build/server/assets/quickstart-BbDWVyvF.js                             10.89 kB │ gzip:   2.30 kB
+apps/docs-site build: build/server/assets/protocol-lifecycle-DoYwbGP3.js                     11.26 kB │ gzip:   2.33 kB
+apps/docs-site build: build/server/assets/runtime-ui-tour-ViW024G_.js                        12.79 kB │ gzip:   2.45 kB
+apps/docs-site build: build/server/assets/run-full-benchmark-02I44X6R.js                     13.70 kB │ gzip:   2.57 kB
+apps/docs-site build: build/server/assets/models-and-role-activation-Q_KBk7eY.js             14.22 kB │ gzip:   2.59 kB
+apps/docs-site build: build/server/assets/provider-connections-pYm9lQPY.js                   14.29 kB │ gzip:   2.53 kB
+apps/docs-site build: build/server/assets/first-launch-and-connect-models-CGvtkrCT.js        14.80 kB │ gzip:   2.99 kB
+apps/docs-site build: build/server/assets/overview-C6WI2b7E.js                               15.16 kB │ gzip:   2.62 kB
+apps/docs-site build: build/server/assets/mixedbread-h__ax5mZ.js                             15.17 kB │ gzip:   6.26 kB
+apps/docs-site build: build/server/assets/observe-and-telemetry-analytics-C6H1q6jR.js        15.32 kB │ gzip:   2.67 kB
+apps/docs-site build: build/server/assets/capability-taxonomy-Dv53nPUl.js                    15.49 kB │ gzip:   2.58 kB
+apps/docs-site build: build/server/assets/trace-and-usage-artifacts-BvkejBJ7.js              15.70 kB │ gzip:   2.48 kB
+apps/docs-site build: build/server/assets/protocol-rcWZ-QcY.js                               16.28 kB │ gzip:   2.72 kB
+apps/docs-site build: build/server/assets/router-decision-artifact-ClnogjB6.js               16.49 kB │ gzip:   2.67 kB
+apps/docs-site build: build/server/assets/declared-capability-profiles-B6DM3Gcf.js           16.52 kB │ gzip:   2.72 kB
+apps/docs-site build: build/server/assets/downstream-openai-discovery-ozVD1JS4.js            16.73 kB │ gzip:   2.89 kB
+apps/docs-site build: build/server/assets/benchmarks-and-evaluation-BH5s8JXW.js              17.63 kB │ gzip:   3.03 kB
+apps/docs-site build: build/server/assets/protocol-to-router-mapping-D2oRPFan.js             18.15 kB │ gzip:   2.99 kB
+apps/docs-site build: build/server/assets/routing-controls-and-decision-review-Be1Z9wCD.js   18.23 kB │ gzip:   3.05 kB
+apps/docs-site build: build/server/assets/routing-policy-DCQYwhGX.js                         19.24 kB │ gzip:   2.99 kB
+apps/docs-site build: build/server/assets/how-routing-works-end-to-end-B0q1346P.js           20.50 kB │ gzip:   3.43 kB
+apps/docs-site build: build/server/assets/install-nw3n_rwz.js                                21.34 kB │ gzip:   3.54 kB
+apps/docs-site build: build/server/assets/protocol-object-model-DNLettCF.js                  21.39 kB │ gzip:   3.46 kB
+apps/docs-site build: build/server/assets/core-vocabulary-X3LKIrqc.js                        21.63 kB │ gzip:   3.46 kB
+apps/docs-site build: build/server/assets/canonical-schemas-reference-CNve8JUG.js            22.25 kB │ gzip:   3.13 kB
+apps/docs-site build: build/server/assets/reason-codes-and-rejection-taxonomy-CJ6UDBd5.js    22.27 kB │ gzip:   3.06 kB
+apps/docs-site build: build/server/assets/how-role-model-works-CoLaIg9E.js                   22.44 kB │ gzip:   3.63 kB
+apps/docs-site build: build/server/assets/routing-overview-BlTpKuFM.js                       22.55 kB │ gzip:   3.61 kB
+apps/docs-site build: build/server/assets/protocol-overview-DfdvPjG3.js                      22.96 kB │ gzip:   3.71 kB
+apps/docs-site build: build/server/assets/observed-performance-profiles-BQZ_ktZ5.js          23.74 kB │ gzip:   3.48 kB
+apps/docs-site build: build/server/assets/docs-C-hhmT4V.js                                   25.30 kB │ gzip:   4.26 kB
+apps/docs-site build: build/server/assets/endpoint-identity-GS9zDhDt.js                      27.36 kB │ gzip:   3.79 kB
+apps/docs-site build: build/server/assets/choose-routing-strategy-DX5Y4L0I.js                31.35 kB │ gzip:   4.52 kB
+apps/docs-site build: build/server/assets/fallbacks-failures-and-observability-DZIHrR99.js   32.98 kB │ gzip:   4.93 kB
+apps/docs-site build: build/server/assets/pi-CJw_UQ4o.js                                     33.25 kB │ gzip:   5.02 kB
+apps/docs-site build: build/server/assets/codex-D4gOQFsH.js                                  34.01 kB │ gzip:   4.18 kB
+apps/docs-site build: build/server/assets/candidate-selection-and-eligibility-DlgYi750.js    34.32 kB │ gzip:   4.74 kB
+apps/docs-site build: build/server/assets/introduction-qH1iaYkt.js                           34.76 kB │ gzip:   5.26 kB
+apps/docs-site build: build/server/assets/scoring-tie-breaks-and-decisions-XCLci4Ut.js       36.71 kB │ gzip:   5.23 kB
+apps/docs-site build: build/server/assets/routing-modes-locality-and-execution-DMvAWJS9.js   46.46 kB │ gzip:   5.96 kB
+apps/docs-site build: build/server/assets/strategy-modes-and-tradeoffs-B3iEhjQp.js           57.94 kB │ gzip:   7.42 kB
+apps/docs-site build: build/server/index.js                                                 372.99 kB │ gzip:  89.56 kB
+apps/docs-site build: build/server/assets/remark-DmD561_2.js                                383.60 kB │ gzip:  81.28 kB
+apps/docs-site build: build/server/assets/search-obKmH3BU.js                                509.64 kB │ gzip: 122.51 kB
+apps/docs-site build: build/server/assets/roles-and-tasks-bsMC04nE.js                       861.20 kB │ gzip:  92.03 kB
+apps/docs-site build: [33m[PLUGIN_TIMINGS] Warning:[0m Your build spent significant time in plugins. Here is a breakdown:
+apps/docs-site build:   - fumadocs-mdx (44%)
+apps/docs-site build:   - react-router:route-exports (17%)
+apps/docs-site build:   - react-router:inject-hmr-runtime (9%)
+apps/docs-site build:   - react-router:build-client-route (5%)
+apps/docs-site build:   - react-router:route-chunks-index (5%)
+apps/docs-site build: See https://rolldown.rs/options/checks#plugintimings for more details.
+apps/docs-site build: ✓ built in 7.61s
+apps/docs-site build: npm warn Unknown env config "recursive". This will stop working in the next major version of npm.
+apps/docs-site build: npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
+apps/docs-site build: > types:check
+apps/docs-site build: > react-router typegen && fumadocs-mdx && tsc --noEmit
+apps/docs-site build: [MDX] generated files in 5.420999999999822ms
+apps/docs-site build: [MDX] generated files in 6.271199999999908ms
+apps/docs-site build: Materialized search index at D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\apps\docs-site\build\client\api\search.json
+apps/docs-site build: Done
+role-model-router/apps/bench-cli build$ tsc -p tsconfig.json
+role-model-router/apps/runtime-ui build$ react-router build && tsc --noEmit
+role-model-router/packages/bench-routing build$ tsc -p tsconfig.json
+role-model-router/packages/core build$ tsc -p tsconfig.json
+role-model-router/apps/bench-cli build: Done
+.../packages/profile-aggregator build$ tsc -p tsconfig.json
+role-model-router/packages/core build: Done
+.../packages/provider-account build$ tsc -p tsconfig.json
+role-model-router/packages/bench-routing build: Done
+role-model-router/packages/trace build$ tsc -p tsconfig.json
+role-model-router/apps/runtime-ui build: vite v7.3.2 building client environment for production...
+role-model-router/apps/runtime-ui build: transforming...
+.../packages/profile-aggregator build: Done
+role-model-router/packages/usage build$ tsc -p tsconfig.json
+.../packages/provider-account build: Done
+.../packages/vendor-litellm build$ tsc -p tsconfig.json
+role-model-router/packages/trace build: Done
+.../packages/vendor-llama-swap build$ tsc -p tsconfig.json
+role-model-router/packages/usage build: Done
+.../packages/vendor-litellm build: Done
+.../packages/vendor-llama-swap build: Done
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/sidebar.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/segmented-control.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-logs.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/metric-strip.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-activity.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/chart-composition.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/page-filters.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-shared.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-requests.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/page-shell.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/chart-ranking.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-routing.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/runtime-overview.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ✓ 2407 modules transformed.
+role-model-router/apps/runtime-ui build: rendering chunks...
+role-model-router/apps/runtime-ui build: computing gzip size...
+role-model-router/apps/runtime-ui build: build/client/.vite/manifest.json                           29.36 kB │ gzip:   2.66 kB
+role-model-router/apps/runtime-ui build: build/client/assets/root-DD3btEJq.css                      78.19 kB │ gzip:  14.13 kB
+role-model-router/apps/runtime-ui build: build/client/assets/index-CKLjkIRh.js                       0.15 kB │ gzip:   0.15 kB
+role-model-router/apps/runtime-ui build: build/client/assets/live-refresh-DcaagJbF.js                0.16 kB │ gzip:   0.14 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-models-B4n-mSaY.js                0.16 kB │ gzip:   0.16 kB
+role-model-router/apps/runtime-ui build: build/client/assets/router-config-6C-g6hXx.js               0.16 kB │ gzip:   0.16 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-matrix-CdXZR64P.js                0.18 kB │ gzip:   0.18 kB
+role-model-router/apps/runtime-ui build: build/client/assets/format-score-CvKL6Nty.js                0.27 kB │ gzip:   0.21 kB
+role-model-router/apps/runtime-ui build: build/client/assets/shell-header-context-DojSALrV.js        0.65 kB │ gzip:   0.39 kB
+role-model-router/apps/runtime-ui build: build/client/assets/llama-swap-setup-zJl1O37-.js            0.82 kB │ gzip:   0.40 kB
+role-model-router/apps/runtime-ui build: build/client/assets/segmented-control-OFrtyx20.js           0.86 kB │ gzip:   0.52 kB
+role-model-router/apps/runtime-ui build: build/client/assets/badge-Dsa2DwYC.js                       0.88 kB │ gzip:   0.39 kB
+role-model-router/apps/runtime-ui build: build/client/assets/not-found-DayeuYg7.js                   1.04 kB │ gzip:   0.56 kB
+role-model-router/apps/runtime-ui build: build/client/assets/checkbox-control-6q5rTQPB.js            1.06 kB │ gzip:   0.55 kB
+role-model-router/apps/runtime-ui build: build/client/assets/theme-rIEsxy66.js                       1.14 kB │ gzip:   0.52 kB
+role-model-router/apps/runtime-ui build: build/client/assets/legacy-redirect-BuGSblma.js             1.24 kB │ gzip:   0.44 kB
+role-model-router/apps/runtime-ui build: build/client/assets/routing-mode-DNUoJD-d.js                1.54 kB │ gzip:   0.69 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-choose-DiOohlya.js                1.67 kB │ gzip:   0.71 kB
+role-model-router/apps/runtime-ui build: build/client/assets/effort-identity-rhAw6yCc.js             2.61 kB │ gzip:   1.10 kB
+role-model-router/apps/runtime-ui build: build/client/assets/metric-strip-BbsrEd3y.js                2.72 kB │ gzip:   0.86 kB
+role-model-router/apps/runtime-ui build: build/client/assets/integrations-downstream-8ov3CSEq.js     2.76 kB │ gzip:   1.14 kB
+role-model-router/apps/runtime-ui build: build/client/assets/router-decisions-BGd_hBAd.js            2.87 kB │ gzip:   1.34 kB
+role-model-router/apps/runtime-ui build: build/client/assets/router-candidates-Dp303q4i.js           3.14 kB │ gzip:   1.54 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-swap-Cd4R7eFy.js                  3.33 kB │ gzip:   1.36 kB
+role-model-router/apps/runtime-ui build: build/client/assets/control-controller-ssn3HhOY.js          3.47 kB │ gzip:   1.62 kB
+role-model-router/apps/runtime-ui build: build/client/assets/observe-logs-Cf2X879m.js                3.54 kB │ gzip:   1.49 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-policy-C5rnc96Y.js                3.59 kB │ gzip:   1.54 kB
+role-model-router/apps/runtime-ui build: build/client/assets/studio-advanced-BeZaUrro.js             3.76 kB │ gzip:   1.61 kB
+role-model-router/apps/runtime-ui build: build/client/assets/studio-rerank-Ih4irAH4.js               3.80 kB │ gzip:   1.67 kB
+role-model-router/apps/runtime-ui build: build/client/assets/control-runtime-config-Mlzvjs7m.js      3.97 kB │ gzip:   1.72 kB
+role-model-router/apps/runtime-ui build: build/client/assets/studio-images-CpIrBJ3C.js               4.10 kB │ gzip:   1.66 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-peers-BatH_kr_.js                 4.13 kB │ gzip:   1.69 kB
+role-model-router/apps/runtime-ui build: build/client/assets/workbench-BBo4mPrA.js                   4.15 kB │ gzip:   1.91 kB
+role-model-router/apps/runtime-ui build: build/client/assets/root-b7Q7zase.js                        4.16 kB │ gzip:   1.74 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-logs-CnAO-3Cz.js                  4.22 kB │ gzip:   1.69 kB
+role-model-router/apps/runtime-ui build: build/client/assets/runtime-CxEX_ZGX.js                     4.25 kB │ gzip:   1.77 kB
+role-model-router/apps/runtime-ui build: build/client/assets/page-filters-DWW_Up4G.js                4.39 kB │ gzip:   1.82 kB
+role-model-router/apps/runtime-ui build: build/client/assets/integrations-upstream-J0LLF9UG.js       4.40 kB │ gzip:   1.67 kB
+role-model-router/apps/runtime-ui build: build/client/assets/observe-activity-DZTOGDqF.js            4.72 kB │ gzip:   2.06 kB
+role-model-router/apps/runtime-ui build: build/client/assets/system-peers-erwzNNbC.js                4.74 kB │ gzip:   1.87 kB
+role-model-router/apps/runtime-ui build: build/client/assets/role-task-hierarchy-B47HxU1w.js         5.28 kB │ gzip:   1.85 kB
+role-model-router/apps/runtime-ui build: build/client/assets/endpoints-Ct9vwj63.js                   5.29 kB │ gzip:   1.96 kB
+role-model-router/apps/runtime-ui build: build/client/assets/session-readiness-DJfrnQ9u.js           5.40 kB │ gzip:   2.01 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-peer-models-Mk1418vQ.js           5.81 kB │ gzip:   2.11 kB
+role-model-router/apps/runtime-ui build: build/client/assets/observe-routing-D8lbG6nW.js             6.33 kB │ gzip:   2.50 kB
+role-model-router/apps/runtime-ui build: build/client/assets/page-primitives-BrAHTW6H.js             6.84 kB │ gzip:   2.66 kB
+role-model-router/apps/runtime-ui build: build/client/assets/control-routing-strategy-J0kdJjqE.js    7.00 kB │ gzip:   2.59 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-llama-swap-models-Duo2vQn1.js     7.12 kB │ gzip:   2.45 kB
+role-model-router/apps/runtime-ui build: build/client/assets/studio-audio-Bnip41BB.js                7.15 kB │ gzip:   2.92 kB
+role-model-router/apps/runtime-ui build: build/client/assets/storage-retention-RgoGRtZ-.js           7.35 kB │ gzip:   2.60 kB
+role-model-router/apps/runtime-ui build: build/client/assets/router-decision-detail-3vDZ4dz9.js      7.90 kB │ gzip:   2.52 kB
+role-model-router/apps/runtime-ui build: build/client/assets/router-BuQVycM5.js                      8.51 kB │ gzip:   2.63 kB
+role-model-router/apps/runtime-ui build: build/client/assets/local-model-role-picker-DbuSnF_P.js     8.96 kB │ gzip:   2.95 kB
+role-model-router/apps/runtime-ui build: build/client/assets/telemetry-page-filters-Ck_5vw9i.js      9.41 kB │ gzip:   3.09 kB
+role-model-router/apps/runtime-ui build: build/client/assets/requests-B_ns5RQi.js                   10.75 kB │ gzip:   3.96 kB
+role-model-router/apps/runtime-ui build: build/client/assets/control-roles-Dnk99Urf.js              12.63 kB │ gzip:   3.53 kB
+role-model-router/apps/runtime-ui build: build/client/assets/app-layout-A5y6eVSI.js                 13.91 kB │ gzip:   4.92 kB
+role-model-router/apps/runtime-ui build: build/client/assets/extensions-DPxtuVZg.js                 14.11 kB │ gzip:   4.78 kB
+role-model-router/apps/runtime-ui build: build/client/assets/runtime-api-BinJXMyE.js                17.83 kB │ gzip:   4.39 kB
+role-model-router/apps/runtime-ui build: build/client/assets/dashboard-DQllg34v.js                  18.98 kB │ gzip:   6.51 kB
+role-model-router/apps/runtime-ui build: build/client/assets/control-models-D9il_dy5.js             20.15 kB │ gzip:   6.62 kB
+role-model-router/apps/runtime-ui build: build/client/assets/request-detail-DMHjbpME.js             21.20 kB │ gzip:   6.36 kB
+role-model-router/apps/runtime-ui build: build/client/assets/control-benchmark-Byx2p-EW.js          21.83 kB │ gzip:   6.62 kB
+role-model-router/apps/runtime-ui build: build/client/assets/design-system-io-4_AOW.js              25.05 kB │ gzip:   7.71 kB
+role-model-router/apps/runtime-ui build: build/client/assets/view-models-BXKXikR-.js                25.80 kB │ gzip:   8.22 kB
+role-model-router/apps/runtime-ui build: build/client/assets/providers-DEYGrDZK.js                  27.11 kB │ gzip:   8.43 kB
+role-model-router/apps/runtime-ui build: build/client/assets/chart-grid-CqXjTUqn.js                 78.21 kB │ gzip:  26.08 kB
+role-model-router/apps/runtime-ui build: build/client/assets/chunk-EVOBXE3Y-g5m91DvX.js            128.07 kB │ gzip:  43.13 kB
+role-model-router/apps/runtime-ui build: build/client/assets/entry.client-B4czBmcP.js              190.57 kB │ gzip:  60.05 kB
+role-model-router/apps/runtime-ui build: build/client/assets/telemetry-route-models-BaGo3qRk.js    389.60 kB │ gzip: 103.81 kB
+role-model-router/apps/runtime-ui build: ✓ built in 17.80s
+role-model-router/apps/runtime-ui build: vite v7.3.2 building ssr environment for production...
+role-model-router/apps/runtime-ui build: transforming...
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/segmented-control.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/page-shell.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/chart-ranking.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-routing.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-logs.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/metric-strip.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-shared.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/chart-composition.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-requests.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/observe-activity.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/runtime-overview.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/sidebar.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ../../packages/ui/src/page-filters.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
+role-model-router/apps/runtime-ui build: ✓ 32 modules transformed.
+role-model-router/apps/runtime-ui build: rendering chunks...
+role-model-router/apps/runtime-ui build: build/server/.vite/manifest.json                0.23 kB
+role-model-router/apps/runtime-ui build: build/server/assets/server-build-DD3btEJq.css  78.19 kB
+role-model-router/apps/runtime-ui build: build/server/index.js                          75.05 kB
+role-model-router/apps/runtime-ui build: ✓ 1 asset cleaned from React Router server build.
+role-model-router/apps/runtime-ui build: build\server\assets\server-build-DD3btEJq.css
+role-model-router/apps/runtime-ui build: SPA Mode: Generated build\client\index.html
+role-model-router/apps/runtime-ui build: Removing the server build in D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\role-model-router\apps\runtime-ui\build\server due to ssr:false
+role-model-router/apps/runtime-ui build: ✓ built in 964ms
+role-model-router/apps/runtime-ui build: Done
+role-model-router/packages/openai-compat build$ tsc -p tsconfig.json
+role-model-router/packages/provider-acp build$ tsc -p tsconfig.json
+role-model-router/packages/provider-cli build$ tsc -p tsconfig.json
+role-model-router/packages/provider-mcp build$ tsc -p tsconfig.json
+role-model-router/packages/provider-acp build: Done
+role-model-router/packages/roles build$ tsc -p tsconfig.json
+role-model-router/packages/openai-compat build: Done
+role-model-router/packages/sqlite-memory build$ tsc -p tsconfig.json
+role-model-router/packages/provider-cli build: Done
+role-model-router/packages/tasks build$ tsc -p tsconfig.json
+role-model-router/packages/provider-mcp build: Done
+role-model-router/packages/roles build: Done
+role-model-router/packages/tasks build: Done
+role-model-router/packages/sqlite-memory build: Done
+role-model-router/apps/router-devtools build$ tsc -p tsconfig.json
+.../packages/context-envelope build$ tsc -p tsconfig.json
+role-model-router/apps/router-devtools build: Done
+.../packages/context-envelope build: Done
+.../packages/retrieval-receipt build$ tsc -p tsconfig.json
+.../packages/retrieval-receipt build: Done
+.../packages/endpoint-registry build$ tsc -p tsconfig.json
+.../packages/endpoint-registry build: Done
+.../packages/protocol-routing build$ tsc -p tsconfig.json
+.../packages/protocol-routing build: Done
+packages/conformance build$ tsc -p tsconfig.json
+packages/conformance build: Done
+.../packages/adapter-execution build$ tsc -p tsconfig.json
+.../packages/provider-anthropic build$ tsc -p tsconfig.json
+.../packages/provider-anthropic build: Done
+.../packages/adapter-execution build: Done
+.../packages/provider-openai build$ tsc -p tsconfig.json
+.../packages/runtime-observability build$ tsc -p tsconfig.json
+.../packages/provider-openai build: Done
+.../packages/runtime-observability build: Done
+.../packages/provider-litellm build$ tsc -p tsconfig.json
+role-model-router/apps/gateway-smoke build$ tsc -p tsconfig.json
+.../packages/provider-litellm build: Done
+role-model-router/apps/gateway-smoke build: Done
+.../apps/runtime-host-bridge build$ tsc -p tsconfig.json
+.../apps/runtime-host-bridge build: Done
+
+> role-model@0.0.0 test D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm run test:release-workflows && corepack pnpm -r --if-present --filter=./** --filter=!@role-model-router/runtime-host-bridge --filter=!@try-works/pi-role-model test && corepack pnpm --filter @role-model-router/runtime-host-bridge test && corepack pnpm --filter @try-works/pi-role-model test
+
+
+> role-model@0.0.0 test:release-workflows D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs scripts/track-b/wait-for-runtime-readiness.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
+
+✔ docs deploy workflow skips gracefully when Cloudflare secrets are absent (9.8072ms)
+✔ docs deploy is a single main-only deployment even for manual runs (2.5337ms)
+✔ build-binaries retries release attestation before failing (1.8732ms)
+✔ build-binaries pins one exact Node patch for reproducible SEA payloads (0.5432ms)
+✔ build-binaries produces stage candidates, manual dev builds, and tag-only releases (0.3697ms)
+✔ production artifacts include the exact private runtime tested at stage (0.3673ms)
+✔ the public release orchestrator enforces paired private promotion (0.3783ms)
+✔ paired private checkout never dirties the public package provenance worktree (0.4625ms)
+✔ stage pushes publish downloadable prereleases before stable promotion (0.6523ms)
+✔ stable tags require a manually accepted exact stage candidate (0.3824ms)
+✔ release candidate acceptance is explicit, checksum-bound, and manual only (0.6532ms)
+✔ CI is scoped to long-lived branches with stable cancellable lanes (3.1583ms)
+✔ Track B CI is always-on, explicit, and runs the tagged browser contract (0.8ms)
+✔ Track B browser gate waits for semantic readiness without weakening exact private pairing (0.4723ms)
+✔ promotion guard encodes dev to stage to main with a hotfix exception (0.5004ms)
+✔ workspace tests serialize the resource-heavy runtime proofs (0.4814ms)
+✔ refuses an HTTP-200 health response while runtime bootstrap is degraded and pending (3.6905ms)
+✔ retains the last semantic observation when a near-deadline request aborts (0.8142ms)
+✔ accepts only healthy, authoritative, bootstrap-ready runtime health (231.9448ms)
+✔ fails closed when health responds with malformed JSON (1.3525ms)
+✔ fails closed with bounded diagnostics when health never becomes ready (0.6862ms)
+ℹ tests 21
+ℹ suites 0
+ℹ pass 21
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 515.3673
+Scope: 43 of 46 workspace projects
+packages/schema-tools test$ vitest run
+role-model-router/packages/bench-judge test$ vitest run
+apps/docs-site test$ node --test
+packages/codex-role-model test$ vitest run
+apps/docs-site test: ✔ docs deploy workflow skips gracefully when Cloudflare secrets are absent (10.122ms)
+apps/docs-site test: ✔ docs deploy is a single main-only deployment even for manual runs (3.0616ms)
+apps/docs-site test: ℹ tests 2
+apps/docs-site test: ℹ suites 0
+apps/docs-site test: ℹ pass 2
+apps/docs-site test: ℹ fail 0
+apps/docs-site test: ℹ cancelled 0
+apps/docs-site test: ℹ skipped 0
+apps/docs-site test: ℹ todo 0
+apps/docs-site test: ℹ duration_ms 437.9409
+apps/docs-site test: Done
+role-model-router/packages/catalog test$ vitest run test
+role-model-router/packages/bench-judge test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/bench-judge
+packages/schema-tools test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/packages/schema-tools
+packages/codex-role-model test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/packages/codex-role-model
+role-model-router/packages/bench-judge test:  ✓ src/index.test.ts (7 tests) 17ms
+role-model-router/packages/bench-judge test:  Test Files  1 passed (1)
+role-model-router/packages/bench-judge test:       Tests  7 passed (7)
+role-model-router/packages/bench-judge test:    Start at  22:13:16
+role-model-router/packages/bench-judge test:    Duration  2.01s (transform 554ms, setup 0ms, collect 371ms, tests 17ms, environment 0ms, prepare 850ms)
+role-model-router/packages/catalog test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/catalog
+packages/codex-role-model test:  ✓ test/docs-and-safety.test.ts (3 tests) 63ms
+role-model-router/packages/bench-judge test: Done
+.../packages/process-supervisor test$ vitest run
+packages/codex-role-model test:  ✓ test/web-search.test.ts (6 tests) 29ms
+packages/codex-role-model test:  ✓ test/codex-config.test.ts (5 tests) 33ms
+packages/codex-role-model test:  ✓ test/signed-in-integration.test.ts (2 tests) 27ms
+packages/codex-role-model test:  ✓ test/codex-tool-bridge.test.ts (15 tests) 77ms
+packages/codex-role-model test:  ✓ test/effort-identity.test.ts (1 test) 9ms
+packages/codex-role-model test:  ✓ test/native-alias.test.ts (4 tests) 148ms
+packages/codex-role-model test:  ✓ test/catalog.test.ts (2 tests) 22ms
+packages/codex-role-model test:  ✓ test/runtime-discovery.test.ts (4 tests) 103ms
+packages/codex-role-model test:  ✓ test/package-manifest.test.ts (3 tests) 290ms
+packages/codex-role-model test:  ✓ test/responses-intent.test.ts (3 tests) 23ms
+packages/codex-role-model test:  ✓ test/commands.test.ts (3 tests) 21ms
+packages/codex-role-model test:  ✓ test/secret-safety.test.ts (1 test) 24ms
+packages/codex-role-model test:  ✓ test/config.test.ts (3 tests) 12ms
+role-model-router/packages/catalog test:  ✓ test/run91-reasoning-effort.test.ts (10 tests) 84ms
+packages/codex-role-model test:  ✓ test/responses-websocket.test.ts (3 tests) 746ms
+packages/codex-role-model test:    ✓ responses websocket bridge > upgrade on /v1/responses succeeds (no HTTP 404)  479ms
+packages/codex-role-model test:  ✓ test/request-intent.test.ts (3 tests) 24ms
+packages/schema-tools test:  ✓ test/recursive-biome-local-router-config-format.test.ts (1 test) 4303ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for local router config format batch > requires the local router config format blocker set to pass under repository config  4299ms
+packages/codex-role-model test:  ✓ test/forwarder.test.ts (32 tests) 1756ms
+packages/codex-role-model test:    ✓ web_search mixed client tools gate > mixed update_plan+web_search fulfills search in-place via alpha/search (not Codex client)  709ms
+packages/codex-role-model test:  Test Files  17 passed (17)
+packages/codex-role-model test:       Tests  93 passed (93)
+packages/codex-role-model test:    Start at  22:13:16
+packages/codex-role-model test:    Duration  6.92s (transform 12.17s, setup 0ms, collect 19.53s, tests 3.41s, environment 8ms, prepare 14.96s)
+.../packages/process-supervisor test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/process-supervisor
+packages/schema-tools test:  ✓ test/recursive-biome-run75.test.ts (1 test) 3462ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for run75 > requires the run75 Biome blocker set to pass under repository config  3458ms
+packages/schema-tools test:  ✓ test/recursive-biome-local-provider-config-format.test.ts (1 test) 3618ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for local provider config format batch > requires the local provider config format blocker set to pass under repository config  3612ms
+packages/schema-tools test:  ✓ test/recursive-biome-run78.test.ts (1 test) 3645ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for run78 > requires the run78 Biome blocker set to pass under repository config  3641ms
+packages/schema-tools test:  ✓ test/recursive-biome-local-runtime-package-format.test.ts (1 test) 3540ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for local runtime package format batch > requires the local runtime package format blocker set to pass under repository config  3534ms
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for benchmark-run.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for benchmark-suite.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for capability-taxonomy.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for declared-capability-profile.schema.json
+packages/schema-tools test:  ✓ test/recursive-biome-local-config-format.test.ts (1 test) 3970ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for local config format batch > requires the local config format blocker set to pass under repository config  3966ms
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for downstream-openai-discovery.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for endpoint-identity.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for judge-score.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for model-pack-manifest.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for observed-performance-profile.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for package-manifest.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for planspec.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for role-binding.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for role-definition.schema.json
+packages/schema-tools test:  ✓ test/recursive-biome-run74.test.ts (1 test) 4260ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression > requires the run74 Biome blocker set to pass under repository config  4257ms
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for router-decision.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for routing-policy.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for task-definition.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for task-execution-profile.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for trace-event.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for trace-span.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas
+packages/schema-tools test: Generated types for usage-event.schema.json
+packages/codex-role-model test: Done
+role-model-router/packages/tool-registry test$ vitest run
+packages/schema-tools test:  ✓ test/recursive-biome-semantic-remainder.test.ts (1 test) 3717ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for semantic remainder > requires the remaining 7-file semantic lint batch to pass under repository config  3711ms
+packages/schema-tools test: Formatted 1 file in 60ms. Fixed 1 file.
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for benchmark-run.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for benchmark-suite.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for capability-taxonomy.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for declared-capability-profile.schema.json
+packages/schema-tools test:  ✓ test/recursive-biome-run79.test.ts (1 test) 3382ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for run79 > requires the run79 Biome blocker set to pass under repository config  3378ms
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for downstream-openai-discovery.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for endpoint-identity.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for judge-score.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for model-pack-manifest.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for observed-performance-profile.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for package-manifest.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for planspec.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for role-binding.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for role-definition.schema.json
+packages/schema-tools test:  ✓ test/recursive-biome-run80.test.ts (1 test) 3480ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for run80 > requires the run80 Biome blocker set to pass under repository config  3477ms
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for router-decision.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for routing-policy.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for task-definition.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for task-execution-profile.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for trace-event.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for trace-span.schema.json
+packages/schema-tools test: stdout | test/generate-protocol-types.test.ts > generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol
+packages/schema-tools test: Generated types for usage-event.schema.json
+packages/schema-tools test:  ✓ test/recursive-biome-run76.test.ts (1 test) 4743ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for run76 > requires the run76 Biome blocker set to pass under repository config  4740ms
+role-model-router/packages/catalog test:  ✓ test/token-economics.test.ts (10 tests) 5368ms
+role-model-router/packages/catalog test:    ✓ token-economics > respects priced gateway rows and resolves unpriced aliases to models.dev pricing  2051ms
+role-model-router/packages/catalog test:    ✓ token-economics > copies models.dev pricing onto all operator moonshot/kimi rows  2165ms
+packages/schema-tools test: Formatted 1 file in 50ms. Fixed 1 file.
+packages/schema-tools test:  ✓ test/generate-protocol-types.test.ts (2 tests) 3342ms
+packages/schema-tools test:    ✓ generateProtocolTypes > does not emit duplicate exported interfaces for externally referenced schemas  2227ms
+packages/schema-tools test:    ✓ generateProtocolTypes > emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol  1112ms
+packages/schema-tools test:  ✓ test/validate-schemas.test.ts (7 tests) 3051ms
+packages/schema-tools test:    ✓ loadSchemas > treats manifest expectations as authoritative for valid and invalid fixtures  1813ms
+packages/schema-tools test:    ✓ loadSchemas > validates the full fixture manifest through the schema-tool entrypoint  748ms
+role-model-router/packages/tool-registry test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/tool-registry
+packages/schema-tools test:  ✓ test/recursive-biome-run77.test.ts (1 test) 7009ms
+packages/schema-tools test:    ✓ run31 bounded Biome regression for run77 > requires the run77 Biome blocker set to pass under repository config  7005ms
+packages/schema-tools test:  ✓ test/recursive-biome-repo-wide.test.ts (1 test) 4921ms
+packages/schema-tools test:    ✓ run31 repo-wide Biome parity > requires repo-wide biome check to pass under repository config  4918ms
+role-model-router/packages/tool-registry test:  ✓ test/index.test.ts (4 tests) 14ms
+role-model-router/packages/tool-registry test:  Test Files  1 passed (1)
+role-model-router/packages/tool-registry test:       Tests  4 passed (4)
+role-model-router/packages/tool-registry test:    Start at  22:13:28
+role-model-router/packages/tool-registry test:    Duration  2.64s (transform 184ms, setup 0ms, collect 188ms, tests 14ms, environment 0ms, prepare 400ms)
+role-model-router/packages/tool-registry test: Done
+role-model-router/packages/ui test$ vitest run
+packages/schema-tools test:  ✓ test/recursive-core-run81-typecheck.test.ts (1 test) 7052ms
+packages/schema-tools test:    ✓ run31 core build regression for run81 > requires @role-model-router/core to build cleanly under repository config  7049ms
+role-model-router/packages/ui test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/ui
+role-model-router/packages/catalog test:  ✓ test/index.test.ts (16 tests) 11990ms
+role-model-router/packages/catalog test:    ✓ normalizeCatalogSnapshot > loads the tracked compact artifact through the canonical hydrated file boundary  322ms
+role-model-router/packages/catalog test:    ✓ exportCatalogArtifacts > writes stable normalized catalog and vendor ledger artifacts for local validation  2824ms
+role-model-router/packages/catalog test:    ✓ runCatalogExportCli > derives the repo-local catalog export paths for the validation command  2307ms
+role-model-router/packages/catalog test:    ✓ runCatalogExportCli > exports moonshot/kimi-k3 from local supplement into normalized catalog  3669ms
+role-model-router/packages/catalog test:    ✓ runCatalogExportCli > rewrites tracked package-data catalog artifacts alongside the runtime-output export  2391ms
+role-model-router/packages/catalog test:  Test Files  3 passed (3)
+role-model-router/packages/catalog test:       Tests  36 passed (36)
+role-model-router/packages/catalog test:    Start at  22:13:18
+role-model-router/packages/catalog test:    Duration  15.84s (transform 1.80s, setup 0ms, collect 3.35s, tests 17.44s, environment 1ms, prepare 2.00s)
+role-model-router/packages/catalog test: Done
+.../packages/vendor-abstraction test$ vitest run
+.../packages/process-supervisor test:  ✓ test/index.test.ts (5 tests) 9676ms
+.../packages/process-supervisor test:    ✓ process-supervisor > starts a vendor process, waits for health, and reports it as healthy  1792ms
+.../packages/process-supervisor test:    ✓ process-supervisor > tracks crash callbacks when a managed vendor exits unexpectedly  1724ms
+.../packages/process-supervisor test:    ✓ process-supervisor > captures child logs and restarts an unexpectedly crashed vendor with backoff  2810ms
+.../packages/process-supervisor test:    ✓ process-supervisor > forces bounded shutdown when a vendor ignores the initial termination signal  1071ms
+.../packages/process-supervisor test:    ✓ process-supervisor > stops spawned child processes when a managed vendor shuts down on Windows  2275ms
+role-model-router/packages/ui test:  ✓ src/chart-grid.test.ts (1 test) 7ms
+.../packages/process-supervisor test:  Test Files  1 passed (1)
+.../packages/process-supervisor test:       Tests  5 passed (5)
+.../packages/process-supervisor test:    Start at  22:13:23
+.../packages/process-supervisor test:    Duration  11.99s (transform 783ms, setup 0ms, collect 643ms, tests 9.68s, environment 0ms, prepare 686ms)
+role-model-router/packages/ui test:  ✓ src/badge.test.ts (2 tests) 56ms
+role-model-router/packages/ui test:  ✓ src/sidebar.test.ts (4 tests) 115ms
+.../packages/process-supervisor test: Done
+role-model-router/packages/ui test:  ✓ src/chart.test.ts (13 tests) 27ms
+role-model-router/packages/ui test:  ✓ src/chart-composition.test.ts (3 tests) 10ms
+.../packages/vendor-abstraction test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/vendor-abstraction
+role-model-router/packages/ui test:  ✓ src/runtime-overview.test.ts (3 tests) 10ms
+role-model-router/packages/ui test:  ✓ src/observe.test.ts (5 tests) 19ms
+role-model-router/packages/ui test:  Test Files  7 passed (7)
+role-model-router/packages/ui test:       Tests  31 passed (31)
+role-model-router/packages/ui test:    Start at  22:13:33
+role-model-router/packages/ui test:    Duration  3.86s (transform 1.33s, setup 0ms, collect 8.77s, tests 245ms, environment 4ms, prepare 3.72s)
+role-model-router/packages/ui test: Done
+.../packages/vendor-abstraction test:  ✓ test/index.test.ts (3 tests) 19ms
+.../packages/vendor-abstraction test:  Test Files  1 passed (1)
+.../packages/vendor-abstraction test:       Tests  3 passed (3)
+.../packages/vendor-abstraction test:    Start at  22:13:37
+.../packages/vendor-abstraction test:    Duration  1.66s (transform 250ms, setup 0ms, collect 180ms, tests 19ms, environment 0ms, prepare 570ms)
+.../packages/vendor-abstraction test: Done
+packages/schema-tools test:  ✓ test/recursive-evidence-json.test.ts (1 test) 19389ms
+packages/schema-tools test:    ✓ tracked recursive JSON evidence > requires tracked recursive JSON files to contain parseable JSON payloads  19386ms
+packages/schema-tools test:  ✓ test/recursive-runtime-host-bridge-build.test.ts (1 test) 20232ms
+packages/schema-tools test:    ✓ run31 runtime-host-bridge build regression > requires @role-model-router/runtime-host-bridge to build cleanly under repository config  20229ms
+packages/schema-tools test:  Test Files  18 passed (18)
+packages/schema-tools test:       Tests  25 passed (25)
+packages/schema-tools test:    Start at  22:13:16
+packages/schema-tools test:    Duration  28.59s (transform 27.44s, setup 0ms, collect 32.58s, tests 107.12s, environment 11ms, prepare 16.50s)
+packages/schema-tools test: Done
+role-model-router/apps/runtime-ui test$ vitest run
+role-model-router/packages/bench-routing test$ vitest run
+role-model-router/packages/core test$ vitest run
+.../packages/profile-aggregator test$ vitest run test/benchmark-routing-quality.test.ts
+role-model-router/packages/bench-routing test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/bench-routing
+role-model-router/packages/core test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/core
+.../packages/profile-aggregator test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/profile-aggregator
+.../packages/profile-aggregator test:  ✓ test/benchmark-routing-quality.test.ts (5 tests) 16ms
+.../packages/profile-aggregator test:  Test Files  1 passed (1)
+.../packages/profile-aggregator test:       Tests  5 passed (5)
+.../packages/profile-aggregator test:    Start at  22:13:46
+.../packages/profile-aggregator test:    Duration  2.30s (transform 554ms, setup 0ms, collect 382ms, tests 16ms, environment 0ms, prepare 797ms)
+role-model-router/packages/core test:  ✓ test/taxonomy-docs.test.ts (2 tests) 22ms
+role-model-router/packages/core test:  ✓ test/observed-data-decay-policy.test.ts (5 tests) 22ms
+role-model-router/packages/bench-routing test:  ✓ src/reasoning-extraction.test.ts (2 tests) 23ms
+role-model-router/packages/bench-routing test:  ✓ src/answer-format.test.ts (9 tests) 31ms
+role-model-router/packages/bench-routing test:  ✓ test/answer-format.test.ts (4 tests) 14ms
+role-model-router/packages/core test:  ✓ test/routing-intent.test.ts (36 tests) 116ms
+.../packages/profile-aggregator test: Done
+.../packages/provider-account test$ vitest run test/index.test.ts
+role-model-router/packages/bench-routing test:  ✓ src/diff-validator.test.ts (4 tests) 12ms
+role-model-router/packages/bench-routing test:  ✓ test/subject-prompt.test.ts (1 test) 9ms
+role-model-router/packages/bench-routing test:  ✓ src/judge-brief.test.ts (7 tests) 25ms
+role-model-router/packages/bench-routing test:  ✓ test/judge-brief.test.ts (5 tests) 23ms
+role-model-router/packages/bench-routing test:  ✓ src/index.test.ts (29 tests) 49ms
+role-model-router/packages/core test:  ✓ test/taxonomy-catalog.test.ts (9 tests) 360ms
+role-model-router/packages/bench-routing test:  Test Files  8 passed (8)
+role-model-router/packages/bench-routing test:       Tests  61 passed (61)
+role-model-router/packages/bench-routing test:    Start at  22:13:46
+role-model-router/packages/bench-routing test:    Duration  3.55s (transform 3.91s, setup 0ms, collect 6.09s, tests 186ms, environment 4ms, prepare 6.37s)
+role-model-router/packages/core test:  ✓ test/taxonomy-data-files.test.ts (5 tests) 972ms
+role-model-router/packages/core test:    ✓ taxonomy data and schema files > run 58 benchmark and telemetry schemas validate sample data  725ms
+role-model-router/packages/core test:  Test Files  5 passed (5)
+role-model-router/packages/core test:       Tests  57 passed (57)
+role-model-router/packages/core test:    Start at  22:13:46
+role-model-router/packages/core test:    Duration  4.05s (transform 1.84s, setup 0ms, collect 2.76s, tests 1.49s, environment 2ms, prepare 3.69s)
+role-model-router/packages/bench-routing test: Done
+role-model-router/packages/trace test$ vitest run
+role-model-router/packages/core test: Done
+role-model-router/packages/usage test$ vitest run
+role-model-router/apps/runtime-ui test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/apps/runtime-ui
+.../packages/provider-account test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/provider-account
+role-model-router/packages/trace test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/trace
+role-model-router/packages/usage test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/usage
+role-model-router/apps/runtime-ui test: stderr | app/lib/stale-refresh-diagnostics.test.ts > stale-refresh-diagnostics > emit and flush diagnostics > batches diagnostics until flushed
+role-model-router/apps/runtime-ui test: [telemetry] Background analytics refresh reused stale data {
+role-model-router/apps/runtime-ui test:   routeId: 'dashboard',
+role-model-router/apps/runtime-ui test:   staleChartCount: 2,
+role-model-router/apps/runtime-ui test:   charts: [
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart A',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart B',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     }
+role-model-router/apps/runtime-ui test:   ]
+role-model-router/apps/runtime-ui test: }
+role-model-router/apps/runtime-ui test: stderr | app/lib/stale-refresh-diagnostics.test.ts > stale-refresh-diagnostics > emit and flush diagnostics > auto-flushes at max batch size
+role-model-router/apps/runtime-ui test: [telemetry] Background analytics refresh reused stale data {
+role-model-router/apps/runtime-ui test:   routeId: 'dashboard',
+role-model-router/apps/runtime-ui test:   staleChartCount: 10,
+role-model-router/apps/runtime-ui test:   charts: [
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 0',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 1',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 2',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 3',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 4',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 5',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 6',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 7',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 8',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     },
+role-model-router/apps/runtime-ui test:     {
+role-model-router/apps/runtime-ui test:       title: 'Chart 9',
+role-model-router/apps/runtime-ui test:       query: 'range=week',
+role-model-router/apps/runtime-ui test:       error: 'fail',
+role-model-router/apps/runtime-ui test:       staleReused: true
+role-model-router/apps/runtime-ui test:     }
+role-model-router/apps/runtime-ui test:   ]
+role-model-router/apps/runtime-ui test: }
+role-model-router/apps/runtime-ui test:  ✓ app/lib/device-authorization.test.ts (19 tests) 26ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/stale-refresh-diagnostics.test.ts (14 tests) 155ms
+role-model-router/packages/trace test:  ✓ test/run91-lineage.test.ts (4 tests) 21ms
+role-model-router/packages/trace test:  ✓ test/recursive-87-projections.test.ts (5 tests) 92ms
+.../packages/provider-account test:  ✓ test/index.test.ts (9 tests) 402ms
+role-model-router/packages/trace test:  ✓ test/index.test.ts (8 tests) 65ms
+role-model-router/packages/trace test:  Test Files  3 passed (3)
+role-model-router/packages/trace test:       Tests  17 passed (17)
+role-model-router/packages/trace test:    Start at  22:13:54
+role-model-router/packages/trace test:    Duration  2.45s (transform 1.41s, setup 0ms, collect 1.34s, tests 177ms, environment 1ms, prepare 2.03s)
+.../packages/provider-account test:  Test Files  1 passed (1)
+.../packages/provider-account test:       Tests  9 passed (9)
+.../packages/provider-account test:    Start at  22:13:52
+.../packages/provider-account test:    Duration  4.18s (transform 1.70s, setup 0ms, collect 1.87s, tests 402ms, environment 0ms, prepare 472ms)
+role-model-router/packages/usage test:  ✓ test/index.test.ts (7 tests) 165ms
+role-model-router/packages/usage test:  ✓ test/run91-effort-lineage.test.ts (4 tests) 55ms
+role-model-router/packages/usage test:  Test Files  2 passed (2)
+role-model-router/packages/usage test:       Tests  11 passed (11)
+role-model-router/packages/usage test:    Start at  22:13:54
+role-model-router/packages/usage test:    Duration  2.62s (transform 268ms, setup 0ms, collect 302ms, tests 219ms, environment 1ms, prepare 846ms)
+role-model-router/apps/runtime-ui test:  ✓ app/lib/telemetry-route-models.test.ts (3 tests) 22ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/effort-identity.test.ts (7 tests) 61ms
+.../packages/provider-account test: Done
+.../packages/vendor-litellm test$ vitest run
+role-model-router/apps/runtime-ui test:  ✓ app/lib/runtime-api.test.ts (68 tests) 353ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/telemetry-analytics.test.ts (13 tests) 162ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/candidate-space.test.ts (25 tests) 225ms
+role-model-router/packages/trace test: Done
+.../packages/vendor-llama-swap test$ vitest run
+role-model-router/apps/runtime-ui test:  ✓ app/lib/view-models.test.ts (48 tests) 193ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/sidebar-footer.test.ts (5 tests) 13ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/theme.test.ts (6 tests) 22ms
+role-model-router/packages/usage test: Done
+role-model-router/apps/runtime-ui test:  ✓ app/components/telemetry-charts.test.tsx (13 tests) 150ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/telemetry-chart-config.test.ts (3 tests) 17ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/benchmark-model-cards.test.ts (5 tests) 15ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/llama-swap-setup.test.ts (6 tests) 18ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/runtime-refresh-bus.test.ts (5 tests) 17ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/router-candidate-labels.test.ts (5 tests) 47ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/startup-bootstrap-regression.test.ts (11 tests) 18ms
+.../packages/vendor-litellm test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/vendor-litellm
+.../packages/vendor-llama-swap test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/vendor-llama-swap
+role-model-router/apps/runtime-ui test:  ✓ app/lib/benchmark-decision-evidence.test.ts (2 tests) 10ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/telemetry-performance-semantics.test.ts (3 tests) 17ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/build-sync.test.ts (3 tests) 44ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/live-refresh.test.ts (2 tests) 149ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/role-task-hierarchy.test.tsx (4 tests) 113ms
+role-model-router/apps/runtime-ui test:  ✓ app/components/local-model-role-picker.test.tsx (9 tests) 190ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/overview-chart-adapter.test.ts (13 tests) 98ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/extensions.test.tsx (2 tests) 114ms
+role-model-router/apps/runtime-ui test:  ✓ app/components/page-primitives.test.tsx (7 tests) 69ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/storage-retention.test.tsx (3 tests) 171ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/providers.test.ts (19 tests) 282ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/control-models.test.ts (31 tests) 215ms
+role-model-router/apps/runtime-ui test:  ✓ app/root.test.tsx (3 tests) 10ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/provider-account-state.test.ts (2 tests) 9ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/format-score.test.ts (5 tests) 12ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/index.test.tsx (1 test) 8ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/benchmark-latency.test.ts (2 tests) 10ms
+role-model-router/apps/runtime-ui test:  ✓ app/components/device-authorization-modal.test.tsx (1 test) 35ms
+role-model-router/apps/runtime-ui test:  ✓ app/components/device-authorization-card.test.tsx (2 tests) 73ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/observe-chart-adapter.test.ts (4 tests) 15ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/endpoints.test.tsx (1 test) 54ms
+role-model-router/apps/runtime-ui test:  ✓ app/lib/design-system.test.ts (96 tests) 352ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/request-detail.test.tsx (6 tests) 12ms
+.../packages/vendor-llama-swap test:  ✓ test/index.test.ts (7 tests) 3353ms
+.../packages/vendor-llama-swap test:    ✓ vendor-llama-swap > does not export the bridge listen port into provisioned llama-swap process env  328ms
+.../packages/vendor-llama-swap test:    ✓ vendor-llama-swap > starts a managed llama-swap vendor and executes local openai-compatible requests through it  1335ms
+.../packages/vendor-llama-swap test:    ✓ vendor-llama-swap > streams chat-completions deltas through the managed llama-swap vendor  1323ms
+.../packages/vendor-llama-swap test:  Test Files  1 passed (1)
+.../packages/vendor-llama-swap test:       Tests  7 passed (7)
+.../packages/vendor-llama-swap test:    Start at  22:14:00
+.../packages/vendor-llama-swap test:    Duration  6.74s (transform 590ms, setup 0ms, collect 1.03s, tests 3.35s, environment 0ms, prepare 528ms)
+role-model-router/apps/runtime-ui test:  ✓ app/routes/studio-audio.test.ts (2 tests) 7ms
+role-model-router/apps/runtime-ui test:  ✓ app/routes/control-benchmark.test.ts (1 test) 74ms
+role-model-router/apps/runtime-ui test:  Test Files  42 passed (42)
+role-model-router/apps/runtime-ui test:       Tests  480 passed (480)
+role-model-router/apps/runtime-ui test:    Start at  22:13:51
+role-model-router/apps/runtime-ui test:    Duration  16.05s (transform 43.20s, setup 0ms, collect 122.61s, tests 3.65s, environment 30ms, prepare 28.95s)
+.../packages/vendor-llama-swap test: Done
+role-model-router/apps/runtime-ui test: Done
+.../packages/vendor-litellm test:  ✓ test/index.test.ts (14 tests) 6193ms
+.../packages/vendor-litellm test:    ✓ vendor-litellm > starts a managed LiteLLM vendor and captures cost plus cache metadata from responses  1634ms
+.../packages/vendor-litellm test:    ✓ vendor-litellm > captures response cost from LiteLLM headers when the proxy strips hidden params  1237ms
+.../packages/vendor-litellm test:    ✓ vendor-litellm > captures cache status from LiteLLM headers when the proxy omits hidden cache markers  1148ms
+.../packages/vendor-litellm test:    ✓ vendor-litellm > forwards fallback model ids into the LiteLLM request body  987ms
+.../packages/vendor-litellm test:    ✓ vendor-litellm > streams chat-completions deltas through the managed LiteLLM vendor  792ms
+.../packages/vendor-litellm test:  Test Files  1 passed (1)
+.../packages/vendor-litellm test:       Tests  14 passed (14)
+.../packages/vendor-litellm test:    Start at  22:14:00
+.../packages/vendor-litellm test:    Duration  8.69s (transform 633ms, setup 0ms, collect 805ms, tests 6.19s, environment 0ms, prepare 595ms)
+.../packages/vendor-litellm test: Done
+role-model-router/packages/provider-mcp test$ vitest run
+role-model-router/packages/roles test$ vitest run
+role-model-router/packages/tasks test$ vitest run
+role-model-router/packages/sqlite-memory test$ vitest run test
+role-model-router/packages/provider-mcp test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/provider-mcp
+role-model-router/packages/roles test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/roles
+role-model-router/packages/tasks test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/tasks
+role-model-router/packages/sqlite-memory test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/sqlite-memory
+role-model-router/packages/provider-mcp test:  ✓ test/index.test.ts (1 test) 9ms
+role-model-router/packages/provider-mcp test:  Test Files  1 passed (1)
+role-model-router/packages/provider-mcp test:       Tests  1 passed (1)
+role-model-router/packages/provider-mcp test:    Start at  22:14:10
+role-model-router/packages/provider-mcp test:    Duration  2.60s (transform 488ms, setup 0ms, collect 541ms, tests 9ms, environment 0ms, prepare 791ms)
+role-model-router/packages/tasks test:  ✓ test/default-tasks-taxonomy.test.ts (1 test) 10ms
+role-model-router/packages/provider-mcp test: Done
+role-model-router/packages/tasks test:  Test Files  1 passed (1)
+role-model-router/packages/tasks test:       Tests  1 passed (1)
+role-model-router/packages/tasks test:    Start at  22:14:10
+role-model-router/packages/tasks test:    Duration  3.42s (transform 977ms, setup 0ms, collect 1.11s, tests 10ms, environment 1ms, prepare 598ms)
+role-model-router/packages/roles test:  ✓ test/default-roles-taxonomy.test.ts (1 test) 11ms
+role-model-router/packages/sqlite-memory test: (node:40164) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+role-model-router/packages/sqlite-memory test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/packages/sqlite-memory test: (node:56060) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+role-model-router/packages/sqlite-memory test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/packages/sqlite-memory test: (node:12504) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+role-model-router/packages/sqlite-memory test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/packages/sqlite-memory test: (node:33884) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+role-model-router/packages/sqlite-memory test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/packages/sqlite-memory test: (node:56124) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+role-model-router/packages/sqlite-memory test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/packages/sqlite-memory test: (node:57088) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+role-model-router/packages/sqlite-memory test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/packages/sqlite-memory test: (node:8472) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+role-model-router/packages/sqlite-memory test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/packages/roles test:  Test Files  1 passed (1)
+role-model-router/packages/roles test:       Tests  1 passed (1)
+role-model-router/packages/roles test:    Start at  22:14:10
+role-model-router/packages/roles test:    Duration  3.63s (transform 1.67s, setup 0ms, collect 1.77s, tests 11ms, environment 0ms, prepare 861ms)
+role-model-router/packages/tasks test: Done
+role-model-router/packages/roles test: Done
+role-model-router/packages/sqlite-memory test:  ✓ test/recursive-87-maintenance.test.ts (1 test) 283ms
+role-model-router/packages/sqlite-memory test:  ✓ test/recursive-87-atomic-observation.test.ts (2 tests) 440ms
+role-model-router/packages/sqlite-memory test:    ✓ Phase 3.5 graph-primary observation persistence rolls back every SQLite row after a late failure  427ms
+role-model-router/packages/sqlite-memory test:  ✓ test/effort-instance-identity.test.ts (3 tests) 483ms
+role-model-router/packages/sqlite-memory test:  ✓ test/recursive-87-history-policy.test.ts (4 tests) 1137ms
+role-model-router/packages/sqlite-memory test:    ✓ SP3 bounds raw performance history, bytes, rebuild work, late data, and restart state  560ms
+role-model-router/packages/sqlite-memory test:  ✓ test/legacy-migration.test.ts (6 tests) 3021ms
+role-model-router/packages/sqlite-memory test:    ✓ TB04 real SQLite legacy migration > audits legacy storage without mutating the database  2231ms
+role-model-router/packages/sqlite-memory test:  ✓ test/run90-telemetry-query-semantics.test.ts (5 tests) 6223ms
+role-model-router/packages/sqlite-memory test:    ✓ Run 90 aggregates are independent of the 50-row page and use a half-open window  937ms
+role-model-router/packages/sqlite-memory test:    ✓ Run 90 exact telemetry lookup reads by request identity without a bounded page scan  2146ms
+role-model-router/packages/sqlite-memory test:    ✓ Run 90 canonical corpus is exactly 257 in-window plus nine out-of-window rows  2359ms
+role-model-router/packages/sqlite-memory test:    ✓ Run 90 performance corpus keeps aggregate and lookup plans indexed  775ms
+role-model-router/packages/sqlite-memory test:  ✓ test/index.test.ts (47 tests) 10720ms
+role-model-router/packages/sqlite-memory test:    ✓ initializeSqliteMemory > persists runtime observation bundles, profile snapshots, and maintenance-policy reads  353ms
+role-model-router/packages/sqlite-memory test:    ✓ initializeSqliteMemory > externalizes and hydrates normal runtime observations across graph-primary cutover  478ms
+role-model-router/packages/sqlite-memory test:    ✓ persistObservedBenchmarkSample benchmark_mode > retries through a transient sqlite write lock when persisting benchmark samples  462ms
+role-model-router/packages/sqlite-memory test:    ✓ persistObservedBenchmarkSample benchmark_mode > retries through a transient sqlite write lock when persisting runtime observation bundles  1255ms
+role-model-router/packages/sqlite-memory test:    ✓ persistObservedBenchmarkSample benchmark_mode > waits through a transient sqlite lock when reading difficulty classification cache  418ms
+role-model-router/packages/sqlite-memory test:    ✓ persistObservedBenchmarkSample benchmark_mode > retries through a transient sqlite write lock when persisting difficulty classification cache  450ms
+role-model-router/packages/sqlite-memory test:    ✓ persistObservedBenchmarkSample benchmark_mode > waits through a transient sqlite lock when reading advisory max difficulty recommendations  434ms
+role-model-router/packages/sqlite-memory test:    ✓ persistObservedBenchmarkSample benchmark_mode > waits through a transient sqlite lock when listing runtime telemetry records  558ms
+role-model-router/packages/sqlite-memory test:    ✓ persistObservedBenchmarkSample benchmark_mode > waits through a transient sqlite lock when reading batched observation telemetry columns  575ms
+role-model-router/packages/sqlite-memory test:  Test Files  7 passed (7)
+role-model-router/packages/sqlite-memory test:       Tests  68 passed (68)
+role-model-router/packages/sqlite-memory test:    Start at  22:14:10
+role-model-router/packages/sqlite-memory test:    Duration  15.39s (transform 2.35s, setup 0ms, collect 5.94s, tests 22.31s, environment 3ms, prepare 5.88s)
+role-model-router/packages/sqlite-memory test: Done
+.../packages/context-envelope test$ vitest run test/index.test.ts
+role-model-router/apps/router-devtools test$ vitest run test/index.test.ts
+.../packages/context-envelope test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/context-envelope
+role-model-router/apps/router-devtools test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/apps/router-devtools
+role-model-router/apps/router-devtools test:  ✓ test/index.test.ts (1 test) 24ms
+.../packages/context-envelope test: (node:30300) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+.../packages/context-envelope test: (Use `node --trace-warnings ...` to show where the warning was created)
+role-model-router/apps/router-devtools test:  Test Files  1 passed (1)
+role-model-router/apps/router-devtools test:       Tests  1 passed (1)
+role-model-router/apps/router-devtools test:    Start at  22:14:27
+role-model-router/apps/router-devtools test:    Duration  1.72s (transform 265ms, setup 0ms, collect 222ms, tests 24ms, environment 0ms, prepare 516ms)
+.../packages/context-envelope test:  ✓ test/index.test.ts (1 test) 104ms
+.../packages/context-envelope test:  Test Files  1 passed (1)
+.../packages/context-envelope test:       Tests  1 passed (1)
+.../packages/context-envelope test:    Start at  22:14:27
+.../packages/context-envelope test:    Duration  2.05s (transform 433ms, setup 0ms, collect 504ms, tests 104ms, environment 0ms, prepare 476ms)
+role-model-router/apps/router-devtools test: Done
+.../packages/context-envelope test: Done
+.../packages/retrieval-receipt test$ vitest run test/index.test.ts
+.../packages/retrieval-receipt test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/retrieval-receipt
+.../packages/retrieval-receipt test:  ✓ test/index.test.ts (1 test) 5ms
+.../packages/retrieval-receipt test:  Test Files  1 passed (1)
+.../packages/retrieval-receipt test:       Tests  1 passed (1)
+.../packages/retrieval-receipt test:    Start at  22:14:30
+.../packages/retrieval-receipt test:    Duration  909ms (transform 114ms, setup 0ms, collect 109ms, tests 5ms, environment 0ms, prepare 305ms)
+.../packages/retrieval-receipt test: Done
+.../packages/endpoint-registry test$ vitest run test/index.test.ts
+.../packages/endpoint-registry test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/endpoint-registry
+.../packages/endpoint-registry test:  ✓ test/index.test.ts (1 test) 10ms
+.../packages/endpoint-registry test:  Test Files  1 passed (1)
+.../packages/endpoint-registry test:       Tests  1 passed (1)
+.../packages/endpoint-registry test:    Start at  22:14:33
+.../packages/endpoint-registry test:    Duration  1.05s (transform 164ms, setup 0ms, collect 173ms, tests 10ms, environment 0ms, prepare 365ms)
+.../packages/endpoint-registry test: Done
+.../packages/protocol-routing test$ vitest run test
+.../packages/protocol-routing test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/protocol-routing
+.../packages/protocol-routing test: (node:40652) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+.../packages/protocol-routing test: (Use `node --trace-warnings ...` to show where the warning was created)
+.../packages/protocol-routing test:  ✓ test/observed-data-decay-policy.test.ts (2 tests) 14ms
+.../packages/protocol-routing test:  ✓ test/catalog-economics-routing.test.ts (3 tests) 181ms
+.../packages/protocol-routing test:  ✓ test/index.test.ts (11 tests) 280ms
+.../packages/protocol-routing test:  Test Files  3 passed (3)
+.../packages/protocol-routing test:       Tests  16 passed (16)
+.../packages/protocol-routing test:    Start at  22:14:35
+.../packages/protocol-routing test:    Duration  1.76s (transform 884ms, setup 0ms, collect 1.73s, tests 476ms, environment 1ms, prepare 996ms)
+.../packages/protocol-routing test: Done
+packages/conformance test$ vitest run
+packages/conformance test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/packages/conformance
+packages/conformance test:  ✓ src/profile-aggregation-deterministic.test.ts (6 tests) 15ms
+packages/conformance test:  ✓ src/observability-linkage.test.ts (2 tests) 11ms
+packages/conformance test:  ✓ src/router-role-task-eligibility.test.ts (10 tests) 27ms
+packages/conformance test:  ✓ src/router-conformance.test.ts (17 tests) 65ms
+packages/conformance test:  ✓ src/run91-effort-schema.test.ts (1 test) 564ms
+packages/conformance test:    ✓ Run 91 effort-instance protocol fields > accepts endpoint, discovery, router, usage, and trace effort identity fields  560ms
+packages/conformance test: (node:50564) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+packages/conformance test: (Use `node --trace-warnings ...` to show where the warning was created)
+packages/conformance test:  ✓ src/router-fixture-conformance.test.ts (1 test) 526ms
+packages/conformance test:    ✓ router fixture conformance > validates golden routing cases from fixture inputs against the hardened router decision contract  523ms
+packages/conformance test:  ✓ src/protocol-schema-conformance.test.ts (9 tests) 916ms
+packages/conformance test:    ✓ run01 protocol schema conformance > endpoint identity permits run01 optional metadata fields to be absent  348ms
+packages/conformance test:  ✓ src/runtime-routing-conformance.test.ts (2 tests) 667ms
+packages/conformance test:    ✓ runtime routing conformance > emits a schema-valid decision for fixture-backed runtime routing validation  653ms
+packages/conformance test:  ✓ src/protocol-fixture-conformance.test.ts (2 tests) 4265ms
+packages/conformance test:    ✓ run01 protocol fixture conformance > schema-tools validate the expanded valid and invalid fixture manifest  605ms
+packages/conformance test:    ✓ run01 protocol fixture conformance > schemas:validate reports fixture validation as part of the canonical schema-tool path  3657ms
+packages/conformance test:  ✓ src/gateway-smoke-observability.test.ts (2 tests) 7412ms
+packages/conformance test:    ✓ gateway smoke observability conformance > emits trace and usage artifacts with run01 linkage ids and canonical trace shapes  4107ms
+packages/conformance test:    ✓ gateway smoke observability conformance > emits observed performance with the run01 sample window and sources shape  3303ms
+packages/conformance test:  Test Files  10 passed (10)
+packages/conformance test:       Tests  52 passed (52)
+packages/conformance test:    Start at  22:14:38
+packages/conformance test:    Duration  8.69s (transform 1.59s, setup 0ms, collect 4.62s, tests 14.47s, environment 4ms, prepare 4.17s)
+packages/conformance test: Done
+.../packages/adapter-execution test$ vitest run
+.../packages/provider-anthropic test$ vitest run test/index.test.ts
+.../packages/provider-anthropic test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/provider-anthropic
+.../packages/adapter-execution test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/adapter-execution
+.../packages/provider-anthropic test:  ✓ test/index.test.ts (4 tests) 20ms
+.../packages/provider-anthropic test:  Test Files  1 passed (1)
+.../packages/provider-anthropic test:       Tests  4 passed (4)
+.../packages/provider-anthropic test:    Start at  22:14:48
+.../packages/provider-anthropic test:    Duration  1.88s (transform 425ms, setup 0ms, collect 312ms, tests 20ms, environment 0ms, prepare 787ms)
+.../packages/adapter-execution test:  ✓ test/index.test.ts (5 tests) 21ms
+.../packages/provider-anthropic test: Done
+.../packages/adapter-execution test: (node:57440) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+.../packages/adapter-execution test: (Use `node --trace-warnings ...` to show where the warning was created)
+.../packages/adapter-execution test:  ✓ test/cli.test.ts (1 test) 214ms
+.../packages/adapter-execution test:  Test Files  2 passed (2)
+.../packages/adapter-execution test:       Tests  6 passed (6)
+.../packages/adapter-execution test:    Start at  22:14:48
+.../packages/adapter-execution test:    Duration  3.09s (transform 1.05s, setup 0ms, collect 1.39s, tests 235ms, environment 1ms, prepare 1.28s)
+.../packages/adapter-execution test: Done
+.../packages/provider-openai test$ vitest run test/index.test.ts
+.../packages/runtime-observability test$ vitest run
+.../packages/provider-openai test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/provider-openai
+.../packages/runtime-observability test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/runtime-observability
+.../packages/provider-openai test:  ✓ test/index.test.ts (33 tests) 31ms
+.../packages/provider-openai test:  Test Files  1 passed (1)
+.../packages/provider-openai test:       Tests  33 passed (33)
+.../packages/provider-openai test:    Start at  22:14:53
+.../packages/provider-openai test:    Duration  1.69s (transform 553ms, setup 0ms, collect 544ms, tests 31ms, environment 0ms, prepare 543ms)
+.../packages/provider-openai test: Done
+.../packages/runtime-observability test: (node:56356) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+.../packages/runtime-observability test: (Use `node --trace-warnings ...` to show where the warning was created)
+.../packages/runtime-observability test: (node:39260) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+.../packages/runtime-observability test: (Use `node --trace-warnings ...` to show where the warning was created)
+.../packages/runtime-observability test: (node:18420) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+.../packages/runtime-observability test: (Use `node --trace-warnings ...` to show where the warning was created)
+.../packages/runtime-observability test:  ✓ test/run91-effort-otel.test.ts (2 tests) 379ms
+.../packages/runtime-observability test:    ✓ Run 91 runtime effort receipts > persists exact effort fields on the observation and maps them to OTel  375ms
+.../packages/runtime-observability test:  ✓ test/otel.test.ts (1 test) 387ms
+.../packages/runtime-observability test:    ✓ runtime-observability otel mapping > derives a deterministic OpenTelemetry export from canonical role-model artifacts  385ms
+.../packages/runtime-observability test:  ✓ test/index.test.ts (6 tests) 1067ms
+.../packages/runtime-observability test:    ✓ runtime-observability > creates a redacted runtime observation bundle with diagnostics and profile updates  405ms
+.../packages/runtime-observability test:  Test Files  3 passed (3)
+.../packages/runtime-observability test:       Tests  9 passed (9)
+.../packages/runtime-observability test:    Start at  22:14:53
+.../packages/runtime-observability test:    Duration  3.42s (transform 868ms, setup 0ms, collect 2.45s, tests 1.83s, environment 1ms, prepare 1.23s)
+.../packages/runtime-observability test: Done
+.../packages/provider-litellm test$ vitest run test/index.test.ts
+.../packages/provider-litellm test:  RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/packages/provider-litellm
+.../packages/provider-litellm test:  ✓ test/index.test.ts (3 tests) 12ms
+.../packages/provider-litellm test:  Test Files  1 passed (1)
+.../packages/provider-litellm test:       Tests  3 passed (3)
+.../packages/provider-litellm test:    Start at  22:14:57
+.../packages/provider-litellm test:    Duration  1.17s (transform 266ms, setup 0ms, collect 283ms, tests 12ms, environment 0ms, prepare 405ms)
+.../packages/provider-litellm test: Done
+
+> @role-model-router/runtime-host-bridge@0.0.0 test D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\role-model-router\apps\runtime-host-bridge
+> vitest run
+
+
+ RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/apps/runtime-host-bridge
+
+(node:9008) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:59884) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:40996) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:34604) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:42608) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:41280) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:34840) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/unified-runtime-config.test.ts (27 tests) 152ms
+(node:48624) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:4088) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:49960) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:31032) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:49396) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:10912) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/executable.test.ts (23 tests) 324ms
+ ✓ test/benchmark-summary.test.ts (15 tests) 319ms
+(node:48600) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:33640) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:25084) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/run88-stage-release.unit.test.ts (19 tests) 202ms
+ ✓ test/benchmark-runner-judge.test.ts (16 tests) 2648ms
+   ✓ benchmark-runner judge remediation > persists cross-model compare artifacts for multi-endpoint runs  901ms
+   ✓ benchmark-runner judge remediation > compare rankings stay diagnostic and do not rewrite endpoint scores  519ms
+ ✓ src/local-model-role-bindings.test.ts (12 tests) 75ms
+(node:52360) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ↓ test/packaged-standalone-restart.test.ts (1 test | 1 skipped)
+ ✓ test/execution-circuit-breaker.test.ts (12 tests) 115ms
+(node:45684) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:51652) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/run91-effort-instance-identity.test.ts (13 tests) 89ms
+ ✓ src/remote-health-probe.test.ts (12 tests) 43ms
+(node:57256) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/recursive-87-shadow-pipeline.test.ts (10 tests) 9109ms
+   ✓ SP1 runs the useful routing-learning DAG through supervised shadow capabilities  2340ms
+   ✓ Phase 3.5 normal request completion dispatches the persisted observation to Track B  6553ms
+ ✓ test/controller-routing-contract.test.ts (8 tests) 68ms
+(node:24040) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/track-b-runtime-composition.test.ts (14 tests) 23747ms
+   ✓ production Track B composition > verifies and supervises the packaged sidecar process over a readiness protocol  357ms
+   ✓ production Track B composition > passes cloud contribution trust and aggregate destination into the launcher-owned sidecar  386ms
+   ✓ production Track B composition > runs all thirteen canonical extensions through the real process host and supervisor  5417ms
+   ✓ production Track B composition > gives production extension workers a bounded startup budget that tolerates host contention  16982ms
+   ✓ production Track B composition > stages the integrity-verified private runtime beside the packaged launcher  435ms
+ ✓ test/downstream-openai-discovery.test.ts (4 tests) 91ms
+(node:19048) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/recursive-87-registry-lifecycle.test.ts (6 tests) 16438ms
+   ✓ recursive run 87 SP0 registry and lifecycle authority > a synthetic future extension uses the same generic runtime path as the fixed release set  4587ms
+   ✓ recursive run 87 SP0 registry and lifecycle authority > the production constructor keeps thirteen release extensions while admitting an explicit QA extension  4468ms
+   ✓ recursive run 87 SP0 registry and lifecycle authority > durable lifecycle mutations change observed worker state and are idempotent  5664ms
+   ✓ recursive run 87 SP0 registry and lifecycle authority > Phase 3.5 journal replay preserves stopped state and never resurrects removed extensions  1045ms
+   ✓ recursive run 87 SP0 registry and lifecycle authority > Phase 3.5 failed durable mutation is compensated before returning an error  632ms
+ ✓ test/taxonomy-discovery.test.ts (3 tests) 397ms
+   ✓ taxonomy discovery API > exposes the proposal taxonomy discovery route family  319ms
+(node:50948) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/alias-capability-routing.test.ts (8 tests) 81ms
+(node:51840) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/craft-ask-difficulty.test.ts (4 tests) 60ms
+ ✓ test/remote-health-bootstrap.test.ts (5 tests) 27830ms
+   ✓ remote health bootstrap > does not fail open when a Codex Subscription endpoint has no Responses admission probe  7848ms
+   ✓ remote health bootstrap > admits a remote effort instance only after its exact readiness request succeeds  4515ms
+   ✓ remote health bootstrap > keeps a 503 effort instance degraded and ineligible at admission  5953ms
+   ✓ remote health bootstrap > serializes concurrent add requests for one exact effort instance into one readiness probe  4826ms
+   ✓ remote health bootstrap > skips remote-health probes in decision_only mode  4679ms
+(node:1524) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ↓ test/kw-prompt-inject-map-surface.test.ts (1 test | 1 skipped)
+ ✓ src/operator-intent.test.ts (8 tests) 180ms
+ ✓ test/model-capability-resolver.test.ts (5 tests) 55ms
+ ✓ src/routable-inventory.test.ts (6 tests) 59ms
+ ✓ test/benchmark-artifacts.test.ts (4 tests) 83ms
+(node:13064) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/runtime-assets.test.ts (5 tests) 72ms
+ ✓ test/run91-recommendation-effort.test.ts (2 tests) 131ms
+ ✓ test/litellm-catalog.test.ts (7 tests) 95ms
+(node:53232) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/candidate-profile-scaling.test.ts (5 tests) 853ms
+   ✓ projects immutable decision-time live telemetry evidence  780ms
+(node:34532) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/runtime-endpoint-lifecycle.test.ts (10 tests) 16ms
+ ✓ test/routable-inventory-bootstrap.test.ts (3 tests) 4704ms
+   ✓ routable inventory bootstrap > exposes inventory summary and inventory bootstrap stage after startup  4641ms
+(node:15960) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/recursive-87-compatibility.test.ts (4 tests) 182ms
+(node:37516) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/configured-model-membership.test.ts (4 tests) 47ms
+ ✓ test/runtime-version.test.ts (4 tests) 39ms
+ ✓ test/run90-telemetry-query-semantics.test.ts (5 tests) 34795ms
+   ✓ Run 90 host aggregates ignore the activity page limit  5863ms
+   ✓ Run 90 request pages carry a filter-bound snapshot cursor and total  4905ms
+   ✓ Run 90 canonical host view reconciles 257 totals with a 50-row page  11204ms
+   ✓ Run 90 router decisions expose a full total beside the bounded page  12795ms
+(node:38744) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/benchmark-runner-compare.test.ts (1 test) 308ms
+   ✓ benchmark-runner compare remediation > writes fallback compare artifact when judge compare parse fails  305ms
+ ✓ test/benchmark-data-clear.test.ts (3 tests) 6243ms
+   ✓ benchmark global data clear > DELETE /api/role-model/benchmark/data clears sqlite samples and artifact runs  6082ms
+ ✓ test/run91-wave-b-gaps.test.ts (3 tests) 48ms
+(node:57516) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/remove-account-model.test.ts (4 tests) 42369ms
+   ✓ removeProviderAccountModel > removes the selected model and stale endpoint rows while preserving sibling models  6188ms
+   ✓ removeProviderAccountModel > deletes the backing account when its last configured model is removed  4596ms
+   ✓ removeProviderAccountModel > reassigns the controller to a surviving manual-account model during eject  15114ms
+   ✓ removeProviderAccountModel > clears the controller when eject removes the last surviving controller-backed manual-account model  16468ms
+(node:54232) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/account-repair.test.ts (7 tests) 43259ms
+   ✓ account repair mutations > starting Kimi Code authorization for k3 preserves existing allowed models and active endpoints  6575ms
+   ✓ account repair mutations > reconnect returns the current pending device-authorization session for the same account  4215ms
+   ✓ account repair mutations > reconnect starts a fresh Codex Subscription device-code session instead of reusing a stale pending one  4191ms
+   ✓ account repair mutations > starting Codex Subscription authorization again supersedes the older pending session  4554ms
+   ✓ account repair mutations > update API key preserves account identity, bindings, and endpoint associations  8904ms
+   ✓ account repair mutations > rejects overlapping repair mutations for the same account without partially mutating state  5677ms
+   ✓ account repair mutations > codex subscription start returns a real device-code session and poll connects through managed Codex auth  9128ms
+ ✓ test/session-readiness-api.test.ts (1 test) 4903ms
+   ✓ session readiness API > exposes bootstrap, inventory, and readiness fields over HTTP  4897ms
+ ✓ test/recursive-87-graph-primary.test.ts (1 test) 411ms
+   ✓ SP2 host observation persistence delegates rich bytes to graph storage after cutover  408ms
+ ✓ test/benchmark-start-guards.test.ts (9 tests) 17ms
+ ✓ test/cli-startup-readiness.test.ts (3 tests) 358ms
+   ✓ cli startup readiness > binds health and static UI before backend initialization completes  326ms
+ ✓ test/benchmark-candidates-routing-quality.test.ts (2 tests) 13ms
+ ✓ test/health-policy.test.ts (10 tests) 13ms
+ ✓ src/session-bootstrap.test.ts (4 tests) 18ms
+(node:8880) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/observed-data-decay-policy.test.ts (5 tests) 94ms
+ ✓ test/runtime-state-migration.test.ts (2 tests) 194ms
+ ✓ test/kw-prompt-inject-host.test.ts (4 tests) 28ms
+(node:52048) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:35632) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/remote-endpoint-admission-probe.test.ts (2 tests) 22ms
+ ✓ test/runtime-routing-model.test.ts (4 tests) 12ms
+(node:54896) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/system-open-url.test.ts (2 tests) 188ms
+ ✓ test/request-capability-inference.test.ts (2 tests) 48ms
+ ✓ src/oauth-credential.test.ts (2 tests) 133ms
+ ✓ test/runtime-channel-options.test.ts (2 tests) 45ms
+ ✓ src/benchmark-reasoning.test.ts (6 tests) 12ms
+ ✓ test/kw-prompt-inject.test.ts (3 tests) 16ms
+ ✓ src/open-external-url.test.ts (4 tests) 13ms
+(node:56296) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:33056) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:59996) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/benchmark-validation-metrics.test.ts (2 tests) 9ms
+(node:58428) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/recursive-87-projection-consumers.test.ts (1 test) 19ms
+ ✓ test/validate-operations.test.ts (1 test) 2442ms
+   ✓ runRuntimeOperationsValidation > validates isolated scopes and runtime-state maintenance drills  2408ms
+ ✓ test/benchmark-progress.test.ts (2 tests) 9ms
+(node:32476) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/recursive-87-bounded-history.test.ts (1 test) 214ms
+ ✓ test/runtime-channel.test.ts (5 tests) 13ms
+(node:54328) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/session-bootstrap-health.test.ts (1 test) 5266ms
+   ✓ session bootstrap health > exposes bootstrap receipts on /healthz summary after async startup  5262ms
+ ✓ test/benchmark-judge-runtime.test.ts (3 tests) 13ms
+ ✓ test/operator-intent-corrupt-bootstrap.test.ts (1 test) 5393ms
+   ✓ operator intent corrupt manifest > surfaces corrupt operator-intent diagnostics and blocks bootstrap  5389ms
+(node:41032) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/credential-ref-env.test.ts (6 tests) 11ms
+(node:53304) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:56492) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/recursive-87-retention-inventory.test.ts (1 test) 11ms
+ ✓ test/run88-stage-release.integration.test.ts (24 tests) 889ms
+(node:38200) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:46548) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/run88-stage-release.regression.test.ts (9 tests) 187ms
+ ✓ test/validate-tools.test.ts (1 test) 5430ms
+   ✓ runRuntimeToolsValidation > executes runtime-owned MCP tool calls and persists their observation receipts  5427ms
+ ↓ test/kw-private-loader.test.ts (2 tests | 2 skipped)
+ ✓ test/local-policy.test.ts (14 tests) 61517ms
+   ✓ local policy persistence > readLocalPolicy returns defaults when file does not exist  5718ms
+   ✓ local policy persistence > updateLocalPolicy writes merged policy to file  3850ms
+   ✓ local policy persistence > readLocalPolicy reads persisted file  3910ms
+   ✓ local policy persistence > updateLocalPolicy merges with existing policy  3450ms
+   ✓ local swap history > listSwapHistory returns empty array when no events  4010ms
+   ✓ local swap history > listSwapHistory returns events in descending order  3515ms
+   ✓ model overrides > readModelOverrides returns empty object when file does not exist  3953ms
+   ✓ model overrides > updateModelOverrides writes to file  4616ms
+   ✓ model overrides > readModelOverrides reads persisted file  4007ms
+   ✓ peer configuration > readPeers returns empty array when file does not exist  4258ms
+   ✓ peer configuration > updatePeers writes to file  4243ms
+   ✓ peer configuration > readPeers reads persisted file  4263ms
+   ✓ peer configuration > updatePeers replays persisted peer auto-reload entries when peers become available  7119ms
+   ✓ peer configuration > checkPeerHealth returns false for unreachable url  4592ms
+ ✓ test/catalog-economics-providers.test.ts (2 tests) 15132ms
+   ✓ catalog economics provider surfaces > hides moonshotai from listProviders while keeping operator moonshot  7842ms
+   ✓ catalog economics provider surfaces > lists Moonshot Kimi coding models on moonshot and kimi-code variants  7286ms
+(node:34448) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:51088) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/benchmark-endpoint-health.test.ts (6 tests) 9ms
+ ✓ test/recursive-87-ci-contract.test.ts (1 test) 7ms
+ ✓ test/validate-ui-cleanup.test.ts (2 tests) 14ms
+(node:51652) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/track-b-operations-api.test.ts (20 tests) 67146ms
+   ✓ Track B operations APIs > fails closed instead of issuing unauthenticated calls to an owned operations endpoint  5457ms
+   ✓ Track B operations APIs > serves extension lifecycle and storage retention through bounded callbacks  4747ms
+   ✓ Track B operations APIs > fails closed when an operations capability is not wired  4210ms
+   ✓ Track B operations APIs > production backend never infers extension health from the catalog  4606ms
+   ✓ Track B operations APIs > local Track B bridge seed marks catalog extensions ready without ExtensionHost override  4802ms
+   ✓ Track B operations APIs > production backend reports readiness only from the supervised ExtensionHost  4609ms
+   ✓ Track B operations APIs > production backend clean start uses the canonical Advanced aggregate defaults  5418ms
+   ✓ Track B operations APIs > production request completion reports only aggregate metrics to the private operations boundary  5732ms
+   ✓ Track B operations APIs > production Responses requests report aggregate metrics through the same private operations boundary  6609ms
+   ✓ Track B operations APIs > production backend reads and atomically updates real bridge storage state  6344ms
+   ✓ Track B operations APIs > RUN88-I-PUB-R8-AC04 stage recommendation downloads propagate candidate correlation  5118ms
+   ✓ Track B operations APIs > RUN88-R-PUB-R8-AC04 stage recommendation downloads fail closed without candidate identity  5132ms
+   ✓ Track B operations APIs > run79 HTTP exposes extensions mutate and recommendations dismiss routes  3955ms
+ ✓ test/validate-catalog-economics.test.ts (1 test) 13673ms
+   ✓ runCatalogEconomicsValidation > hides moonshotai, routes easy cost work to local peer, and emits catalogEconomics  13669ms
+ ✓ test/endpoint-rehydration.test.ts (6 tests) 74124ms
+   ✓ endpoint rehydration > commits a multi-effort activation as one durable batch and rehydrates every identity  11659ms
+   ✓ endpoint rehydration > rehydrates explicit reasoning effort into the authoritative registry identity  12861ms
+   ✓ endpoint rehydration > migrates legacy opaque effort endpoints and their role ownership to readable identities  12900ms
+   ✓ endpoint rehydration > rehydrates sqlite runtime endpoints across backend restart without re-activation  11242ms
+   ✓ endpoint rehydration > reconciles missing persisted remote activations even when sqlite already has endpoint rows  10055ms
+   ✓ endpoint rehydration > marks restarted remote endpoints offline and ineligible when startup probes time out  15393ms
+ ✓ test/validate-restart-rehydration.test.ts (1 test) 16005ms
+   ✓ runRestartRehydrationValidation > rehydrates activated endpoints and mixed alias model list after backend restart  16001ms
+ ✓ test/validate-observability.test.ts (1 test) 17158ms
+   ✓ runRuntimeObservabilityValidation > proves structured request, capture, metrics, and otel observability over the real host path  17155ms
+ ✓ test/validate-ui.test.ts (1 test) 36016ms
+   ✓ runRuntimeUiValidation > validates runtime config reads and the main control-plane mutations  36013ms
+ ✓ test/openai-codex-subscription-matrix.test.ts (9 tests) 90845ms
+   ✓ OpenAI Codex Subscription model matrix > listProviders exposes the full Codex Subscription 5.3+ matrix for OpenAI  7193ms
+   ✓ OpenAI Codex Subscription model matrix > provider catalog exposes exact GPT-5.6 subscription rows with native reasoning levels  5287ms
+   ✓ OpenAI Codex Subscription model matrix > rejects pre-5.3 Codex Subscription model ids during device authorization setup  4361ms
+   ✓ OpenAI Codex Subscription model matrix > accepts hosted web search and function-tool request surfaces for every supported OpenAI model id  51585ms
+   ✓ OpenAI Codex Subscription model matrix > keeps every supported OpenAI GPT-5.3+ subscription model coder.patch routable  22260ms
+ ✓ test/restart-rehydration.test.ts (15 tests) 110075ms
+   ✓ restart rehydration > restores activated endpoints and session readiness summary after backend restart  9608ms
+   ✓ restart rehydration > keeps restarted remote endpoints healthy when provider /models returns unprefixed ids  16559ms
+   ✓ restart rehydration > does not count expired pending device authorization as an active readiness blocker after restart  10527ms
+   ✓ restart rehydration > archives orphan pending authorizations and orphan credential files instead of counting them as active readiness  9868ms
+   ✓ restart rehydration > archives invalid persisted provider accounts instead of surfacing them as active lifecycle records  10529ms
+   ✓ restart rehydration > surfaces failed pending authorization polling in bootstrap stage details after restart  8744ms
+   ✓ restart rehydration > classifies failed startup OAuth refresh as expired auth after restart  8330ms
+   ✓ restart rehydration > repairs stale bridge Kimi OAuth credentials from fresher standalone runtime tokens on restart  6157ms
+   ✓ restart rehydration > repairs stale standalone Kimi OAuth credentials from fresher bridge tokens on restart and restores endpoint eligibility  5219ms
+   ✓ restart rehydration > sanitizes stale activation and endpoint evidence without expanding configured membership  4986ms
+   ✓ restart rehydration > refreshes Kimi OAuth after restart by honoring the stored token device id  4263ms
+   ✓ restart rehydration > polls the earliest-expiring pending authorizations first and surfaces deferred count  4404ms
+   ✓ restart rehydration > cleans up a pending Codex Subscription device-code session after restart  3959ms
+   ✓ restart rehydration > normalizes legacy local peer role bindings during restart rehydration  4568ms
+   ✓ restart rehydration > defers persisted peer auto-reload entries during restart bootstrap when peers are not configured  2338ms
+ ✓ test/provider-overlap-metadata.test.ts (50 tests) 128401ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for baseten  7514ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for cerebras  8231ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for cohere  7108ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for crusoe  8010ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for databricks  7277ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for deepinfra  7804ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for deepseek  7350ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for groq  6082ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for minimax  4864ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for mistral  4262ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for morph  4136ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for nebius  3568ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for openrouter  3418ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for ovhcloud  3604ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for perplexity  4066ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for sarvam  3815ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for v0  3719ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for wandb  2567ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for watsonx  2557ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for xai  2843ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for zai  2866ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes one OpenAI provider with API Key and Codex Subscription variants  2471ms
+   ✓ listProviders overlap metadata (R1 integration) > every remote connection method resolves its allowed models through the same effort-aware catalog  14746ms
+ ✓ test/backend-unified-runtime-config.test.ts (29 tests) 177973ms
+   ✓ runtime-host-bridge unified runtime backend > preserves the exact LiteLLM provider account on config-owned endpoint readback  9395ms
+   ✓ runtime-host-bridge unified runtime backend > ejects config-owned membership durably across config reapply and restart  22740ms
+   ✓ runtime-host-bridge unified runtime backend > reassigns the controller when config-owned eject removes the active controller model  18491ms
+   ✓ runtime-host-bridge unified runtime backend > clears the controller when config-owned eject removes the last controller-backed model  13268ms
+   ✓ runtime-host-bridge unified runtime backend > router candidates expose every configured endpoint and mark current execution-mode eligibility  9734ms
+   ✓ runtime-host-bridge unified runtime backend > rejects benchmark runs that target endpoints excluded by execution mode  6249ms
+   ✓ runtime-host-bridge unified runtime backend > surfaces the derived execution mode in the runtime summary when a unified config file is provided  3407ms
+   ✓ runtime-host-bridge unified runtime backend > reads and updates unified runtime config through the backend  4595ms
+   ✓ runtime-host-bridge unified runtime backend > merges partial runtime config updates without dropping existing routing strategy  4192ms
+   ✓ runtime-host-bridge unified runtime backend > canonicalizes the primary routing alias to the live routing matrix on startup  3131ms
+   ✓ runtime-host-bridge unified runtime backend > creates and updates unified runtime config when the configured path does not exist yet  2620ms
+   ✓ runtime-host-bridge unified runtime backend > persists explicit hybrid execution mode from routing strategy updates  3921ms
+   ✓ runtime-host-bridge unified runtime backend > bootstraps the primary routing alias when routing posture is saved without preconfigured aliases  4102ms
+   ✓ runtime-host-bridge unified runtime backend > bootstraps a settings-specific primary routing alias for remote-only posture without preconfigured aliases  4508ms
+   ✓ runtime-host-bridge unified runtime backend > maintains the routing alias matrix across strategy families and execution modes  22825ms
+   ✓ runtime-host-bridge unified runtime backend > persists the full canonical routing alias matrix instead of a single primary alias  2835ms
+   ✓ runtime-host-bridge unified runtime backend > normalizes legacy craft-ask routing strategy updates to the default alias family  4720ms
+   ✓ runtime-host-bridge unified runtime backend > rewrites persisted craft-ask alias ids out of startup config materialization  2207ms
+   ✓ runtime-host-bridge unified runtime backend > rewrites legacy craft-ask matrix rows from persisted config even when the canonical matrix already exists  2137ms
+   ✓ runtime-host-bridge unified runtime backend > rewrites legacy craft-ask matrix rows from persisted config even when startup does not need to re-materialize aliases  2097ms
+   ✓ runtime-host-bridge unified runtime backend > renames the primary routing alias when routing strategy and execution mode change  3147ms
+   ✓ runtime-host-bridge unified runtime backend > does not mark all candidates ignored when routing guidance has no preferred endpoints  1674ms
+   ✓ runtime-host-bridge unified runtime backend > preserves synthesized activated endpoint models across runtime config updates  4298ms
+   ✓ runtime-host-bridge unified runtime backend > returns no controller assignment when the unified config has no endpoints yet  2085ms
+   ✓ runtime-host-bridge unified runtime backend > surfaces normalized provider docs and npm metadata through listProviders  2229ms
+   ✓ runtime-host-bridge unified runtime backend > uses YAML membership authority while preserving manual metadata on reserved-id collision  4566ms
+   ✓ runtime-host-bridge unified runtime backend > migrates a legacy standalone runtime config into the canonical state path on startup  2040ms
+   ✓ runtime-host-bridge unified runtime backend > repairs stale standalone canonical remote aliases after restart bootstrap rehydrates env-backed persisted endpoints  7830ms
+   ✓ runtime-host-bridge unified runtime backend > surfaces LiteLLM-backed Moonshot models and endpoints from unified runtime config  2926ms
+ ✓ test/index.test.ts (208 tests) 238636ms
+   ✓ runtime-host-bridge > seeds deterministic QA telemetry for chart geometry and token-truth browser checks  3486ms
+   ✓ runtime-host-bridge > suppresses placeholder provider accounts when using the packaged CLI defaults  4023ms
+   ✓ runtime-host-bridge > purges stale runtime-config LiteLLM endpoints when startup has no runtime config  3836ms
+   ✓ runtime-host-bridge > loads placeholder accounts only when fixture-root is explicitly provided  4760ms
+   ✓ runtime-host-bridge > tracks cache continuity per session across A -> B -> A and records create versus restore state  569ms
+   ✓ runtime-host-bridge > creates a runtime backend that executes chat-completions through the real routing and adapter path  4511ms
+   ✓ runtime-host-bridge > creates a runtime backend that persists structured request and endpoint inspection state  6176ms
+   ✓ runtime-host-bridge > persists routing-mode override and rewrite-skipped diagnostics for exact-model runtime-backed chat requests  6211ms
+   ✓ runtime-host-bridge > persists applied role policy diagnostics and injected system instructions for runtime-backed chat requests  6392ms
+   ✓ runtime-host-bridge > does not seed placeholder Anthropic/OpenAI accounts, endpoints, models, or router guidance in the default runtime bootstrap  5337ms
+   ✓ runtime-host-bridge > upsertProviderAccount updates one endpoint role assignment without replacing effort siblings  5419ms
+   ✓ runtime-host-bridge > persists alias-resolution diagnostics for runtime-backed chat requests  8015ms
+   ✓ runtime-host-bridge > executes every canonical remote alias through the runtime-backed chat path  28469ms
+   ✓ runtime-host-bridge > persists difficulty-routing diagnostics for runtime-backed chat requests  3740ms
+   ✓ runtime-host-bridge > allows an observed max-difficulty override when bucketed performance supports a harder request  3345ms
+   ✓ runtime-host-bridge > routes hard requests using bucketed live operational profiles and records the selected difficulty bucket  3480ms
+   ✓ runtime-host-bridge > keeps fresh endpoint-wide metrics when unrevisioned hard-bucket benchmark evidence is quarantined  3550ms
+   ✓ runtime-host-bridge > uses the configured remote classifier result for difficulty-mode runtime-backed chat requests  3805ms
+   ✓ runtime-host-bridge > uses the configured remote controller result for intelligent runtime-backed chat requests  3605ms
+   ✓ runtime-host-bridge > uses the default controller timeout budget for realistic remote controller latency  6986ms
+   ✓ runtime-host-bridge > records sanitized controller guidance through the live HTTP bridge for intelligent aliases  3699ms
+   ✓ runtime-host-bridge > preserves accepted controller directives for known compatibility strategy aliases  2965ms
+   ✓ runtime-host-bridge > gives controller routing enough output budget to avoid empty truncated guidance  2990ms
+   ✓ runtime-host-bridge > retries controller routing once with a compact prompt when the first controller response is empty  3306ms
+   ✓ runtime-host-bridge > falls back to heuristic controller guidance when the live controller returns prose instead of JSON  3002ms
+   ✓ runtime-host-bridge > serves coherent live role and task policy over the HTTP control plane  1560ms
+   ✓ runtime-host-bridge > rehydrates persisted controller assignment for controller aliases after restart even without a controller block in runtime config  6240ms
+   ✓ runtime-host-bridge > persists alias-default hybrid arbitration and rewrite-applied diagnostics for runtime-backed chat requests  2496ms
+   ✓ runtime-host-bridge > falls back deterministically when the configured classifier times out  2494ms
+   ✓ runtime-host-bridge > reuses cached difficulty classification for repeated requests in the same conversation when invalidation thresholds are not exceeded  2978ms
+   ✓ runtime-host-bridge > reports cache invalidation reasons before reclassifying a repeated request  2906ms
+   ✓ runtime-host-bridge > creates a runtime backend that exposes provider presets, runtime summary, and account upserts  2293ms
+   ✓ runtime-host-bridge > persists runtime-managed role policy and task allowlists across backend restart  3027ms
+   ✓ runtime-host-bridge > executes env-backed api-key accounts through the live provider path when the env credential resolves  1749ms
+   ✓ runtime-host-bridge > retries transient API timeouts once and falls back to a secondary endpoint after quota exhaustion  2033ms
+   ✓ runtime-host-bridge > persists routed provider execution failures with selected endpoint inspection context  1995ms
+   ✓ runtime-host-bridge > preserves the original Codex timeout when exact-model fallback exhausts all eligible endpoints  2816ms
+   ✓ runtime-host-bridge > executes direct exact-model chat requests through the Codex subscription endpoint  2759ms
+   ✓ runtime-host-bridge > Codex Subscription request detail preserves Responses-ingress parameter policy  2805ms
+   ✓ runtime-host-bridge > exact Codex execution repairs stale bridge auth from standalone runtime and clears auth cooldowns  2502ms
+   ✓ runtime-host-bridge > suppresses already-executed Codex dynamic tool calls from the final chat response and de-duplicates executions  2494ms
+   ✓ runtime-host-bridge > does not place Codex subscription endpoints on cooldown for invalid_request failures  2415ms
+   ✓ runtime-host-bridge > keeps Kimi Code and DeepSeek coding endpoints coder-eligible from the tracked catalog  1926ms
+   ✓ runtime-host-bridge > registers configured local OpenAI-compatible peers as execution-ready model endpoints  2251ms
+   ✓ runtime-host-bridge > executes non-controller requested coder review task requests without empty chosen-endpoint failures  1592ms
+   ✓ runtime-host-bridge > exposes llama-swap ownership and config metadata on local model and endpoint readback  2720ms
+   ✓ runtime-host-bridge > rejects local model activation when no configured local endpoint exposes the requested model  1626ms
+   ✓ runtime-host-bridge > rehydrates connected OAuth accounts from stored token files on backend restart  3008ms
+   ✓ runtime-host-bridge > restores pending OAuth device-authorizations from SQLite after backend restart  3015ms
+   ✓ runtime-host-bridge > executes chat-completions through an activated Kimi Code endpoint  1780ms
+   ✓ runtime-host-bridge > executes exact Kimi hosted web-search requests through to a final assistant answer  1689ms
+   ✓ runtime-host-bridge > surfaces exact deepseek/deepseek-v4-flash web-search requests as consumer-managed tool calls  1687ms
+   ✓ runtime-host-bridge > surfaces exact deepseek/deepseek-v4-pro web-search requests as consumer-managed tool calls  1709ms
+   ✓ runtime-host-bridge > normalizes DeepSeek DSML web_search markup into consumer-visible tool calls  1589ms
+   ✓ runtime-host-bridge > normalizes DeepSeek DSML web_open markup into consumer-visible tool calls  1734ms
+   ✓ runtime-host-bridge > normalizes DeepSeek DSML web_browse markup into consumer-visible tool calls  1606ms
+   ✓ runtime-host-bridge > creates a runtime backend that executes responses through the real routing and adapter path  1403ms
+   ✓ runtime-host-bridge > persists applied role policy diagnostics and injected policy messages for runtime-backed responses requests  1513ms
+   ✓ runtime-host-bridge > serves structured request and endpoint inspection routes through the bridge server  1637ms
+   ✓ runtime-host-bridge > aggregates generic telemetry analytics from persisted request-time routing and cost facts  1566ms
+   ✓ runtime-host-bridge > aggregates telemetry analytics over the full requested slice with contract metadata and aligned ledger filters  1921ms
+   ✓ runtime-host-bridge > projects canonical model, endpoint, effort, and effort-source telemetry identities  1415ms
+   ✓ runtime-host-bridge > startup retention cleanup removes expired raw observations while preserving telemetry ledger evidence  1592ms
+   ✓ runtime-host-bridge > keeps duplicate caller request ids as separate canonical telemetry rows  1760ms
+   ✓ runtime-host-bridge > records caller correlation and live request classification for failed chat completions  1494ms
+   ✓ runtime-host-bridge > reads bucketed endpoint profiles with an advisory max-difficulty recommendation  1599ms
+   ✓ runtime-host-bridge > streams canonical telemetry updates over SSE after new requests are persisted  5538ms
+   ✓ runtime-host-bridge > executes chat-completions through a LiteLLM-derived moonshot-oauth endpoint with X-Msh headers  1926ms
+   ✓ runtime-host-bridge > executes chat-completions through an api-key-static provider via environment credential  1658ms
+   ✓ runtime-host-bridge > propagates downstream stream-writer failures during direct provider streaming  1565ms
+   ✓ runtime-host-bridge > forwards reasoning-only upstream SSE chunks when chat-completions opted into reasoning  1577ms
+   ✓ runtime-host-bridge > suppresses reasoning-only upstream SSE chunks until downstream-safe content is available when reasoning is not requested  1626ms
+   ✓ runtime-host-bridge > accepts legacy credentialized endpoint ids when pinning a requested endpoint  1628ms
+ ✓ test/validate-vendors.test.ts (2 tests) 273473ms
+   ✓ runRuntimeVendorValidation > executes decision-only, local-only, remote-only, and hybrid vendor modes end to end  273457ms
+
+ Test Files  87 passed | 3 skipped (90)
+      Tests  795 passed | 4 skipped (799)
+   Start at  22:15:01
+   Duration  278.67s (transform 16.59s, setup 0ms, collect 82.73s, tests 1561.97s, environment 45ms, prepare 38.92s)
+
+
+> @try-works/pi-role-model@0.1.4 test D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\packages\pi-role-model
+> vitest run
+
+
+ RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/packages/pi-role-model
+
+ ✓ test/docs-and-safety.test.ts (2 tests) 22ms
+ ✓ test/package-manifest.test.ts (3 tests) 17ms
+ ✓ test/downstream-openai.test.ts (9 tests) 21ms
+ ✓ test/config.test.ts (4 tests) 12ms
+ ✓ test/taxonomy-staged-loader.test.ts (2 tests) 11ms
+ ✓ test/runtime-inspection.test.ts (4 tests) 23ms
+ ✓ test/effort-identity.test.ts (1 test) 13ms
+ ✓ test/request-intent.test.ts (12 tests) 136ms
+ ✓ test/runtime-discovery.test.ts (4 tests) 39ms
+ ✓ test/commands.test.ts (15 tests) 43ms
+ ✓ test/taxonomy-data-files.test.ts (5 tests) 207ms
+ ✓ test/effective-taxonomy.test.ts (5 tests) 107ms
+ ✓ test/taxonomy-classification.test.ts (14 tests) 236ms
+ ✓ test/extension.test.ts (12 tests) 404ms
+ ✓ test/alias-store.test.ts (1 test) 17ms
+
+> @role-model-router/runtime-host-bridge@0.0.0 build D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\role-model-router\apps\runtime-host-bridge
+> tsc -p tsconfig.json
+
+(node:15056) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/validate-agent-path.test.ts (7 tests) 34459ms
+   ✓ validate-agent-path helper > runs the rebuilt-runtime alias proof through canonical runtime aliases  34067ms
+
+ Test Files  16 passed (16)
+      Tests  100 passed (100)
+   Start at  22:19:41
+   Duration  36.31s (transform 4.21s, setup 0ms, collect 6.23s, tests 35.77s, environment 8ms, prepare 6.94s)
+
+
+> role-model@0.0.0 runtime:test-critical D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm --filter @role-model-router/runtime-host-bridge run test:critical && corepack pnpm --filter @role-model-router/runtime-ui run test:critical && corepack pnpm run runtime:validate-ui && corepack pnpm run runtime:validate-observability
+
+
+> @role-model-router/runtime-host-bridge@0.0.0 test:critical D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\role-model-router\apps\runtime-host-bridge
+> vitest run test/account-repair.test.ts test/unified-runtime-config.test.ts test/provider-overlap-metadata.test.ts test/benchmark-summary.test.ts test/validate-observability.test.ts test/validate-ui.test.ts
+
+
+ RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/apps/runtime-host-bridge
+
+ ✓ test/unified-runtime-config.test.ts (27 tests) 88ms
+(node:40748) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:36608) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/benchmark-summary.test.ts (15 tests) 159ms
+(node:49468) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:37852) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+ ✓ test/validate-observability.test.ts (1 test) 12658ms
+   ✓ runRuntimeObservabilityValidation > proves structured request, capture, metrics, and otel observability over the real host path  12656ms
+ ✓ test/account-repair.test.ts (7 tests) 17400ms
+   ✓ account repair mutations > starting Kimi Code authorization for k3 preserves existing allowed models and active endpoints  1965ms
+   ✓ account repair mutations > reconnect returns the current pending device-authorization session for the same account  1692ms
+   ✓ account repair mutations > reconnect starts a fresh Codex Subscription device-code session instead of reusing a stale pending one  1599ms
+   ✓ account repair mutations > starting Codex Subscription authorization again supersedes the older pending session  1739ms
+   ✓ account repair mutations > update API key preserves account identity, bindings, and endpoint associations  6178ms
+   ✓ account repair mutations > rejects overlapping repair mutations for the same account without partially mutating state  1665ms
+   ✓ account repair mutations > codex subscription start returns a real device-code session and poll connects through managed Codex auth  2558ms
+ ✓ test/validate-ui.test.ts (1 test) 25898ms
+   ✓ runRuntimeUiValidation > validates runtime config reads and the main control-plane mutations  25896ms
+ ✓ test/provider-overlap-metadata.test.ts (50 tests) 66958ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for baseten  2642ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for cerebras  2504ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for cohere  2774ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for crusoe  2411ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for databricks  2553ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for deepinfra  2439ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for deepseek  2414ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for groq  2362ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for minimax  2416ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for mistral  2556ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for morph  2529ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for nebius  2268ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for openrouter  2382ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for ovhcloud  2278ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for perplexity  2391ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for sarvam  2343ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for v0  2575ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for wandb  2336ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for watsonx  2262ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for xai  2229ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes validation-canonical providerKind for zai  2250ms
+   ✓ listProviders overlap metadata (R1 integration) > listProviders exposes one OpenAI provider with API Key and Codex Subscription variants  2152ms
+   ✓ listProviders overlap metadata (R1 integration) > every remote connection method resolves its allowed models through the same effort-aware catalog  11602ms
+
+ Test Files  6 passed (6)
+      Tests  101 passed (101)
+   Start at  22:20:20
+   Duration  70.09s (transform 3.55s, setup 0ms, collect 10.32s, tests 123.16s, environment 2ms, prepare 2.04s)
+
+
+> @role-model-router/runtime-ui@ test:critical D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\role-model-router\apps\runtime-ui
+> vitest run app/lib/runtime-api.test.ts app/lib/view-models.test.ts app/lib/telemetry-analytics.test.ts app/lib/telemetry-chart-config.test.ts app/lib/theme.test.ts app/components/page-primitives.test.tsx
+
+
+ RUN  v3.2.4 D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/role-model-router/apps/runtime-ui
+
+ ✓ app/lib/telemetry-chart-config.test.ts (3 tests) 10ms
+ ✓ app/lib/theme.test.ts (6 tests) 14ms
+ ✓ app/lib/telemetry-analytics.test.ts (13 tests) 19ms
+ ✓ app/lib/runtime-api.test.ts (68 tests) 150ms
+ ✓ app/lib/view-models.test.ts (48 tests) 100ms
+ ✓ app/components/page-primitives.test.tsx (7 tests) 38ms
+
+ Test Files  6 passed (6)
+      Tests  145 passed (145)
+   Start at  22:21:34
+   Duration  3.10s (transform 1.61s, setup 0ms, collect 3.83s, tests 331ms, environment 2ms, prepare 2.92s)
+
+
+> role-model@0.0.0 runtime:validate-ui D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm --filter @role-model-router/runtime-host-bridge exec tsx src/validate-ui.ts
+
+(node:39888) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+{
+  "providerCount": 270,
+  "accountCount": 1,
+  "endpointCount": 2,
+  "runtimeConfigPath": "D:\\DEV\\tmp\\role-model-runtime-ui-validation\\runtime-config.yaml",
+  "runtimeConfigInitialApplied": true,
+  "runtimeConfigUpdatedVersion": "1.1",
+  "runtimeConfigUpdatedRoutingStrategy": "baseline",
+  "moonshotVariantIds": [
+    "moonshot-open-platform",
+    "kimi-code"
+  ],
+  "availableRoleIds": [
+    "analyst",
+    "architect",
+    "coder",
+    "coordinator",
+    "creative",
+    "data",
+    "designer",
+    "educator",
+    "finance",
+    "health",
+    "knowledge",
+    "legal",
+    "marketer",
+    "mathematician",
+    "operator",
+    "planner",
+    "procurement",
+    "product",
+    "recruiter",
+    "researcher",
+    "scientist",
+    "security",
+    "seller",
+    "strategist",
+    "support",
+    "tester",
+    "translator",
+    "writer"
+  ],
+  "upsertedAccountId": "moonshot.personal.primary",
+  "accountListIncludesUpsert": true,
+  "accountRoleBindingIncludesUpsert": true,
+  "activatedEndpointId": "moonshot.personal.primary.global.kimi-k2.5",
+  "endpointListIncludesActivation": true,
+  "routedRequestId": "req-runtime-ui-routing-001",
+  "telemetryListIncludesRoutedRequest": true,
+  "routedRequestRoutingDecisionId": "route-runtime-ui-routing-001",
+  "routedRequestEffectiveMode": "baseline",
+  "routedRequestRewriteReason": "requested-model-matches-downstream",
+  "mixedAliasId": "mixed.local-remote",
+  "mixedAliasModelListIncludesAlias": false,
+  "mixedAliasRequestId": "req-runtime-ui-mixed-alias-001",
+  "mixedAliasAllowEndpoints": [
+    "llama-swap.local.lfm2-5-1-2b-instruct",
+    "moonshot.personal.primary.global.kimi-k2.5"
+  ],
+  "mixedAliasResolvedModelIds": [
+    "lfm2.5-1.2b-instruct",
+    "moonshot/kimi-k2.5"
+  ],
+  "mixedAliasTelemetryListIncludesRequest": true,
+  "mixedAliasRequestDetailAliasResolvedModelIds": [
+    "lfm2.5-1.2b-instruct",
+    "moonshot/kimi-k2.5"
+  ],
+  "mixedAliasRouterDecisionMatchesRequest": true,
+  "mixedAliasOverviewIncludesSelectedEndpoint": true,
+  "mixedAliasEndpointsIncludeSelectedEndpoint": true
+}
+
+> role-model@0.0.0 runtime:validate-observability D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm --filter @role-model-router/runtime-host-bridge exec tsx src/validate-observability.ts
+
+(node:45388) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+{
+  "routedRequestId": "req-runtime-ui-routing-001",
+  "telemetryListIncludesRoutedRequest": true,
+  "routedRequestRoutingDecisionId": "route-runtime-ui-routing-001",
+  "mixedAliasTelemetryListIncludesRequest": true,
+  "mixedAliasRouterDecisionMatchesRequest": true,
+  "mixedAliasOverviewIncludesSelectedEndpoint": true
+}
+
+> role-model@0.0.0 test:rust D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> cargo test --manifest-path role-model-router/rust/Cargo.toml --workspace
+
+   Compiling once_cell v1.21.4
+   Compiling windows-link v0.2.1
+   Compiling lazy_static v1.5.0
+   Compiling log v0.4.29
+   Compiling cfg-if v1.0.4
+   Compiling pin-project-lite v0.2.17
+   Compiling smallvec v1.15.1
+   Compiling memchr v2.8.0
+   Compiling serde_core v1.0.228
+   Compiling zmij v1.0.21
+   Compiling itoa v1.0.18
+   Compiling anyhow v1.0.102
+   Compiling thiserror v2.0.18
+   Compiling windows-sys v0.61.2
+   Compiling thread_local v1.1.9
+   Compiling sharded-slab v0.1.7
+   Compiling tracing-core v0.1.36
+   Compiling tracing-log v0.2.0
+   Compiling tracing v0.1.44
+   Compiling nu-ansi-term v0.50.3
+   Compiling tracing-subscriber v0.3.23
+   Compiling serde v1.0.228
+   Compiling serde_json v1.0.149
+   Compiling rm_provider_litertlm v0.0.0 (D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\role-model-router\rust\crates\rm_provider_litertlm)
+   Compiling rm_provider_mediapipe_bridge v0.0.0 (D:\DEV\role-model\.worktrees\93-stage-package-cleanliness\role-model-router\rust\crates\rm_provider_mediapipe_bridge)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 8.15s
+     Running unittests src\lib.rs (role-model-router\rust\target\debug\deps\rm_provider_litertlm-da8ba5bd6633c0ec.exe)
+
+running 1 test
+test tests::exposes_placeholder_provider ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src\lib.rs (role-model-router\rust\target\debug\deps\rm_provider_mediapipe_bridge-06bcb46a64946705.exe)
+
+running 1 test
+test tests::exposes_placeholder_provider ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+   Doc-tests rm_provider_litertlm
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+   Doc-tests rm_provider_mediapipe_bridge
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+> role-model@0.0.0 smoke D:\DEV\role-model\.worktrees\93-stage-package-cleanliness
+> corepack pnpm --filter @role-model-router/gateway-smoke exec tsx src/index.ts
+
+(node:59716) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+{
+  "chosen_endpoint_id": "openai.personal.primary.us-east-1.fast",
+  "adapter_family": "ai-sdk-openai",
+  "router_decision_path": "D:\\DEV\\role-model\\.worktrees\\93-stage-package-cleanliness\\runtime-output\\gateway-smoke\\router-decision.json",
+  "request_capture_path": "D:\\DEV\\role-model\\.worktrees\\93-stage-package-cleanliness\\runtime-output\\gateway-smoke\\request-capture.json",
+  "response_capture_path": "D:\\DEV\\role-model\\.worktrees\\93-stage-package-cleanliness\\runtime-output\\gateway-smoke\\response-capture.json",
+  "request_observation_path": "D:\\DEV\\role-model\\.worktrees\\93-stage-package-cleanliness\\runtime-output\\gateway-smoke\\request-observation.json",
+  "otel_export_path": "D:\\DEV\\role-model\\.worktrees\\93-stage-package-cleanliness\\runtime-output\\gateway-smoke\\otel-export.json",
+  "usage_summary": {
+    "by_app_id": {
+      "app-runtime": 1
+    },
+    "by_endpoint_id": {
+      "openai.personal.primary.us-east-1.fast": 1
+    },
+    "by_model_id": {
+      "openai/gpt-4.1-mini-fast": 1
+    },
+    "by_provider_kind": {
+      "remote_openai_compat": 1
+    },
+    "by_reasoning_effort": {
+      "default": 1
+    },
+    "by_effort_source": {
+      "none": 1
+    },
+    "by_endpoint_effort": {
+      "openai.personal.primary.us-east-1.fast|default": 1
+    }
+  }
+}

--- a/.recursive/run/93-variant-admission-model-pool-integrity/evidence/addenda/stage-package-worktree-cleanliness/red-workflow-contract.log
+++ b/.recursive/run/93-variant-admission-model-pool-integrity/evidence/addenda/stage-package-worktree-cleanliness/red-workflow-contract.log
@@ -1,0 +1,250 @@
+✔ build-binaries retries release attestation before failing (2.0967ms)
+✔ build-binaries pins one exact Node patch for reproducible SEA payloads (0.5696ms)
+✔ build-binaries produces stage candidates, manual dev builds, and tag-only releases (0.3683ms)
+✔ production artifacts include the exact private runtime tested at stage (0.2817ms)
+✔ the public release orchestrator enforces paired private promotion (0.3705ms)
+✖ paired private checkout never dirties the public package provenance worktree (2.3287ms)
+✔ stage pushes publish downloadable prereleases before stable promotion (0.4413ms)
+✔ stable tags require a manually accepted exact stage candidate (0.2594ms)
+✔ release candidate acceptance is explicit, checksum-bound, and manual only (0.4181ms)
+ℹ tests 9
+ℹ suites 0
+ℹ pass 8
+ℹ fail 1
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 169.3769
+
+✖ failing tests:
+
+test at scripts\build-binaries-workflow.test.mjs:60:1
+✖ paired private checkout never dirties the public package provenance worktree (2.3287ms)
+  AssertionError [ERR_ASSERTION]: The input did not match the regular expression /path:\s*\.cache\/paired-private/. Input:
+  
+  'name: build-binaries\n' +
+    '\n' +
+    'on:\n' +
+    '  workflow_dispatch:\n' +
+    '    inputs:\n' +
+    '      channel:\n' +
+    '        description: Runtime channel to package\n' +
+    '        required: true\n' +
+    '        default: development\n' +
+    '        type: choice\n' +
+    '        options:\n' +
+    '          - development\n' +
+    '          - stage\n' +
+    '          - production\n' +
+    '      private_sha:\n' +
+    '        description: Exact private role-model-internal commit embedded in a stage candidate\n' +
+    '        required: false\n' +
+    '        type: string\n' +
+    '      release_id:\n' +
+    '        description: Exact sha256-prefixed Run 88 candidate identity to bind into a stage package\n' +
+    '        required: false\n' +
+    '        type: string\n' +
+    '  push:\n' +
+    '    branches:\n' +
+    '      - stage\n' +
+    '    tags:\n' +
+    '      - "v*"\n' +
+    '\n' +
+    'env:\n' +
+    '  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\n' +
+    "  ROLE_MODEL_BUILD_CHANNEL: ${{ github.ref_type == 'tag' && 'production' || (github.ref_name == 'stage' && 'stage' || inputs.channel || 'development') }}\n" +
+    '  PRIVATE_PAIRED_SHA: ${{ inputs.private_sha || vars.ROLE_MODEL_PAIRED_PRIVATE_SHA }}\n' +
+    '  RUN88_RELEASE_ID: ${{ inputs.release_id || vars.RUN88_RELEASE_ID }}\n' +
+    '\n' +
+    'concurrency:\n' +
+    "  group: runtime-build-${{ github.ref }}-${{ inputs.channel || 'automatic' }}\n" +
+    "  cancel-in-progress: ${{ github.ref_type != 'tag' }}\n" +
+    '\n' +
+    'jobs:\n' +
+    '  build-runtime:\n' +
+    '    name: build ${{ matrix.target }}\n' +
+    '    runs-on: ${{ matrix.runner }}\n' +
+    '    timeout-minutes: 60\n' +
+    '    permissions:\n' +
+    '      actions: read\n' +
+    '      contents: read\n' +
+    '      attestations: write\n' +
+    '      id-token: write\n' +
+    '      artifact-metadata: write\n' +
+    '    strategy:\n' +
+    '      fail-fast: false\n' +
+    '      matrix:\n' +
+    '        include:\n' +
+    '          - runner: ubuntu-latest\n' +
+    '            target: linux-x64\n' +
+    '          - runner: macos-15-intel\n' +
+    '            target: darwin-x64\n' +
+    '          - runner: macos-14\n' +
+    '            target: darwin-arm64\n' +
+    '          - runner: windows-latest\n' +
+    '            target: win32-x64\n' +
+    '\n' +
+    '    steps:\n' +
+    '      - uses: actions/checkout@v4\n' +
+    '\n' +
+    '      - name: Validate stable production tag\n' +
+    "        if: github.ref_type == 'tag'\n" +
+    '        shell: bash\n' +
+    '        run: |\n' +
+    '          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]; then\n' +
+    '            echo "Stable release tag must be exact SemVer (vMAJOR.MINOR.PATCH)."\n' +
+    '            exit 1\n' +
+    '          fi\n' +
+    '          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"\n' +
+    '          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then\n' +
+    '            echo "Production tag must point to a commit promoted through main."\n' +
+    '            exit 1\n' +
+    '          fi\n' +
+    '\n' +
+    '      - name: Resolve public source tree\n' +
+    '        id: public_source\n' +
+    '        shell: bash\n' +
+    '        run: |\n' +
+    '          source_tree="$(git rev-parse HEAD^{tree})"\n' +
+    '          if [[ ! "$source_tree" =~ ^[0-9a-f]{40}$ ]]; then\n' +
+    '            echo "Public source tree must be an exact 40-character Git tree."\n' +
+    '            exit 1\n' +
+    '          fi\n' +
+    '          echo "source_tree=$source_tree" >> "$GITHUB_OUTPUT"\n' +
+    '\n' +
+    '      - name: Validate Run 88 stage identity inputs\n' +
+    "        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'\n" +
+    '        shell: bash\n' +
+    '        env:\n' +
+    '          PUBLIC_PAIRED_SHA: ${{ github.sha }}\n' +
+    '        run: |\n' +
+    '          if [[ ! "$PUBLIC_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then\n' +
+    '            echo "Stage public revision must be an exact 40-character commit."\n' +
+    '            exit 1\n' +
+    '          fi\n' +
+    '          if [[ ! "$PRIVATE_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then\n' +
+    '            echo "Stage private revision must be an exact 40-character commit."\n' +
+    '            exit 1\n' +
+    '          fi\n' +
+    '          if [[ ! "$RUN88_RELEASE_ID" =~ ^sha256:[0-9a-f]{64}$ ]]; then\n' +
+    '            echo "RUN88_RELEASE_ID must be an exact sha256-prefixed candidate identity."\n' +
+    '            exit 1\n' +
+    '          fi\n' +
+    '\n' +
+    '      - name: Resolve tested stage candidate\n' +
+    '        id: stage_candidate\n' +
+    "        if: env.ROLE_MODEL_BUILD_CHANNEL == 'production'\n" +
+    '        shell: pwsh\n' +
+    '        env:\n' +
+    '          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n' +
+    '        run: |\n' +
+    '          $artifactName = "role-model-stage-candidate-${{ steps.public_source.outputs.source_tree }}-${{ matrix.target }}"\n' +
+    '          $headers = @{\n' +
+    '            Authorization = "Bearer $env:GITHUB_TOKEN"\n' +
+    '            Accept = "application/vnd.github+json"\n' +
+    '            "X-GitHub-Api-Version" = "2022-11-28"\n' +
+    '          }\n' +
+    '          $listUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/artifacts?name=$artifactName&per_page=20"\n' +
+    '          $artifact = $null\n' +
+    '          $candidates = (Invoke-RestMethod -Headers $headers -Uri $listUrl).artifacts |\n' +
+    '            Where-Object { -not $_.expired } |\n' +
+    '            Sort-Object created_at -Descending\n' +
+    '          foreach ($candidate in $candidates) {\n' +
+    '            if ($candidate.workflow_run.head_branch -ne "stage") { continue }\n' +
+    '            $runUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/runs/$($candidate.workflow_run.id)"\n' +
+    '            $run = Invoke-RestMethod -Headers $headers -Uri $runUrl\n' +
+    '            if (\n' +
+    '              $run.status -eq "completed" -and\n' +
+    '              $run.conclusion -eq "success" -and\n' +
+    '              $run.event -eq "push" -and\n' +
+    '              $run.head_branch -eq "stage" -and\n' +
+    '              $run.head_sha -eq $candidate.workflow_run.head_sha -and\n' +
+    '              $run.path -eq ".github/workflows/build-binaries.yml"\n' +
+    '            ) {\n' +
+    '              $artifact = $candidate\n' +
+    '              break\n' +
+    '            }\n' +
+    '          }\n' +
+    '          if (-not $artifact) { throw "No tested stage candidate found for $artifactName" }\n' +
+    '          $stageSha = $artifact.workflow_run.head_sha\n' +
+    '          $candidateTag = "stage-rc-$($stageSha.Substring(0, 12))"\n' +
+    '          $approvalRefUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/git/ref/tags/rc-approved/$stageSha"\n' +
+    '          try {\n' +
+    '            $approval = Invoke-RestMethod -Headers $headers -Uri $approvalRefUrl\n' +
+    '          } catch {\n' +
+    '            throw "Tested stage candidate $stageSha has no explicit rc-approved acceptance receipt"\n' +
+    '          }\n' +
+    '          if ($approval.object.type -ne "commit" -or $approval.object.sha -ne $stageSha) {\n' +
+    '            throw "Release candidate acceptance receipt does not point to the tested stage commit"\n' +
+    '          }\n' +
+    '          $candidateReleaseUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/tags/$candidateTag"\n' +
+    '          try {\n' +
+    '            $candidateRelease = Invoke-RestMethod -Headers $headers -Uri $candidateReleaseUrl\n' +
+    '          } catch {\n' +
+    '            throw "Accepted stage candidate has no published prerelease: $candidateTag"\n' +
+    '          }\n' +
+    '          if ($candidateRelease.draft -or -not $candidateRelease.prerelease -or $candidateRelease.tag_name -ne $candidateTag) {\n' +
+    '            throw "Accepted stage candidate release is not a published prerelease"\n' +
+    '          }\n' +
+    '          $candidateRefUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/git/ref/tags/$candidateTag"\n' +
+    '          try {\n' +
+    '            $candidateRef = Invoke-RestMethod -Headers $headers -Uri $candidateRefUrl\n' +
+    '          } catch {\n' +
+    '            throw "Published stage prerelease tag cannot be resolved: $candidateTag"\n' +
+    '          }\n' +
+    '          if ($candidateRef.object.type -ne "commit" -or $candidateRef.object.sha -ne $stageSha) {\n' +
+    '            throw "Published stage prerelease tag does not point to the tested stage commit"\n' +
+    '          }\n' +
+    '          $outerZip = Join-Path $env:RUNNER_TEMP "stage-candidate.zip"\n' +
+    '          $outerDir = Join-Path $env:RUNNER_TEMP "stage-candidate"\n' +
+    '          $innerDir = Join-Path $env:RUNNER_TEMP "stage-package"\n' +
+    '          Invoke-WebRequest -Headers $headers -Uri $artifact.archive_download_url -OutFile $outerZip\n' +
+    '          Expand-Archive -LiteralPath $outerZip -DestinationPath $outerDir -Force\n' +
+    '          $archive = Get-ChildItem -LiteralPath $outerDir -File | Select-Object -First 1\n' +
+    '          if (-not $archive) { throw "Stage candidate artifact contains no archive" }\n' +
+    '          New-Item -ItemType Directory -Force -Path $innerDir | Out-Null\n' +
+    '          if ($archive.Extension -eq ".zip") {\n' +
+    '            Expand-Archive -LiteralPath $archive.FullName -DestinationPath $innerDir -Force\n' +
+    '          } else {\n' +
+    '            tar -xzf $archive.FullName -C $innerDir\n' +
+    '            if ($LASTEXITCODE -ne 0) { throw "Failed to extract stage candidate" }\n' +
+    '          }\n' +
+    '          $stageManifestPath = Get-ChildItem -LiteralPath $innerDir -Recurse -Filter manifest.json |\n' +
+    '            Select-Object -First 1 -ExpandProperty FullName\n' +
+    '          if (-not $stageManifestPath) { throw "Stage candidate contains no manifest" }\n' +
+    '          $stage = Get-Content -LiteralPath $stageManifestPath -Raw | ConvertFrom-Json\n' +
+    '          if ($stage.channel -ne "stage" -or $stage.name -ne "role-model-stage") { throw "Artifact is not a stage candidate" }\n' +
+    '          if ($stage.source_tree -ne "${{ steps.public_source.outputs.source_tree }}") { throw "Stage candidate public source tree mismatch" }\n' +
+    `          if ($stage.release_id -notmatch '^sha256:[0-9a-f]{64}$') { throw "Stage candidate release identity is invalid" }\n` +
+    `          if ($stage.private_source_commit -notmatch '^[0-9a-f]{40}$') { throw "Stage candidate private source identity is invalid" }\n` +
+    '          if ($stage.private_distribution_sha256 -ne $stage.track_b_runtime.manifest_sha256) { throw "Stage candidate private distribution binding mismatch" }\n' +
+    `          if ($stage.track_b_runtime.sidecar_sha256 -notmatch '^[0-9a-f]{64}$') { throw "Stage candidate sidecar identity is invalid" }\n` +
+    '          if ($stage.track_b_runtime.extension_count -ne 13) { throw "Stage candidate does not contain all thirteen extensions" }\n' +
+    '          "stage_manifest_path=$stageManifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n' +
+    '          "release_id=$($stage.release_id)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n' +
+    '          "private_source_commit=$($stage.private_source_commit)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n' +
+    '          "stage_sha=$stageSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n' +
+    '\n' +
+    '      - name: Select exact paired release identity\n' +
+    '        id: release_identity\n' +
+    "        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'\n" +
+    '        shell: pwsh\n' +
+    '        run: |\n' +
+    '          if ($env:ROLE_MODEL_BUILD_CHANNEL -eq "production") {\n' +
+    '            $privateSource = "${{ steps.stage_candidate.outputs.private_source_commit }}"\n' +
+    '            $releaseId = "${'... 19184 more characters
+  
+      at TestContext.<anonymous> (file:///D:/DEV/role-model/.worktrees/93-stage-package-cleanliness/scripts/build-binaries-workflow.test.mjs:61:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1106:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:788:18)
+      at Test.postRun (node:internal/test_runner/test:1235:19)
+      at Test.run (node:internal/test_runner/test:1163:12)
+      at async Test.processPendingSubtests (node:internal/test_runner/test:788:7) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 'name: build-binaries\n\non:\n  workflow_dispatch:\n    inputs:\n      channel:\n        description: Runtime channel to package\n        required: true\n        default: development\n        type: choice\n        options:\n          - development\n          - stage\n          - production\n      private_sha:\n        description: Exact private role-model-internal commit embedded in a stage candidate\n        required: false\n        type: string\n      release_id:\n        description: Exact sha256-prefixed Run 88 candidate identity to bind into a stage package\n        required: false\n        type: string\n  push:\n    branches:\n      - stage\n    tags:\n      - "v*"\n\nenv:\n  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\n  ROLE_MODEL_BUILD_CHANNEL: ${{ github.ref_type == \'tag\' && \'production\' || (github.ref_name == \'stage\' && \'stage\' || inputs.channel || \'development\') }}\n  PRIVATE_PAIRED_SHA: ${{ inputs.private_sha || vars.ROLE_MODEL_PAIRED_PRIVATE_SHA }}\n  RUN88_RELEASE_ID: ${{ inputs.release_id || vars.RUN88_RELEASE_ID }}\n\nconcurrency:\n  group: runtime-build-${{ github.ref }}-${{ inputs.channel || \'automatic\' }}\n  cancel-in-progress: ${{ github.ref_type != \'tag\' }}\n\njobs:\n  build-runtime:\n    name: build ${{ matrix.target }}\n    runs-on: ${{ matrix.runner }}\n    timeout-minutes: 60\n    permissions:\n      actions: read\n      contents: read\n      attestations: write\n      id-token: write\n      artifact-metadata: write\n    strategy:\n      fail-fast: false\n      matrix:\n        include:\n          - runner: ubuntu-latest\n            target: linux-x64\n          - runner: macos-15-intel\n            target: darwin-x64\n          - runner: macos-14\n            target: darwin-arm64\n          - runner: windows-latest\n            target: win32-x64\n\n    steps:\n      - uses: actions/checkout@v4\n\n      - name: Validate stable production tag\n        if: github.ref_type == \'tag\'\n        shell: bash\n        run: |\n          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]; then\n            echo "Stable release tag must be exact SemVer (vMAJOR.MINOR.PATCH)."\n            exit 1\n          fi\n          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"\n          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then\n            echo "Production tag must point to a commit promoted through main."\n            exit 1\n          fi\n\n      - name: Resolve public source tree\n        id: public_source\n        shell: bash\n        run: |\n          source_tree="$(git rev-parse HEAD^{tree})"\n          if [[ ! "$source_tree" =~ ^[0-9a-f]{40}$ ]]; then\n            echo "Public source tree must be an exact 40-character Git tree."\n            exit 1\n          fi\n          echo "source_tree=$source_tree" >> "$GITHUB_OUTPUT"\n\n      - name: Validate Run 88 stage identity inputs\n        if: env.ROLE_MODEL_BUILD_CHANNEL == \'stage\'\n        shell: bash\n        env:\n          PUBLIC_PAIRED_SHA: ${{ github.sha }}\n        run: |\n          if [[ ! "$PUBLIC_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then\n            echo "Stage public revision must be an exact 40-character commit."\n            exit 1\n          fi\n          if [[ ! "$PRIVATE_PAIRED_SHA" =~ ^[0-9a-f]{40}$ ]]; then\n            echo "Stage private revision must be an exact 40-character commit."\n            exit 1\n          fi\n          if [[ ! "$RUN88_RELEASE_ID" =~ ^sha256:[0-9a-f]{64}$ ]]; then\n            echo "RUN88_RELEASE_ID must be an exact sha256-prefixed candidate identity."\n            exit 1\n          fi\n\n      - name: Resolve tested stage candidate\n        id: stage_candidate\n        if: env.ROLE_MODEL_BUILD_CHANNEL == \'production\'\n        shell: pwsh\n        env:\n          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n        run: |\n          $artifactName = "role-model-stage-candidate-${{ steps.public_source.outputs.source_tree }}-${{ matrix.target }}"\n          $headers = @{\n            Authorization = "Bearer $env:GITHUB_TOKEN"\n            Accept = "application/vnd.github+json"\n            "X-GitHub-Api-Version" = "2022-11-28"\n          }\n          $listUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/artifacts?name=$artifactName&per_page=20"\n          $artifact = $null\n          $candidates = (Invoke-RestMethod -Headers $headers -Uri $listUrl).artifacts |\n            Where-Object { -not $_.expired } |\n            Sort-Object created_at -Descending\n          foreach ($candidate in $candidates) {\n            if ($candidate.workflow_run.head_branch -ne "stage") { continue }\n            $runUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/runs/$($candidate.workflow_run.id)"\n            $run = Invoke-RestMethod -Headers $headers -Uri $runUrl\n            if (\n              $run.status -eq "completed" -and\n              $run.conclusion -eq "success" -and\n              $run.event -eq "push" -and\n              $run.head_branch -eq "stage" -and\n              $run.head_sha -eq $candidate.workflow_run.head_sha -and\n              $run.path -eq ".github/workflows/build-binaries.yml"\n            ) {\n              $artifact = $candidate\n              break\n            }\n          }\n          if (-not $artifact) { throw "No tested stage candidate found for $artifactName" }\n          $stageSha = $artifact.workflow_run.head_sha\n          $candidateTag = "stage-rc-$($stageSha.Substring(0, 12))"\n          $approvalRefUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/git/ref/tags/rc-approved/$stageSha"\n          try {\n            $approval = Invoke-RestMethod -Headers $headers -Uri $approvalRefUrl\n          } catch {\n            throw "Tested stage candidate $stageSha has no explicit rc-approved acceptance receipt"\n          }\n          if ($approval.object.type -ne "commit" -or $approval.object.sha -ne $stageSha) {\n            throw "Release candidate acceptance receipt does not point to the tested stage commit"\n          }\n          $candidateReleaseUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/tags/$candidateTag"\n          try {\n            $candidateRelease = Invoke-RestMethod -Headers $headers -Uri $candidateReleaseUrl\n          } catch {\n            throw "Accepted stage candidate has no published prerelease: $candidateTag"\n          }\n          if ($candidateRelease.draft -or -not $candidateRelease.prerelease -or $candidateRelease.tag_name -ne $candidateTag) {\n            throw "Accepted stage candidate release is not a published prerelease"\n          }\n          $candidateRefUrl = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/git/ref/tags/$candidateTag"\n          try {\n            $candidateRef = Invoke-RestMethod -Headers $headers -Uri $candidateRefUrl\n          } catch {\n            throw "Published stage prerelease tag cannot be resolved: $candidateTag"\n          }\n          if ($candidateRef.object.type -ne "commit" -or $candidateRef.object.sha -ne $stageSha) {\n            throw "Published stage prerelease tag does not point to the tested stage commit"\n          }\n          $outerZip = Join-Path $env:RUNNER_TEMP "stage-candidate.zip"\n          $outerDir = Join-Path $env:RUNNER_TEMP "stage-candidate"\n          $innerDir = Join-Path $env:RUNNER_TEMP "stage-package"\n          Invoke-WebRequest -Headers $headers -Uri $artifact.archive_download_url -OutFile $outerZip\n          Expand-Archive -LiteralPath $outerZip -DestinationPath $outerDir -Force\n          $archive = Get-ChildItem -LiteralPath $outerDir -File | Select-Object -First 1\n          if (-not $archive) { throw "Stage candidate artifact contains no archive" }\n          New-Item -ItemType Directory -Force -Path $innerDir | Out-Null\n          if ($archive.Extension -eq ".zip") {\n            Expand-Archive -LiteralPath $archive.FullName -DestinationPath $innerDir -Force\n          } else {\n            tar -xzf $archive.FullName -C $innerDir\n            if ($LASTEXITCODE -ne 0) { throw "Failed to extract stage candidate" }\n          }\n          $stageManifestPath = Get-ChildItem -LiteralPath $innerDir -Recurse -Filter manifest.json |\n            Select-Object -First 1 -ExpandProperty FullName\n          if (-not $stageManifestPath) { throw "Stage candidate contains no manifest" }\n          $stage = Get-Content -LiteralPath $stageManifestPath -Raw | ConvertFrom-Json\n          if ($stage.channel -ne "stage" -or $stage.name -ne "role-model-stage") { throw "Artifact is not a stage candidate" }\n          if ($stage.source_tree -ne "${{ steps.public_source.outputs.source_tree }}") { throw "Stage candidate public source tree mismatch" }\n          if ($stage.release_id -notmatch \'^sha256:[0-9a-f]{64}$\') { throw "Stage candidate release identity is invalid" }\n          if ($stage.private_source_commit -notmatch \'^[0-9a-f]{40}$\') { throw "Stage candidate private source identity is invalid" }\n          if ($stage.private_distribution_sha256 -ne $stage.track_b_runtime.manifest_sha256) { throw "Stage candidate private distribution binding mismatch" }\n          if ($stage.track_b_runtime.sidecar_sha256 -notmatch \'^[0-9a-f]{64}$\') { throw "Stage candidate sidecar identity is invalid" }\n          if ($stage.track_b_runtime.extension_count -ne 13) { throw "Stage candidate does not contain all thirteen extensions" }\n          "stage_manifest_path=$stageManifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n          "release_id=$($stage.release_id)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n          "private_source_commit=$($stage.private_source_commit)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n          "stage_sha=$stageSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append\n\n      - name: Select exact paired release identity\n        id: release_identity\n        if: env.ROLE_MODEL_BUILD_CHANNEL == \'stage\' || env.ROLE_MODEL_BUILD_CHANNEL == \'production\'\n        shell: pwsh\n        run: |\n          if ($env:ROLE_MODEL_BUILD_CHANNEL -eq "production") {\n            $privateSource = "${{ steps.stage_candidate.outputs.private_source_commit }}"\n            $releaseId = "${'... 19184 more characters,
+    expected: /path:\s*\.cache\/paired-private/,
+    operator: 'match',
+    diff: 'simple'
+  }

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -57,6 +57,16 @@ test("the public release orchestrator enforces paired private promotion", () => 
   assert.match(workflow, /git merge-base --is-ancestor/);
 });
 
+test("paired private checkout never dirties the public package provenance worktree", () => {
+  assert.match(workflow, /path:\s*\.cache\/paired-private/);
+  assert.match(workflow, /working-directory:\s*\.cache\/paired-private/);
+  assert.match(
+    workflow,
+    /ROLE_MODEL_TRACK_B_DISTRIBUTION_ROOT:[\s\S]*?\.cache\/paired-private\/dist\/run00-dev/,
+  );
+  assert.doesNotMatch(workflow, /(?:path|working-directory):\s*_private\b/);
+});
+
 test("stage pushes publish downloadable prereleases before stable promotion", () => {
   assert.match(workflow, /^ {2}publish-stage-prerelease:/m);
   assert.match(workflow, /github\.ref == 'refs\/heads\/stage'/);


### PR DESCRIPTION
## Summary
- move the paired private checkout from untracked `_private/` to ignored `.cache/paired-private`
- preserve the SEA packager's strict clean-public-worktree provenance guard
- add a workflow-contract regression that prevents the topology from returning

## Verification
- `node --test scripts/build-binaries-workflow.test.mjs scripts/ci-workflow.test.mjs scripts/run88-stage-release-workflow.test.mjs scripts/run88-stage-release-workflow.integration.test.mjs scripts/run88-stage-release-workflow.regression.test.mjs` (28 passed)
- `corepack pnpm ci:check` (passed)

Fixes the failed stage binary workflow caused by its own paired checkout appearing as untracked public source. A new Stage RC is gated on this PR's GitHub CI and subsequent stage package build.