### PR TITLE
fix(release): bind production Track B to accepted stage tree

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -202,6 +202,32 @@ jobs:
           "private_source_commit=$($stage.private_source_commit)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "stage_sha=$stageSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Checkout exact accepted stage public revision
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.stage_candidate.outputs.stage_sha }}
+          # The stable package is built from main, but Track B must preserve
+          # the exact accepted stage candidate's public-commit provenance.
+          path: .cache/paired-public
+          fetch-depth: 1
+
+      - name: Verify accepted stage public source identity
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        shell: bash
+        env:
+          ACCEPTED_STAGE_SHA: ${{ steps.stage_candidate.outputs.stage_sha }}
+          EXPECTED_SOURCE_TREE: ${{ steps.public_source.outputs.source_tree }}
+        run: |
+          if [[ "$(git -C .cache/paired-public rev-parse HEAD)" != "$ACCEPTED_STAGE_SHA" ]]; then
+            echo "Accepted stage public checkout does not match the stage candidate."
+            exit 1
+          fi
+          if [[ "$(git -C .cache/paired-public rev-parse HEAD^{tree})" != "$EXPECTED_SOURCE_TREE" ]]; then
+            echo "Accepted stage public checkout does not match the production source tree."
+            exit 1
+          fi
+
       - name: Select exact paired release identity
         id: release_identity
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
@@ -291,7 +317,7 @@ jobs:
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
         working-directory: .cache/paired-private
         env:
-          ROLE_MODEL_PUBLIC_WORKTREE: ${{ github.workspace }}
+          ROLE_MODEL_PUBLIC_WORKTREE: ${{ env.ROLE_MODEL_BUILD_CHANNEL == 'production' && format('{0}/.cache/paired-public', github.workspace) || github.workspace }}
           NODE_OPTIONS: --conditions=runtime
         run: |
           corepack pnpm install --frozen-lockfile

--- a/.recursive/run/94-stage-manifest-commit-identity/09-production-release-candidate-tree-binding-addendum.md
+++ b/.recursive/run/94-stage-manifest-commit-identity/09-production-release-candidate-tree-binding-addendum.md
@@ -1,0 +1,65 @@
+Run: `/.recursive/run/94-stage-manifest-commit-identity/`
+Addendum: `Production Track-B candidate-tree binding`
+Status: `DRAFT`
+Date: `2026-08-29`
+
+## Release-blocking observation
+
+Stable tag `v0.0.12` was built from public `main` commit
+`86ae3be0fdb7523385ad7259b2b74ef41469434d`. The accepted Stage package was
+built from `d97d7ccf66d91de6702433ac1075e31c07201f39`. Both commits resolve to
+public source tree `73fd52db96793cddd8b4686c2110dfdee480b60f`, and both use
+private commit `4b23c9940dc2674440c38f384c16fe3075e4e3c3`.
+
+The production package correctly failed closed because the rebuilt Track-B
+manifest used `publicCommit: 86ae…` and therefore hashed to
+`e10fbe…`, while the Stage package used `publicCommit: d97…` and hashed to
+`e093a7…`. Extension files, sidecar, source trees, and private commit matched.
+
+## Root cause
+
+The production workflow reused the public `main` checkout for both the stable
+package and the private Track-B distribution build. Track-B correctly records
+the public *commit* as well as its tree, so a merge commit with the same tree
+produced a different distribution manifest identity. The production verifier
+correctly rejected it.
+
+## Remediation
+
+For production only:
+
+1. Checkout the exact accepted Stage public commit into `.cache/paired-public`.
+2. Verify its commit equals the accepted candidate SHA and its tree equals the
+   production `main` source tree.
+3. Pass that clean checkout to the private Track-B distribution build. Continue
+   packaging the public runtime from `main`.
+4. Preserve the existing exact manifest-hash comparison; do not normalize or
+   weaken it.
+
+## Strict TDD evidence
+
+- **RED:** Added `production rebuilds Track B against the accepted stage public
+  commit` to `scripts/build-binaries-workflow.test.mjs`; it failed because the
+  workflow had no accepted-public checkout.
+- **GREEN:** Added the checkout, commit/tree gate, and production-only worktree
+  selection. The regression test passed.
+- **Regression:** 40 focused Run-88 and binary-workflow tests passed.
+
+## Required release verification
+
+1. Merge this workflow-only repair to `dev`, then promote it through `stage`.
+2. Download and inspect the new Stage RC: its package includes 13 extensions
+   and the accepted source/Track-B identities.
+3. Run stage UAT and explicit candidate acceptance.
+4. Promote the paired branches to `main`, tag the next unused SemVer patch, and
+   verify every production matrix package reports the same Track-B manifest and
+   sidecar digests as the accepted Stage package.
+5. Verify the stable GitHub release contains all four platform archives,
+   installers, checksums, highlights, and attestations.
+
+## Non-goals
+
+- Do not retag or publish the failed `v0.0.12` build.
+- Do not weaken candidate identity validation or treat matching source trees as
+  permission to ignore commit provenance.
+

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -87,6 +87,16 @@ test("production rejects a stage candidate whose packaged commit is not its acce
   assert.match(workflow, /Stage candidate public commit mismatch/);
 });
 
+test("production rebuilds Track B against the accepted stage public commit", () => {
+  assert.match(workflow, /Checkout exact accepted stage public revision/);
+  assert.match(workflow, /ref:\s*\$\{\{ steps\.stage_candidate\.outputs\.stage_sha \}\}/);
+  assert.match(workflow, /path:\s*\.cache\/paired-public/);
+  assert.match(
+    workflow,
+    /ROLE_MODEL_PUBLIC_WORKTREE:[\s\S]*?ROLE_MODEL_BUILD_CHANNEL == 'production'[\s\S]*?\.cache\/paired-public/,
+  );
+});
+
 test("stable tags require a manually accepted exact stage candidate", () => {
   assert.match(workflow, /rc-approved/);
   assert.match(workflow, /candidate\.workflow_run\.head_sha/);


### PR DESCRIPTION
## Release-pipeline repair

Fixes the production-only Track-B identity mismatch that blocked stable tag `v0.0.12`.

The production build now checks out the exact accepted Stage public commit for the paired private Track-B distribution, verifies its tree equals the promoted public `main` tree, and retains the exact manifest-hash comparison.

### Verification
- RED: new workflow regression failed before the accepted-public checkout existed.
- GREEN: focused binary/release workflow and Run-88 suite: 40 passed.
- No production identity guard was relaxed.

See Run 94 addendum for the failure values and required new Stage RC verification.