### PR TITLE
fix(run94): preserve storage inventory projections

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -118,22 +118,27 @@ type StorageRecord = {
   readonly conflicts?: readonly string[];
 };
 
-function normalizeStorageRetentionContract(value: unknown): Record<string, unknown> {
+export function normalizeStorageRetentionContract(value: unknown): Record<string, unknown> {
   const raw = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-  const logicalClasses = Array.isArray(raw.logicalClasses)
-    ? raw.logicalClasses
-    : Array.isArray(raw.categories)
-      ? raw.categories
-      : [];
   const inventory =
     raw.storageInventory && typeof raw.storageInventory === "object"
       ? (raw.storageInventory as Record<string, unknown>)
       : undefined;
+  const nestedLogicalClasses = Array.isArray(inventory?.logicalClasses)
+    ? inventory.logicalClasses
+    : undefined;
+  const logicalClasses = Array.isArray(raw.logicalClasses)
+    ? raw.logicalClasses
+    : Array.isArray(raw.categories)
+      ? raw.categories
+      : nestedLogicalClasses ?? [];
+  const nestedPhysicalResources = Array.isArray(inventory?.physicalResources)
+    ? inventory.physicalResources
+    : undefined;
   const physicalResources = Array.isArray(raw.physicalResources)
     ? raw.physicalResources
-    : Array.isArray(inventory?.entries)
-      ? inventory.entries
-      : [];
+    : nestedPhysicalResources ??
+      (Array.isArray(inventory?.entries) ? inventory.entries : []);
   return {
     ...raw,
     logicalClasses,
@@ -145,6 +150,8 @@ function normalizeStorageRetentionContract(value: unknown): Record<string, unkno
             ...inventory,
             complete: inventory.complete === true,
             entries: physicalResources,
+            physicalResources,
+            logicalClasses,
           },
         }
       : {}),

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -126,12 +126,12 @@ export function normalizeStorageRetentionContract(value: unknown): Record<string
       : undefined;
   const nestedLogicalClasses = Array.isArray(inventory?.logicalClasses)
     ? inventory.logicalClasses
-    : undefined;
+    : [];
   const logicalClasses = Array.isArray(raw.logicalClasses)
     ? raw.logicalClasses
     : Array.isArray(raw.categories)
       ? raw.categories
-      : nestedLogicalClasses ?? [];
+      : [];
   const nestedPhysicalResources = Array.isArray(inventory?.physicalResources)
     ? inventory.physicalResources
     : undefined;
@@ -151,7 +151,7 @@ export function normalizeStorageRetentionContract(value: unknown): Record<string
             complete: inventory.complete === true,
             entries: physicalResources,
             physicalResources,
-            logicalClasses,
+            logicalClasses: nestedLogicalClasses,
           },
         }
       : {}),

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-retention-inventory.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-retention-inventory.test.ts
@@ -51,9 +51,25 @@ test("SP50 preserves distinct nested physical resources and logical classes", ()
   expect(normalized.physicalResources).toEqual([
     { id: "cloud_history_r2", physicalBytes: 42 },
   ]);
-  expect(normalized.logicalClasses).toEqual([{ id: "history", bytes: 21 }]);
+  expect(normalized.logicalClasses).toEqual([]);
   expect(normalized.storageInventory).toMatchObject({
     physicalResources: [{ id: "cloud_history_r2", physicalBytes: 42 }],
     logicalClasses: [{ id: "history", bytes: 21 }],
   });
+});
+
+test("SP53 never projects physical-inventory logical mappings as usage categories", () => {
+  const normalized = normalizeStorageRetentionContract({
+    storageInventory: {
+      schemaVersion: "role-model.storage-registry.v2",
+      complete: true,
+      logicalClasses: [{ id: "artifact_graph", physicalResourceId: "physical-a", measurement: "physical_resource_reference" }],
+      physicalResources: [{ id: "physical-a", physicalBytes: 10 }],
+    },
+  });
+
+  expect(normalized.logicalClasses).toEqual([]);
+  expect((normalized.storageInventory as { logicalClasses: unknown[] }).logicalClasses).toEqual([
+    { id: "artifact_graph", physicalResourceId: "physical-a", measurement: "physical_resource_reference" },
+  ]);
 });

--- a/role-model-router/apps/runtime-host-bridge/test/recursive-87-retention-inventory.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/recursive-87-retention-inventory.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 
 import * as trackBRuntime from "../src/track-b-runtime.js";
+import { normalizeStorageRetentionContract } from "../src/track-b-operations.js";
 
 test("SP5 host retention inventory refuses incomplete physical storage claims", () => {
   expect(typeof trackBRuntime.validateTrackBRetentionInventory).toBe("function");
@@ -34,4 +35,25 @@ test("SP5 host retention inventory refuses incomplete physical storage claims", 
       entries: [{ id: "unknown", owner: "", health: "ready" }],
     }),
   ).toThrow(/incomplete physical storage inventory/i);
+});
+
+test("SP50 preserves distinct nested physical resources and logical classes", () => {
+  const normalized = normalizeStorageRetentionContract({
+    storageInventory: {
+      schemaVersion: "role-model.storage-registry.v2",
+      complete: true,
+      entries: [{ id: "legacy-entry" }],
+      physicalResources: [{ id: "cloud_history_r2", physicalBytes: 42 }],
+      logicalClasses: [{ id: "history", bytes: 21 }],
+    },
+  });
+
+  expect(normalized.physicalResources).toEqual([
+    { id: "cloud_history_r2", physicalBytes: 42 },
+  ]);
+  expect(normalized.logicalClasses).toEqual([{ id: "history", bytes: 21 }]);
+  expect(normalized.storageInventory).toMatchObject({
+    physicalResources: [{ id: "cloud_history_r2", physicalBytes: 42 }],
+    logicalClasses: [{ id: "history", bytes: 21 }],
+  });
 });

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
@@ -1882,7 +1882,7 @@ function normalizeStorageRetentionSummary(
     readonly physicalResources?: RuntimeStorageRetentionSummary["physicalResources"];
   };
   const logicalClasses =
-    raw.logicalClasses ?? raw.categories ?? raw.storageInventory?.logicalClasses ?? [];
+    raw.logicalClasses ?? raw.categories ?? [];
   const physicalResources =
     raw.physicalResources ?? raw.storageInventory?.physicalResources ?? raw.storageInventory?.entries ?? [];
   return {
@@ -1891,7 +1891,7 @@ function normalizeStorageRetentionSummary(
     categories: logicalClasses,
     physicalResources,
     storageInventory: raw.storageInventory
-      ? { ...raw.storageInventory, entries: physicalResources, physicalResources, logicalClasses }
+      ? { ...raw.storageInventory, entries: physicalResources, physicalResources }
       : undefined,
   };
 }

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
@@ -1822,17 +1822,20 @@ export interface RuntimeStorageRetentionSummary {
     readonly blocks: readonly string[];
   } | null;
   readonly storageInventory?: {
-    readonly schemaVersion: "role-model.storage-registry.v1";
+    readonly schemaVersion: "role-model.storage-registry.v1" | "role-model.storage-registry.v2";
     readonly complete: boolean;
     readonly entries: readonly {
       readonly id: string;
       readonly owner: string;
       readonly health: string;
-      readonly measurement: "measured" | "unavailable";
+      readonly measurement: "measured" | "remote_observed" | "unavailable";
       readonly physicalBytes: number | null;
       readonly heldItems: number;
       readonly retentionState: string;
     }[];
+    /** v2 keeps the measured physical inventory separate from logical accounting. */
+    readonly physicalResources?: RuntimeStorageRetentionSummary["physicalResources"];
+    readonly logicalClasses?: RuntimeStorageRetentionSummary["logicalClasses"];
   };
   // Run 94 SP8: measured physical accounting from the read-only storage audit plus
   // the measured policy state; absent until a real measurement exists.
@@ -1844,6 +1847,9 @@ export interface RuntimeStorageRetentionSummary {
     readonly logicalBytes?: number;
     readonly reclaimableBytes?: number;
     readonly heldBytes?: number | null;
+    /** Physical allocation not attributable to logical rows; never a store health state. */
+    readonly unattributedPhysicalBytes?: number;
+    /** @deprecated Use unattributedPhysicalBytes. */
     readonly unavailableBytes?: number;
     readonly observationRows?: number;
     readonly graphEdges?: number;
@@ -1875,15 +1881,17 @@ function normalizeStorageRetentionSummary(
     readonly logicalClasses?: RuntimeStorageRetentionSummary["logicalClasses"];
     readonly physicalResources?: RuntimeStorageRetentionSummary["physicalResources"];
   };
-  const logicalClasses = raw.logicalClasses ?? raw.categories ?? [];
-  const physicalResources = raw.physicalResources ?? raw.storageInventory?.entries ?? [];
+  const logicalClasses =
+    raw.logicalClasses ?? raw.categories ?? raw.storageInventory?.logicalClasses ?? [];
+  const physicalResources =
+    raw.physicalResources ?? raw.storageInventory?.physicalResources ?? raw.storageInventory?.entries ?? [];
   return {
     ...raw,
     logicalClasses,
     categories: logicalClasses,
     physicalResources,
     storageInventory: raw.storageInventory
-      ? { ...raw.storageInventory, entries: physicalResources }
+      ? { ...raw.storageInventory, entries: physicalResources, physicalResources, logicalClasses }
       : undefined,
   };
 }

--- a/role-model-router/apps/runtime-ui/app/routes/storage-retention.test.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/storage-retention.test.tsx
@@ -37,8 +37,13 @@ describe("StorageRetentionRoute", () => {
       "row.physicalBytes",
       "row.heldItems",
       "row.retentionState",
+      "Unattributed physical bytes",
+      "unattributedPhysicalBytes",
+      "Global policy state",
+      'row.health === "healthy" || row.health === "ready"',
     ])
       expect(source).toContain(token);
+    expect(source).not.toContain("summary.policyState ? summary.policyState.state : row.retentionState");
     expect(source).not.toContain("Maximum bytes");
     expect(source).not.toContain("StatusPill");
     expect(source).not.toContain("FactCard");

--- a/role-model-router/apps/runtime-ui/app/routes/storage-retention.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/storage-retention.tsx
@@ -131,10 +131,12 @@ export function StorageRetentionRouteView() {
           },
           {
             id: "unavailable",
-            label: "Unavailable",
+            label: "Unattributed physical bytes",
             value:
-              summary?.storageAudit?.unavailableBytes != null
-                ? String(formatBytes(summary.storageAudit.unavailableBytes))
+              summary?.storageAudit?.unattributedPhysicalBytes != null
+                ? String(formatBytes(summary.storageAudit.unattributedPhysicalBytes))
+                : summary?.storageAudit?.unavailableBytes != null
+                  ? String(formatBytes(summary.storageAudit.unavailableBytes))
                 : "Not measured",
           },
           {
@@ -158,6 +160,11 @@ export function StorageRetentionRouteView() {
         ]}
       />
       {error ? <ErrorState label={error} /> : null}
+      {summary?.policyState ? (
+        <p className={supportingTextClassName}>
+          Global policy state: {summary.policyState.state}
+        </p>
+      ) : null}
       {summary?.physicalResources ? (
         <SectionCard
           title="Physical storage inventory"
@@ -182,7 +189,7 @@ export function StorageRetentionRouteView() {
                     <td className={`py-3 ${compactTitleClassName}`}>{row.id}</td>
                     <td className={`py-3 ${supportingTextClassName}`}>{row.owner}</td>
                     <td className="py-3">
-                      <Badge tone={row.health === "healthy" ? "success" : "warning"}>
+                      <Badge tone={row.health === "healthy" || row.health === "ready" ? "success" : "warning"}>
                         {row.health}
                       </Badge>
                     </td>
@@ -191,7 +198,7 @@ export function StorageRetentionRouteView() {
                     </td>
                     <td className={`py-3 ${supportingTextClassName}`}>{row.heldItems}</td>
                     <td className={`py-3 ${supportingTextClassName}`}>
-                      {summary.policyState ? summary.policyState.state : row.retentionState}
+                      {row.retentionState}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
Run 94 addendum 12 public half. Keeps nested storage-inventory mappings distinct from usage categories while preserving physical-resource projection and compatibility. Focused bridge/UI tests and builds pass locally.