### PR TITLE
fix(runtime): promote Run 94 legacy SQLite recovery to stage

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -1317,6 +1317,23 @@ function outboxSchema(database: DatabaseSync): void {
       "INSERT OR IGNORE INTO track_b_post_observation_meta (key, value) VALUES ('schemaVersion', ?)",
     )
     .run(TRACK_B_OUTBOX_SCHEMA_VERSION);
+  // SQLite authorities created before effort variants were modeled can retain
+  // pending rows without a complete variant identity. They cannot safely enter
+  // a current Track B workflow: preserve the row as a bounded retired receipt
+  // instead of dispatching it and failing the whole recovery pass.
+  database.exec(`
+    UPDATE track_b_post_observation_pending
+       SET legacy_identity_missing = 1
+     WHERE legacy_identity_missing = 0
+       AND (
+         model_id IS NULL
+         OR trim(model_id) = ''
+         OR effort_source IS NULL
+         OR effort_source NOT IN ('none', 'client', 'variant', 'variant_coerced')
+         OR (reasoning_effort IS NULL AND effort_source <> 'none')
+         OR (reasoning_effort IS NOT NULL AND effort_source = 'none')
+       )
+  `);
 }
 
 function sqliteHeader(bytes: Buffer): boolean {

--- a/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
@@ -1668,6 +1668,10 @@ observed_data:
       runtimeStateRoot,
       scopeId: "runtime-host-legacy-craft-ask",
       unifiedRuntimeConfigPath,
+      // This assertion normalizes persisted routing configuration. It does not
+      // exercise the local vendor process, so keep it hermetic instead of
+      // fetching a mutable llama-swap release from GitHub during CI.
+      runtimeVendorStartup: "disabled",
     });
 
     const updated = await backend.updateRuntimeConfig({

--- a/role-model-router/apps/runtime-host-bridge/test/run94-sp5-sp10.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run94-sp5-sp10.test.ts
@@ -113,6 +113,54 @@ test("GREEN: imports N-1 JSON once, classifies every legacy row, and quarantines
   expect(await readFile(`${filePath}.n-1.json`, "utf8")).toContain("legacy-malformed");
 });
 
+test("retires N-1 SQLite pending work that lacks an effort identity before dispatch", async () => {
+  const root = await import("node:fs/promises").then(({ mkdtemp }) =>
+    mkdtemp(path.join(os.tmpdir(), "run94-sp5-legacy-sqlite-")),
+  );
+  roots.push(root);
+  const filePath = path.join(root, "post-observation-outbox.sqlite");
+  const initial = createTrackBPostObservationOutbox({ filePath, maxItems: 8 });
+  await initial.read();
+  const database = new DatabaseSync(filePath);
+  database
+    .prepare(
+      `INSERT INTO track_b_post_observation_pending
+       (request_id, routing_decision_id, endpoint_id, model_id, reasoning_effort, effort_source,
+        run88_correlation_json, legacy_identity_missing, enqueued_at_ms)
+       VALUES (?, ?, ?, ?, NULL, NULL, NULL, 0, ?)`,
+    )
+    .run(
+      "legacy-sqlite-missing-effort",
+      "decision:legacy-sqlite-missing-effort",
+      "endpoint:legacy",
+      "model:legacy",
+      Date.now(),
+    );
+  database.close();
+
+  const restarted = createTrackBPostObservationOutbox({ filePath, maxItems: 8 });
+  const dispatched: string[] = [];
+  await restarted.drain(async (observation) => {
+    dispatched.push(observation.requestId);
+    return { status: "should-not-dispatch" };
+  });
+
+  expect(dispatched).toEqual([]);
+  expect(await restarted.read()).toMatchObject({
+    pendingCount: 0,
+    receiptCount: 1,
+    receipts: [
+      expect.objectContaining({
+        requestId: "legacy-sqlite-missing-effort",
+        result: expect.objectContaining({
+          status: "retired_legacy_missing_variant_identity",
+          productionMutation: false,
+        }),
+      }),
+    ],
+  });
+});
+
 test("GREEN: malformed legacy JSON fails closed without replacing the source authority", async () => {
   const root = await import("node:fs/promises").then(({ mkdtemp }) =>
     mkdtemp(path.join(os.tmpdir(), "run94-sp5-malformed-")),


### PR DESCRIPTION
Promotes the reviewed Run 94 legacy Track B SQLite recovery fix to stage.\n\nPrivate stage pairing is pinned to 9ff571085e6d330a5fe2b4fca32c7a102af2832e. All dev CI checks passed; stage validation is required before merge.