### PR TITLE
fix(runtime-host-bridge): strip provider prefix from admission-probe model id

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/remote-health-probe.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/remote-health-probe.ts
@@ -138,6 +138,20 @@ export function buildChatCompletionsProbeUrl(apiBase: string): string {
   return trimmed.endsWith("/v1") ? `${trimmed}/chat/completions` : `${trimmed}/v1/chat/completions`;
 }
 
+/**
+ * Resolve the wire model id used by the chat-completions admission probe.
+ *
+ * Catalog model ids are provider-prefixed (e.g. ``deepseek/deepseek-v4-flash``),
+ * but OpenAI-compatible vendors expect the bare upstream id on the wire
+ * (``deepseek-v4-flash``). Sending the prefixed form makes the vendor reject
+ * the probe with a 400 that we previously misclassified as ``vendor-down``.
+ * Mirrors ``resolveProviderLocalModelId`` in the OpenAI execution adapter.
+ */
+function resolveProbeModelId(modelId: string): string {
+  const trimmed = modelId.trim();
+  return trimmed.includes("/") ? trimmed.split("/").slice(1).join("/") : trimmed;
+}
+
 function isTimeoutError(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -337,7 +351,7 @@ export async function probeRemoteEndpointAdmission(
 
   const probeUrl = buildChatCompletionsProbeUrl(context.apiBase);
   const body = {
-    model: context.modelId,
+    model: resolveProbeModelId(context.modelId),
     messages: [{ role: "user", content: "role-model admission readiness probe" }],
     max_tokens: 1,
     stream: false,

--- a/role-model-router/apps/runtime-host-bridge/test/remote-endpoint-admission-probe.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/remote-endpoint-admission-probe.test.ts
@@ -41,7 +41,7 @@ describe("remote endpoint admission probes", () => {
       }),
     );
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
-      model: "deepseek/deepseek-v4-flash",
+      model: "deepseek-v4-flash",
       messages: [{ role: "user", content: "role-model admission readiness probe" }],
       max_tokens: 1,
       stream: false,


### PR DESCRIPTION
## Problem

Activating a DeepSeek endpoint (e.g. `deepseek/deepseek-v4-flash`) leaves it permanently stuck at `healthStatus: "provider-unavailable"` with admission `reasonCode: "vendor-down"`. The endpoint is therefore ineligible for benchmarking and routing, so the provider is unusable.

## Root cause

The catalog stores provider-prefixed model ids (`deepseek/deepseek-v4-flash`), but OpenAI-compatible vendors expect the bare upstream id on the wire (`deepseek-v4-flash`).

The OpenAI execution adapter already handles this via `resolveProviderLocalModelId()` (`provider-openai/src/index.ts`), but the chat-completions admission probe (`remote-health-probe.ts`) builds its request body directly and sent the raw `context.modelId`:

```ts
const body = {
  model: context.modelId,   // "deepseek/deepseek-v4-flash"  ← wrong
  ...
};
```

DeepSeek rejects that with a 400:

```json
{ "error": { "message": "The supported API model names are deepseek-v4-pro, deepseek-v4-flash, ... but you passed deepseek/deepseek-v4-flash.", ... } }
```

The probe classifies any non-401/403/404 as `vendor-down`, so a malformed model id was misreported as a vendor outage.

## Fix

Strip the leading provider segment before probing, mirroring the execution adapter:

```ts
function resolveProbeModelId(modelId: string): string {
  const trimmed = modelId.trim();
  return trimmed.includes("/") ? trimmed.split("/").slice(1).join("/") : trimmed;
}
```

and send `model: resolveProbeModelId(context.modelId)`.

## Test

The existing admission-probe test actually asserted the bug (it expected `deepseek/deepseek-v4-flash` on the wire). Updated it to assert the bare upstream id, so it fails before this fix and passes after.

`corepack pnpm --filter @role-model-router/runtime-host-bridge vitest run test/remote-endpoint-admission-probe.test.ts src/remote-health-probe.test.ts` → 14/14 pass.
