### PR TITLE
fix(stage): keep secrets out of release packages

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -450,21 +450,20 @@ jobs:
             }
           }
 
-      - name: Include managed stage secrets in the stage package
-        if: env.ROLE_MODEL_BUILD_CHANNEL == 'stage'
+      - name: Assert release package has no bundled secret material
         shell: pwsh
-        env:
-          STAGE_ARTIFACT_DIGEST_KEY: ${{ secrets.STAGE_ARTIFACT_DIGEST_KEY }}
-          STAGE_ARTIFACT_ENCRYPTION_KEY: ${{ secrets.STAGE_ARTIFACT_ENCRYPTION_KEY }}
-          STAGE_DESTINATION_MATERIAL: ${{ secrets.STAGE_DESTINATION_MATERIAL }}
-          STAGE_RECOMMENDATION_MATERIAL: ${{ secrets.STAGE_RECOMMENDATION_MATERIAL }}
         run: |
-          $secretsDir = "role-model-router/dist/release/${{ matrix.target }}/secrets"
-          New-Item -ItemType Directory -Force -Path $secretsDir | Out-Null
-          [IO.File]::WriteAllText("$secretsDir/artifact-digest.key", $env:STAGE_ARTIFACT_DIGEST_KEY)
-          [IO.File]::WriteAllText("$secretsDir/artifact-encryption.key", $env:STAGE_ARTIFACT_ENCRYPTION_KEY)
-          [IO.File]::WriteAllText("$secretsDir/destination-material.json", $env:STAGE_DESTINATION_MATERIAL)
-          [IO.File]::WriteAllText("$secretsDir/recommendation-material.json", $env:STAGE_RECOMMENDATION_MATERIAL)
+          $packageDir = "role-model-router/dist/release/${{ matrix.target }}"
+          $forbiddenPaths = @(
+            "$packageDir/secrets",
+            "$packageDir/.env",
+            "$packageDir/.env.local"
+          )
+          foreach ($path in $forbiddenPaths) {
+            if (Test-Path $path) {
+              throw "Bundled secret material is forbidden in release packages: $path"
+            }
+          }
 
       - name: Archive standalone package (Unix)
         if: matrix.target != 'win32-x64'

--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -703,9 +703,7 @@ export function applyRecommendationServiceLauncherConfig(values: LauncherConfigV
     (channel === "stage" ? "https://recommendations-stage.role-model.dev" : undefined);
   const verificationKey = readLauncherString(values, "recommendation-verification-key");
   const serviceToken = readLauncherString(values, "recommendation-service-token");
-  const materialFile =
-    readLauncherString(values, "recommendation-material-file") ??
-    (channel === "stage" ? path.resolve("secrets", "recommendation-material.json") : undefined);
+  const materialFile = readLauncherString(values, "recommendation-material-file");
   const aggregateScope = readLauncherString(values, "aggregate-scope");
   const recommendationScope = readLauncherString(values, "recommendation-scope");
 
@@ -1254,10 +1252,7 @@ export async function main(): Promise<void> {
           trustMaterialFile:
             args.values["destination-material-file"] ??
             args.values["destination-trust-material-file"] ??
-            process.env.ROLE_MODEL_DESTINATION_AUTH_SECRET_FILE ??
-            (runtimeChannel === "stage"
-              ? path.resolve("secrets", "destination-material.json")
-              : undefined),
+            process.env.ROLE_MODEL_DESTINATION_AUTH_SECRET_FILE,
           aggregateEndpoint:
             args.values["aggregate-ingestion-url"] ??
             process.env.ROLE_MODEL_AGGREGATE_INGESTION_URL ??

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -185,7 +185,7 @@ async function assertManagedArtifactKeyFile(filePath: string): Promise<void> {
 }
 
 /**
- * Resolves operator-supplied keys or provisions a runtime-owned production key pair.
+ * Resolves operator-supplied keys or provisions a runtime-owned Stage/production key pair.
  * The owned pair lives under the stable runtime state root, never the versioned package,
  * so manual binary updates keep existing Message Graph ciphertext readable.
  */
@@ -211,19 +211,7 @@ export async function resolveManagedArtifactKeyFiles(options: {
     ]);
     return resolved;
   }
-  if (options.channel === "stage") {
-    const packagedDigest = path.resolve("secrets", "artifact-digest.key");
-    const packagedEncryption = path.resolve("secrets", "artifact-encryption.key");
-    await Promise.all([
-      assertManagedArtifactKeyFile(packagedDigest),
-      assertManagedArtifactKeyFile(packagedEncryption),
-    ]);
-    return {
-      artifactDigestKeyFile: packagedDigest,
-      artifactEncryptionKeyFile: packagedEncryption,
-    };
-  }
-  if (options.channel !== "production") return {};
+  if (options.channel === "development") return {};
 
   const stableStateRoot = path.resolve(options.stateRoot);
   const keyRoot = path.join(stableStateRoot, "managed-keys");
@@ -276,6 +264,13 @@ export interface TrackBProductionRuntimeOptions {
   stateRoot: string;
   sidecar: OwnedTrackBSidecarSpec;
 }
+
+/**
+ * A persisted Track B state can take longer than a process-spawn grace period
+ * to reconcile before it can report ready. Keep that recovery bounded while
+ * matching the extension supervisor's documented allowance.
+ */
+export const TRACK_B_SIDECAR_STARTUP_TIMEOUT_MS = 90_000;
 
 /**
  * Normal host-path adapter for graph-primary observation storage. The SQLite
@@ -2996,7 +2991,7 @@ export function createOwnedTrackBSidecarSpec(options: {
           // window to reconcile durable state before it can publish readiness. Keep
           // this bounded, but align the owned sidecar with the production extension
           // supervisor's recovery allowance.
-        }, options.startupTimeoutMs ?? 30_000);
+        }, options.startupTimeoutMs ?? TRACK_B_SIDECAR_STARTUP_TIMEOUT_MS);
         const rejectError = (error: Error) => {
           clearTimeout(timer);
           reject(

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 
 import {
+  TRACK_B_SIDECAR_STARTUP_TIMEOUT_MS,
   createOwnedTrackBSidecarSpec,
   createPackagedProductionRuntime,
   createProductionExtensionRuntime,
@@ -33,6 +34,10 @@ afterEach(async () => {
 
 describe("production Track B composition", () => {
   const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..", "..");
+
+  test("allows the documented bounded recovery window before a persisted sidecar is rejected", () => {
+    expect(TRACK_B_SIDECAR_STARTUP_TIMEOUT_MS).toBe(90_000);
+  });
 
   test("provisions production Message Graph keys once and reuses them across package updates", async () => {
     const stateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-managed-artifact-keys-"));
@@ -90,13 +95,9 @@ describe("production Track B composition", () => {
     ).rejects.toThrow(/incomplete.*managed artifact key/i);
   });
 
-  test("resolves packaged stage artifact keys from the release secrets directory", async () => {
+  test("provisions stage artifact keys under durable state instead of a release secrets directory", async () => {
     const packageRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-stage-package-"));
     roots.push(packageRoot);
-    const secretsDir = path.join(packageRoot, "secrets");
-    await mkdir(secretsDir, { recursive: true });
-    await writeFile(path.join(secretsDir, "artifact-digest.key"), Buffer.alloc(32, 3));
-    await writeFile(path.join(secretsDir, "artifact-encryption.key"), Buffer.alloc(32, 5));
     const previousCwd = process.cwd();
     process.chdir(packageRoot);
     try {
@@ -112,43 +113,23 @@ describe("production Track B composition", () => {
         channel: "stage",
         stateRoot: path.join(packageRoot, "state"),
       });
+      expect(await readFile(resolved.artifactDigestKeyFile)).toHaveLength(32);
+      expect(await readFile(resolved.artifactEncryptionKeyFile)).toHaveLength(32);
       expect(resolved.artifactDigestKeyFile).toBe(
-        path.join(packageRoot, "secrets", "artifact-digest.key"),
+        path.join(packageRoot, "state", "managed-keys", "artifact-digest.key"),
       );
       expect(resolved.artifactEncryptionKeyFile).toBe(
-        path.join(packageRoot, "secrets", "artifact-encryption.key"),
+        path.join(packageRoot, "state", "managed-keys", "artifact-encryption.key"),
       );
     } finally {
       process.chdir(previousCwd);
     }
   });
 
-  test("refuses a stage package whose packaged artifact keys are missing", async () => {
-    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-stage-package-empty-"));
-    roots.push(packageRoot);
-    const previousCwd = process.cwd();
-    process.chdir(packageRoot);
-    try {
-      const runtimeModule = await import("../src/track-b-runtime.js");
-      const resolveManagedArtifactKeyFiles = Reflect.get(
-        runtimeModule,
-        "resolveManagedArtifactKeyFiles",
-      ) as (input: { channel: "stage"; stateRoot: string }) => Promise<unknown>;
-      await expect(
-        resolveManagedArtifactKeyFiles({
-          channel: "stage",
-          stateRoot: path.join(packageRoot, "state"),
-        }),
-      ).rejects.toThrow(/managed artifact key|ENOENT/i);
-    } finally {
-      process.chdir(previousCwd);
-    }
-  });
-
-  test("packages the stage channel with self-contained secrets defaults", async () => {
+  test("requires external stage trust and recommendation material instead of package-local defaults", async () => {
     const cliSource = readFileSync(new URL("../src/cli.ts", import.meta.url), "utf8");
-    expect(cliSource).toMatch(/secrets",\s*"recommendation-material\.json/);
-    expect(cliSource).toMatch(/secrets",\s*"destination-material\.json/);
+    expect(cliSource).not.toMatch(/secrets",\s*"recommendation-material\.json/);
+    expect(cliSource).not.toMatch(/secrets",\s*"destination-material\.json/);
     expect(cliSource).toMatch(/recommendations-stage\.role-model\.dev/);
     expect(cliSource).toMatch(/ingest-stage\.role-model\.dev\/contribution\/aggregate/);
     expect(cliSource).toMatch(/standalone-runtime-stage/);

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -121,6 +121,13 @@ test("paired Track B packaging builds public runtime dependencies before bundlin
   );
 });
 
+test("stage and production release archives never receive managed runtime secrets", () => {
+  assert.doesNotMatch(workflow, /Include managed stage secrets in the stage package/);
+  assert.doesNotMatch(workflow, /STAGE_ARTIFACT_DIGEST_KEY|STAGE_ARTIFACT_ENCRYPTION_KEY/);
+  assert.doesNotMatch(workflow, /STAGE_DESTINATION_MATERIAL|STAGE_RECOMMENDATION_MATERIAL/);
+  assert.match(workflow, /Assert release package has no bundled secret material/);
+});
+
 test("stable tags require a manually accepted exact stage candidate", () => {
   assert.match(workflow, /rc-approved/);
   assert.match(workflow, /candidate\.workflow_run\.head_sha/);


### PR DESCRIPTION
## Summary
- removes Stage release-archive injection of managed secret material
- provisions Stage artifact keys under the durable runtime state root
- removes package-local Stage trust-material defaults and bounds Track B sidecar recovery at 90 seconds
- adds source-owned archive-boundary and runtime-composition coverage

## Verification
- 
ode --test scripts/build-binaries-workflow.test.mjs
- corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-runtime-composition.test.ts
- corepack pnpm --filter @role-model-router/runtime-host-bridge build
- go test main.go main_test.go in ole-model-router/apps/launcher

## Security note
The four GitHub secrets previously used only to place material in a public Stage archive were revoked after the workflow path was removed. No secret values are included in this PR.