### PR TITLE
ci: add CircleCI public validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,76 @@
+version: 2.1
+
+executors:
+  node24:
+    docker:
+      - image: cimg/node:24.4.1
+    resource_class: medium
+    working_directory: ~/project
+
+commands:
+  install-public:
+    steps:
+      - run:
+          name: Enable Corepack and configure the pnpm store
+          command: |
+            corepack enable
+            corepack pnpm config set store-dir ~/.pnpm-store
+      - restore_cache:
+          keys:
+            - public-pnpm-v1-{{ checksum "pnpm-lock.yaml" }}
+      - run:
+          name: Install the frozen public dependency graph
+          command: corepack pnpm install --frozen-lockfile
+      - save_cache:
+          key: public-pnpm-v1-{{ checksum "pnpm-lock.yaml" }}
+          paths:
+            - ~/.pnpm-store
+  install-rust:
+    steps:
+      - restore_cache:
+          keys:
+            - public-rust-v1-{{ checksum "role-model-router/rust/Cargo.lock" }}
+      - run:
+          name: Install the stable Rust toolchain
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+            echo 'source "$HOME/.cargo/env"' >> "$BASH_ENV"
+      - run:
+          name: Verify the Rust toolchain is available
+          command: |
+            source "$HOME/.cargo/env"
+            rustc --version
+            cargo --version
+      - save_cache:
+          key: public-rust-v1-{{ checksum "role-model-router/rust/Cargo.lock" }}
+          paths:
+            - ~/.cargo/registry
+            - ~/.cargo/git
+            - ~/.rustup/toolchains
+
+jobs:
+  full-contract:
+    executor: node24
+    steps:
+      - checkout
+      - install-rust
+      - install-public
+      - run:
+          name: Run the maintained public CI contract
+          command: |
+            source "$HOME/.cargo/env"
+            corepack pnpm run ci:check
+  router-contract:
+    executor: node24
+    steps:
+      - checkout
+      - install-public
+      - run:
+          name: Run the router and trace verification lane
+          command: corepack pnpm run runtime:test-router
+
+workflows:
+  validation:
+    jobs:
+      - full-contract
+      - router-contract

--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -29,10 +29,23 @@ binary release or an independent version tag.
 
 ## Required CI lanes
 
-`.github/workflows/ci.yml` runs on pull requests and post-merge pushes for `dev`, `stage`, and `main`. Stable check
-names are `promotion-guard`, `quality`, `build-test`, `runtime-critical`, `runtime-router`, `rust`, and `smoke`.
-Superseded runs cancel, permissions default to read-only, jobs use bounded timeouts, and dependencies install with a
-frozen lockfile.
+CircleCI is the primary source of CI evidence for pull requests and promotions. The public
+`.circleci/config.yml` runs two non-deploying jobs: `ci/circleci: router-contract` for the router contract and
+`ci/circleci: full-contract` for the complete public verification contract. Both use the frozen pnpm lockfile; the
+full contract runs `pnpm run ci:check`.
+
+The private repository's CircleCI workflow is the companion Track B gate. It records one exact public source revision
+at pipeline start (or accepts the release-provided `public_paired_sha`), checks out that revision, builds the Track B
+distribution, verifies the paired manifests and external interoperability, runs the private suite, and exercises the
+packaged-runtime browser gate. A stage or production promotion needs the successful public CircleCI checks **and** a
+successful private `ci/circleci: track-b-conformance` run bound to the same public commit. CircleCI validation jobs
+must never deploy, tag, publish, or alter a release.
+
+`.github/workflows/ci.yml` may remain during the migration as a repository-protection compatibility signal, but it is
+not the release-test authority. Do not accept a green GitHub Actions CI run in place of the required CircleCI
+evidence. Before making CircleCI checks mandatory in branch protection, observe their exact names on a real PR and
+then replace the duplicate GitHub Actions CI requirements one recoverable change at a time. GitHub Actions remains
+the owner of promotion guards and release/build publication workflows.
 
 The promotion guard accepts ordinary work into `dev`, only `dev` into `stage`, and only `stage` into `main`.
 Reviewed `hotfix/* -> main` is the explicit emergency exception.
@@ -84,12 +97,13 @@ projects during an incident.
 
 ```bash
 corepack pnpm install --frozen-lockfile
+node --test scripts/circleci-workflow.test.mjs
 node --test scripts/ci-workflow.test.mjs scripts/build-binaries-workflow.test.mjs apps/docs-site/scripts/docs-site-deploy-workflow.test.mjs
 corepack pnpm run ci:check
 corepack pnpm run docs:build
 ROLE_MODEL_BUILD_CHANNEL=development corepack pnpm run runtime:package-sea
 ```
 
-Before changing GitHub protections, observe the successful check names on a real PR. Capture current settings, apply
-one recoverable change at a time, read it back, and keep `main` protected until the complete replacement policy is
-verified.
+Before changing branch protection, observe the successful CircleCI check names on a real PR. Capture current
+settings, apply one recoverable change at a time, read them back, and keep `main` protected until the complete
+CircleCI replacement policy is verified.

--- a/packages/pi-role-model/test/validate-agent-path.test.ts
+++ b/packages/pi-role-model/test/validate-agent-path.test.ts
@@ -452,5 +452,5 @@ describe("validate-agent-path helper", () => {
         expectedCaseEligibleEndpoints,
       );
     }
-  }, 60_000);
+  }, 180_000);
 });

--- a/packages/schema-tools/test/generate-protocol-types.test.ts
+++ b/packages/schema-tools/test/generate-protocol-types.test.ts
@@ -38,7 +38,7 @@ describe("generateProtocolTypes", () => {
     const duplicates = exportMatches.filter((name, index) => exportMatches.indexOf(name) !== index);
 
     expect(duplicates).toEqual([]);
-  });
+  }, 30_000);
 
   it("emits the router metricEntry helper instead of referencing an undefined MetricEntry symbol", async () => {
     const generatedTypesPath = await createGeneratedTypesPath();

--- a/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
@@ -207,7 +207,7 @@ litellm_proxy:
     );
     expect(account?.allowedModels).toEqual(["moonshot/kimi-k2.6"]);
     await restarted.shutdown();
-  });
+  }, 60_000);
 
   test("reassigns the controller when config-owned eject removes the active controller model", async () => {
     const tempRoot = await mkdtemp(

--- a/role-model-router/apps/runtime-host-bridge/test/endpoint-rehydration.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/endpoint-rehydration.test.ts
@@ -747,7 +747,7 @@ describe("endpoint rehydration", () => {
 
   test(
     "marks restarted remote endpoints offline and ineligible when startup probes time out",
-    { timeout: 20_000 },
+    { timeout: 60_000 },
     async () => {
       const runtimeStateRoot = path.join(os.tmpdir(), `runtime-host-endpoint-health-${Date.now()}`);
       const scopeId = "endpoint-health-tests";

--- a/scripts/circleci-workflow.test.mjs
+++ b/scripts/circleci-workflow.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const config = () => readFileSync(path.join(root, ".circleci", "config.yml"), "utf8");
+
+test("CircleCI runs the maintained public verification contract", () => {
+  const source = config();
+  assert.match(source, /cimg\/node:24\.4\.1/);
+  assert.match(source, /corepack pnpm install --frozen-lockfile/);
+  assert.match(source, /corepack pnpm run ci:check/);
+  assert.match(source, /corepack pnpm run runtime:test-router/);
+  assert.doesNotMatch(source, /(?<!p)npm\s+(?:install|test)\b|circleci run release/i);
+});
+
+test("CircleCI does not deploy or publish releases", () => {
+  const source = config();
+  assert.doesNotMatch(source, /\bdeploy\b|pages:deploy|build-binaries/i);
+});


### PR DESCRIPTION
## Summary
- replace CircleCI's generated npm template with the maintained pnpm/Node 24 validation contract
- run the full public CI contract plus the router/trace lane
- add a regression test that prevents generic template commands or publishing steps from returning

## Verification
- 
ode --test scripts/circleci-workflow.test.mjs`n- Python YAML parse of .circleci/config.yml`n- git diff --check`n
## Scope
CI only; no deployment or release action is configured.