### PR TITLE
fix(runtime): preserve default effort through outbox

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -1680,7 +1680,10 @@ export function createTrackBPostObservationOutbox({
               routingDecisionId: row.routing_decision_id,
               endpointId: row.endpoint_id,
               ...(row.model_id !== null ? { modelId: row.model_id } : {}),
-              ...(row.reasoning_effort !== null ? { reasoningEffort: row.reasoning_effort } : {}),
+              // `null` is the explicit provider-default effort identity. Preserve it
+              // through the SQLite round trip so the strict variant validator can
+              // distinguish a valid default from an N-1 record with no identity.
+              reasoningEffort: row.reasoning_effort,
               ...(row.effort_source !== null ? { effortSource: row.effort_source } : {}),
               ...(row.run88_correlation_json
                 ? { run88Correlation: parseBoundedJson(row.run88_correlation_json) }

--- a/role-model-router/apps/runtime-host-bridge/test/run94-sp5-sp10.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/run94-sp5-sp10.test.ts
@@ -161,6 +161,32 @@ test("retires N-1 SQLite pending work that lacks an effort identity before dispa
   });
 });
 
+test("preserves the explicit default-effort identity when SQLite work is dequeued", async () => {
+  const root = await import("node:fs/promises").then(({ mkdtemp }) =>
+    mkdtemp(path.join(os.tmpdir(), "run94-sp5-default-effort-")),
+  );
+  roots.push(root);
+  const outbox = createTrackBPostObservationOutbox({
+    filePath: path.join(root, "post-observation-outbox.sqlite"),
+    maxItems: 8,
+  });
+  await outbox.enqueue(identity("default-effort-round-trip"));
+
+  const dispatched: Array<Record<string, unknown>> = [];
+  await outbox.drain(async (observation) => {
+    dispatched.push(observation);
+    return { status: "processed" };
+  });
+
+  expect(dispatched).toHaveLength(1);
+  expect(dispatched[0]).toMatchObject({
+    requestId: "default-effort-round-trip",
+    reasoningEffort: null,
+    effortSource: "none",
+  });
+  expect("reasoningEffort" in dispatched[0]).toBe(true);
+});
+
 test("GREEN: malformed legacy JSON fails closed without replacing the source authority", async () => {
   const root = await import("node:fs/promises").then(({ mkdtemp }) =>
     mkdtemp(path.join(os.tmpdir(), "run94-sp5-malformed-")),


### PR DESCRIPTION
Summary: preserves the explicit null/none provider-default effort identity when dequeuing SQLite post-observation work. Adds a regression covering default-effort queue round-trip and strict Track B validation. Verification: runtime-host-bridge run94-sp5-sp10 tests pass.