### PR TITLE
test(storage): accept observed cloud inventory bytes

### DIFF
--- a/role-model-router/apps/runtime-ui/e2e/recursive-94-direct-track-b-storage-graph-cloud-roundtrip.sp8.storage-ui.spec.ts
+++ b/role-model-router/apps/runtime-ui/e2e/recursive-94-direct-track-b-storage-graph-cloud-roundtrip.sp8.storage-ui.spec.ts
@@ -24,10 +24,12 @@ test.describe("@recursive:94-direct-track-b-storage-graph-cloud-roundtrip @sp8 @
       };
     };
 
-    // Honest accounting: every unmeasured entry stays unavailable with null bytes.
+    // Honest accounting: local and read-only cloud observations both carry a
+    // numeric byte value; intentionally unobserved/unavailable entries do not.
     expect(Array.isArray(inventory.storageInventory.entries)).toBe(true);
     for (const row of inventory.storageInventory.entries) {
-      if (row.measurement === "measured") expect(typeof row.physicalBytes).toBe("number");
+      if (["measured", "remote_observed"].includes(row.measurement))
+        expect(typeof row.physicalBytes).toBe("number");
       else expect(row.physicalBytes).toBeNull();
     }
 


### PR DESCRIPTION
Restores the Stage/CI storage UI contract: read-only cloud observations are valid measured byte observations; only unobserved or unavailable entries require null physical bytes.\n\nValidation: CircleCI exposed the failing browser gate; local Playwright execution is blocked by a missing local Playwright browser manifest, so the exact packaged browser gate is delegated to CircleCI.