### PR TITLE
fix(runtime): allow bounded Track B state recovery

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -2893,7 +2893,11 @@ export function createOwnedTrackBSidecarSpec(options: {
       const endpoint = await new Promise<string>((resolve, reject) => {
         const timer = setTimeout(() => {
           reject(new Error(`Track B sidecar readiness timeout${stderr ? `: ${stderr}` : ""}`));
-        }, options.startupTimeoutMs ?? 10_000);
+          // A persisted Track B graph can require more than the short process-spawn
+          // window to reconcile durable state before it can publish readiness. Keep
+          // this bounded, but align the owned sidecar with the production extension
+          // supervisor's recovery allowance.
+        }, options.startupTimeoutMs ?? 30_000);
         const rejectError = (error: Error) => {
           clearTimeout(timer);
           reject(

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -265,6 +265,34 @@ describe("production Track B composition", () => {
     ).toThrow(/managed artifact keys/i);
   });
 
+  test("allows the packaged sidecar sufficient startup time to recover persisted Track B state", async () => {
+    const stateRoot = await mkdtemp(
+      path.join(os.tmpdir(), "role-model-track-b-sidecar-persisted-state-"),
+    );
+    roots.push(stateRoot);
+    const artifactPath = path.join(stateRoot, "delayed-sidecar.mjs");
+    const source = [
+      'import http from "node:http";',
+      "setTimeout(()=>{",
+      ' const server=http.createServer((_req,res)=>res.end("ok"));',
+      ' server.listen(0,"127.0.0.1",()=>{const address=server.address();process.stdout.write(JSON.stringify({type:"ready",endpoint:`http://127.0.0.1:${address.port}`})+"\\n")});',
+      ' process.on("SIGTERM",()=>server.close(()=>process.exit(0)));',
+      "}, 11_000);",
+    ].join("\n");
+    await writeFile(artifactPath, source, "utf8");
+
+    const sidecar = createOwnedTrackBSidecarSpec({
+      artifactPath,
+      artifactSha256: createHash("sha256").update(source).digest("hex"),
+      stateRoot,
+      channel: "stage",
+    });
+
+    const child = await sidecar.launch();
+    expect(child.endpoint).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    await child.stop();
+  }, 20_000);
+
   test("passes cloud contribution trust and aggregate destination into the launcher-owned sidecar", async () => {
     const stateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-track-b-sidecar-cloud-"));
     roots.push(stateRoot);


### PR DESCRIPTION
Fixes the packaged stage sidecar readiness timeout seen while reconciling valid persisted Track B state. Adds a RED/GREEN regression for delayed readiness and keeps startup bounded at 30 seconds.