### PR TITLE
fix(router): advertise only routable alias efforts

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/downstream-openai-discovery.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/downstream-openai-discovery.ts
@@ -225,27 +225,22 @@ function buildEndpointIdsByModelId(registry: EndpointRegistryResult): Map<string
   return endpointIdsByModelId;
 }
 
-function buildEffortLevelsByModelId(
-  registry: EndpointRegistryResult,
-  catalog: NormalizedCatalog,
-): Map<string, string[]> {
-  const levelsByModelId = new Map<string, string[]>();
-  for (const endpoint of registry.endpoints) {
-    const profile = resolveModelCapabilityProfile({
-      modelId: endpoint.identity.model_id,
-      catalog,
-    });
-    const levels = levelsByModelId.get(endpoint.identity.model_id) ?? [];
-    levels.push(...profile.reasoning.effortLevels);
-    if (endpoint.identity.reasoning_effort) {
-      levels.push(endpoint.identity.reasoning_effort);
-    }
-    levelsByModelId.set(endpoint.identity.model_id, [...new Set(levels)]);
-  }
-  for (const levels of levelsByModelId.values()) {
-    levels.sort(compareReasoningEffort);
-  }
-  return levelsByModelId;
+/**
+ * A routing alias is only allowed to advertise an effort that it can select as
+ * a concrete configured endpoint instance. Catalog support describes what a
+ * provider could offer; it does not make an unconfigured sibling routable.
+ */
+function configuredAliasEffortLevels(input: {
+  readonly registry: EndpointRegistryResult;
+  readonly endpointIds: readonly string[];
+}): readonly string[] {
+  const allowedEndpointIds = new Set(input.endpointIds);
+  return uniqueReasoningEfforts(
+    input.registry.endpoints
+      .filter((endpoint) => allowedEndpointIds.has(endpoint.identity.endpoint_id))
+      .map((endpoint) => endpoint.identity.reasoning_effort?.trim() ?? "")
+      .filter((effort) => effort.length > 0),
+  );
 }
 
 function targetRows(input: {
@@ -517,7 +512,6 @@ export function createDownstreamOpenAIDiscovery(
   const modelAliases = input.modelAliases ?? [];
   const inventory = input.inventory ?? null;
   const endpointIdsByModelId = buildEndpointIdsByModelId(input.registry);
-  const effortLevelsByModelId = buildEffortLevelsByModelId(input.registry, input.catalog);
   const modelRecords: DownstreamOpenAIModelRecord[] = [];
 
   for (const [modelId, endpointIds] of endpointIdsByModelId.entries()) {
@@ -606,9 +600,10 @@ export function createDownstreamOpenAIDiscovery(
         declaredModelIds: alias.modelIds,
         routableModelIds,
         endpointIds: resolution.endpointIds,
-        effortLevels: aggregateModelIds.flatMap(
-          (modelId) => effortLevelsByModelId.get(modelId) ?? [],
-        ),
+        effortLevels: configuredAliasEffortLevels({
+          registry: input.registry,
+          endpointIds: resolution.endpointIds,
+        }),
         rows,
       }),
     );

--- a/role-model-router/apps/runtime-host-bridge/test/run91-effort-instance-identity.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run91-effort-instance-identity.test.ts
@@ -206,6 +206,34 @@ describe("Run 91 effort instance identity", () => {
     );
   });
 
+  test("advertises only configured fixed efforts for a routing alias", () => {
+    const configuredRegistry = {
+      endpoints: [defaultEndpoint, maxEndpoint],
+      diagnostics: [],
+      lifecycleSummary: { active: 2, degraded: 0, offline: 0 },
+    } as unknown as EndpointRegistryResult;
+    const response = createDownstreamOpenAIDiscovery({
+      baseUrl: "http://127.0.0.1:3456",
+      catalog,
+      registry: configuredRegistry,
+      modelAliases: [
+        {
+          aliasId: "baseline.remote-only",
+          modelIds: ["deepseek/deepseek-v4-pro"],
+          executionMode: "remote_only",
+        },
+      ] as never,
+    });
+
+    expect(
+      response.models.find((model) => model.id === "baseline.remote-only")?.capabilities.reasoning,
+    ).toEqual({
+      supported: true,
+      effortControl: true,
+      effortLevels: ["max"],
+    });
+  });
+
   test("recognizes an endpoint id in model selection before model or alias lookup", () => {
     const plan = mapChatCompletionsRequest(
       registry,


### PR DESCRIPTION
Fixes alias effort discovery so Pi can only select configured variant efforts. Includes a regression test for a default-plus-max alias pool.