### PR TITLE
fix(release): close paired Track B build dependencies

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -280,6 +280,16 @@ jobs:
       - name: Build UI
         run: pnpm --filter @role-model-router/runtime-ui run build
 
+      # The Track B adapter bundles sqlite-memory directly from TypeScript.
+      # That package resolves profile-aggregator through its runtime export,
+      # which intentionally targets dist/.  A fresh CI checkout therefore
+      # needs this focused public build before the paired private distribution
+      # can be assembled.
+      - name: Build public runtime adapter dependencies
+        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
+        working-directory: ${{ env.ROLE_MODEL_BUILD_CHANNEL == 'production' && '.cache/paired-public' || '.' }}
+        run: corepack pnpm --filter @role-model-router/profile-aggregator... build
+
       - name: Validate exact private release revision
         if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage' || env.ROLE_MODEL_BUILD_CHANNEL == 'production'
         shell: bash

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -109,6 +109,18 @@ test("production installs dependencies in the accepted stage checkout before Tra
   );
 });
 
+test("paired Track B packaging builds public runtime dependencies before bundling source imports", () => {
+  assert.match(workflow, /Build public runtime adapter dependencies/);
+  assert.match(
+    workflow,
+    /Build public runtime adapter dependencies[\s\S]*?corepack pnpm --filter @role-model-router\/profile-aggregator\.\.\. build/,
+  );
+  assert.match(
+    workflow,
+    /Build public runtime adapter dependencies[\s\S]*?if: env\.ROLE_MODEL_BUILD_CHANNEL == 'stage' \|\| env\.ROLE_MODEL_BUILD_CHANNEL == 'production'/,
+  );
+});
+
 test("stable tags require a manually accepted exact stage candidate", () => {
   assert.match(workflow, /rc-approved/);
   assert.match(workflow, /candidate\.workflow_run\.head_sha/);


### PR DESCRIPTION
## Summary
- build profile-aggregator before paired private Track B assembly
- regression-test the Stage/production workflow contract

## Verification
- RED: workflow contract test failed before the step existed
- GREEN: node --test scripts/build-binaries-workflow.test.mjs
- GREEN: fresh paired public/private build with 13 extensions