### PR TITLE
Stage RC: self-contained managed secrets in the stage package

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -405,6 +405,21 @@ jobs:
             }
           }
 
+      - name: Include managed stage secrets in the stage package
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+        env:
+          STAGE_ARTIFACT_DIGEST_KEY: ${{ secrets.STAGE_ARTIFACT_DIGEST_KEY }}
+          STAGE_ARTIFACT_ENCRYPTION_KEY: ${{ secrets.STAGE_ARTIFACT_ENCRYPTION_KEY }}
+          STAGE_DESTINATION_MATERIAL: ${{ secrets.STAGE_DESTINATION_MATERIAL }}
+          STAGE_RECOMMENDATION_MATERIAL: ${{ secrets.STAGE_RECOMMENDATION_MATERIAL }}
+        run: |
+          secretsDir="role-model-router/dist/release/${{ matrix.target }}/secrets"
+          mkdir -p "$secretsDir"
+          printf '%s' "$STAGE_ARTIFACT_DIGEST_KEY" > "$secretsDir/artifact-digest.key"
+          printf '%s' "$STAGE_ARTIFACT_ENCRYPTION_KEY" > "$secretsDir/artifact-encryption.key"
+          printf '%s' "$STAGE_DESTINATION_MATERIAL" > "$secretsDir/destination-material.json"
+          printf '%s' "$STAGE_RECOMMENDATION_MATERIAL" > "$secretsDir/recommendation-material.json"
+
       - name: Archive standalone package (Unix)
         if: matrix.target != 'win32-x64'
         run: |

--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -697,11 +697,15 @@ function readLauncherString(values: LauncherConfigValues, key: string): string |
 }
 
 export function applyRecommendationServiceLauncherConfig(values: LauncherConfigValues): void {
-  const serviceUrl = readLauncherString(values, "recommendation-service-url");
   const channel = readLauncherString(values, "recommendation-channel");
+  const serviceUrl =
+    readLauncherString(values, "recommendation-service-url") ??
+    (channel === "stage" ? "https://recommendations-stage.role-model.dev" : undefined);
   const verificationKey = readLauncherString(values, "recommendation-verification-key");
   const serviceToken = readLauncherString(values, "recommendation-service-token");
-  const materialFile = readLauncherString(values, "recommendation-material-file");
+  const materialFile =
+    readLauncherString(values, "recommendation-material-file") ??
+    (channel === "stage" ? path.resolve("secrets", "recommendation-material.json") : undefined);
   const aggregateScope = readLauncherString(values, "aggregate-scope");
   const recommendationScope = readLauncherString(values, "recommendation-scope");
 
@@ -1243,11 +1247,20 @@ export async function main(): Promise<void> {
           trustMaterialFile:
             args.values["destination-material-file"] ??
             args.values["destination-trust-material-file"] ??
-            process.env.ROLE_MODEL_DESTINATION_AUTH_SECRET_FILE,
+            process.env.ROLE_MODEL_DESTINATION_AUTH_SECRET_FILE ??
+            (runtimeChannel === "stage"
+              ? path.resolve("secrets", "destination-material.json")
+              : undefined),
           aggregateEndpoint:
             args.values["aggregate-ingestion-url"] ??
-            process.env.ROLE_MODEL_AGGREGATE_INGESTION_URL,
-          aggregateScope: args.values["aggregate-scope"] ?? process.env.ROLE_MODEL_AGGREGATE_SCOPE,
+            process.env.ROLE_MODEL_AGGREGATE_INGESTION_URL ??
+            (runtimeChannel === "stage"
+              ? "https://ingest-stage.role-model.dev/contribution/aggregate"
+              : undefined),
+          aggregateScope:
+            args.values["aggregate-scope"] ??
+            process.env.ROLE_MODEL_AGGREGATE_SCOPE ??
+            (runtimeChannel === "stage" ? "standalone-runtime-stage" : undefined),
           ...(aggregateCorrelationReleaseId && aggregateCorrelationCohortId
             ? {
                 aggregateCorrelationReleaseId,

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -211,6 +211,18 @@ export async function resolveManagedArtifactKeyFiles(options: {
     ]);
     return resolved;
   }
+  if (options.channel === "stage") {
+    const packagedDigest = path.resolve("secrets", "artifact-digest.key");
+    const packagedEncryption = path.resolve("secrets", "artifact-encryption.key");
+    await Promise.all([
+      assertManagedArtifactKeyFile(packagedDigest),
+      assertManagedArtifactKeyFile(packagedEncryption),
+    ]);
+    return {
+      artifactDigestKeyFile: packagedDigest,
+      artifactEncryptionKeyFile: packagedEncryption,
+    };
+  }
   if (options.channel !== "production") return {};
 
   const stableStateRoot = path.resolve(options.stateRoot);

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -87,6 +88,67 @@ describe("production Track B composition", () => {
     await expect(
       resolveManagedArtifactKeyFiles({ channel: "production", stateRoot }),
     ).rejects.toThrow(/incomplete.*managed artifact key/i);
+  });
+
+  test("resolves packaged stage artifact keys from the release secrets directory", async () => {
+    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-stage-package-"));
+    roots.push(packageRoot);
+    const secretsDir = path.join(packageRoot, "secrets");
+    await mkdir(secretsDir, { recursive: true });
+    await writeFile(path.join(secretsDir, "artifact-digest.key"), Buffer.alloc(32, 3));
+    await writeFile(path.join(secretsDir, "artifact-encryption.key"), Buffer.alloc(32, 5));
+    const previousCwd = process.cwd();
+    process.chdir(packageRoot);
+    try {
+      const runtimeModule = await import("../src/track-b-runtime.js");
+      const resolveManagedArtifactKeyFiles = Reflect.get(
+        runtimeModule,
+        "resolveManagedArtifactKeyFiles",
+      ) as (input: { channel: "stage"; stateRoot: string }) => Promise<{
+        artifactDigestKeyFile: string;
+        artifactEncryptionKeyFile: string;
+      }>;
+      const resolved = await resolveManagedArtifactKeyFiles({
+        channel: "stage",
+        stateRoot: path.join(packageRoot, "state"),
+      });
+      expect(resolved.artifactDigestKeyFile).toBe(
+        path.join(packageRoot, "secrets", "artifact-digest.key"),
+      );
+      expect(resolved.artifactEncryptionKeyFile).toBe(
+        path.join(packageRoot, "secrets", "artifact-encryption.key"),
+      );
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  test("refuses a stage package whose packaged artifact keys are missing", async () => {
+    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-stage-package-empty-"));
+    roots.push(packageRoot);
+    const previousCwd = process.cwd();
+    process.chdir(packageRoot);
+    try {
+      const runtimeModule = await import("../src/track-b-runtime.js");
+      const resolveManagedArtifactKeyFiles = Reflect.get(
+        runtimeModule,
+        "resolveManagedArtifactKeyFiles",
+      ) as (input: { channel: "stage"; stateRoot: string }) => Promise<unknown>;
+      await expect(
+        resolveManagedArtifactKeyFiles({ channel: "stage", stateRoot: path.join(packageRoot, "state") }),
+      ).rejects.toThrow(/managed artifact key|ENOENT/i);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  test("packages the stage channel with self-contained secrets defaults", async () => {
+    const cliSource = readFileSync(new URL("../src/cli.ts", import.meta.url), "utf8");
+    expect(cliSource).toMatch(/secrets",\s*"recommendation-material\.json/);
+    expect(cliSource).toMatch(/secrets",\s*"destination-material\.json/);
+    expect(cliSource).toMatch(/recommendations-stage\.role-model\.dev/);
+    expect(cliSource).toMatch(/ingest-stage\.role-model\.dev\/contribution\/aggregate/);
+    expect(cliSource).toMatch(/standalone-runtime-stage/);
   });
 
   test("owns and supervises the private operations sidecar without URL injection", async () => {

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -135,7 +135,10 @@ describe("production Track B composition", () => {
         "resolveManagedArtifactKeyFiles",
       ) as (input: { channel: "stage"; stateRoot: string }) => Promise<unknown>;
       await expect(
-        resolveManagedArtifactKeyFiles({ channel: "stage", stateRoot: path.join(packageRoot, "state") }),
+        resolveManagedArtifactKeyFiles({
+          channel: "stage",
+          stateRoot: path.join(packageRoot, "state"),
+        }),
       ).rejects.toThrow(/managed artifact key|ENOENT/i);
     } finally {
       process.chdir(previousCwd);


### PR DESCRIPTION
Stage packages resolve their managed keys, destination trust, and recommendation material from a packaged secrets/ directory; build-binaries writes the stage secrets into the archive. TDD: track-b-runtime-composition 17/17.