### PR TITLE
chore(release): promote accepted-Stage dependency repair

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -268,6 +268,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Production Track B is deliberately built against the immutable public
+      # Stage checkout, not the main checkout.  Install its workspace links
+      # separately so esbuild can resolve the public runtime packages without
+      # changing the Stage-source provenance binding.
+      - name: Install exact accepted stage public dependencies
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        working-directory: .cache/paired-public
+        run: corepack pnpm install --frozen-lockfile
+
       - name: Build UI
         run: pnpm --filter @role-model-router/runtime-ui run build
 

--- a/.recursive/run/94-stage-manifest-commit-identity/10-production-stage-dependency-install-addendum.md
+++ b/.recursive/run/94-stage-manifest-commit-identity/10-production-stage-dependency-install-addendum.md
@@ -1,0 +1,41 @@
+# Addendum 10 — production Stage-checkout dependency installation
+
+## Trigger
+
+The `v0.0.13` production build reached the immutable accepted-Stage checkout
+gate successfully, then failed while building the private Track-B runtime.
+The checked-out Stage source tree did not have public workspace dependencies
+installed, so the private bundler could not resolve public packages such as
+`@role-model-router/sqlite-memory`, `trace`, and `profile-aggregator`.
+
+## Requirement
+
+Production packaging must retain the exact accepted Stage public source for
+Track-B provenance **and** install its dependencies before the private runtime
+builder consumes that source tree.  It must not substitute the production-main
+checkout or weaken the accepted Stage commit/tree assertions.
+
+## TDD plan
+
+1. Add a workflow contract test that requires a production-only dependency
+   install in `.cache/paired-public`.
+2. Run the test and record the expected RED failure against the pre-fix
+   workflow.
+3. Add the minimal production-only `corepack pnpm install --frozen-lockfile`
+   step after the Node/pnpm toolchain is ready and before Track-B bundling.
+4. Run the workflow contract suite (GREEN), formatting/static checks, and
+   diff hygiene.
+5. Promote through dev and Stage, build a fresh Stage RC, checksum it and
+   verify its manifest has the accepted public commit/tree plus all 13 Track-B
+   extensions.
+6. After explicit Stage acceptance, promote to main and publish a new stable
+   tag (not the already-failed `v0.0.13`), verifying all platform production
+   builds and release artifacts.
+
+## Verification boundary
+
+The failure is in release packaging rather than request handling.  Release
+verification therefore proves exact Stage source binding, dependency
+resolution, Track-B distribution construction, and 13-extension manifest
+integrity.  Runtime UAT remains attached to the freshly built Stage RC before
+any stable promotion.

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -97,6 +97,18 @@ test("production rebuilds Track B against the accepted stage public commit", () 
   );
 });
 
+test("production installs dependencies in the accepted stage checkout before Track B bundling", () => {
+  assert.match(workflow, /Install exact accepted stage public dependencies/);
+  assert.match(
+    workflow,
+    /Install exact accepted stage public dependencies[\s\S]*?working-directory:\s*\.cache\/paired-public[\s\S]*?corepack pnpm install --frozen-lockfile/,
+  );
+  assert.match(
+    workflow,
+    /Install exact accepted stage public dependencies[\s\S]*?if: env\.ROLE_MODEL_BUILD_CHANNEL == 'production'/,
+  );
+});
+
 test("stable tags require a manually accepted exact stage candidate", () => {
   assert.match(workflow, /rc-approved/);
   assert.match(workflow, /candidate\.workflow_run\.head_sha/);


### PR DESCRIPTION
## Promotion\nPromotes the production Track-B dependency-install repair from dev to stage for a fresh Stage RC.\n\n## Verification\n- PR #189: all GitHub and CircleCI checks passed\n- Workflow contract suite: 13 passing\n- Local frozen install proved the accepted public checkout creates workspace links required by Track-B bundling.