### PR TITLE
test(runtime): keep legacy alias migration hermetic

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/backend-unified-runtime-config.test.ts
@@ -1668,6 +1668,10 @@ observed_data:
       runtimeStateRoot,
       scopeId: "runtime-host-legacy-craft-ask",
       unifiedRuntimeConfigPath,
+      // This assertion normalizes persisted routing configuration. It does not
+      // exercise the local vendor process, so keep it hermetic instead of
+      // fetching a mutable llama-swap release from GitHub during CI.
+      runtimeVendorStartup: "disabled",
     });
 
     const updated = await backend.updateRuntimeConfig({


### PR DESCRIPTION
Fixes the stage-promotion CircleCI failure: a configuration-only test was starting llama-swap and fetching a mutable GitHub release. The test now disables vendor startup, retaining its routing-alias assertion without network dependence.\n\nVerified locally with the focused Vitest test and Biome check.