### PR TITLE
fix(stage): disable aggregate without external trust

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/cli.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/cli.ts
@@ -1217,6 +1217,10 @@ export async function main(): Promise<void> {
       }
       const trackBStateRoot = path.join(options.runtimeStateRoot, options.scopeId, "track-b");
       const runtimeChannel = packagedProfile?.channel ?? "development";
+      const destinationTrustMaterialFile =
+        args.values["destination-material-file"] ??
+        args.values["destination-trust-material-file"] ??
+        process.env.ROLE_MODEL_DESTINATION_AUTH_SECRET_FILE;
       const artifactKeyFiles = await resolveManagedArtifactKeyFiles({
         channel: runtimeChannel,
         stateRoot: trackBStateRoot,
@@ -1249,20 +1253,19 @@ export async function main(): Promise<void> {
           channel: runtimeChannel,
           artifactDigestKeyFile: artifactKeyFiles.artifactDigestKeyFile,
           artifactEncryptionKeyFile: artifactKeyFiles.artifactEncryptionKeyFile,
-          trustMaterialFile:
-            args.values["destination-material-file"] ??
-            args.values["destination-trust-material-file"] ??
-            process.env.ROLE_MODEL_DESTINATION_AUTH_SECRET_FILE,
+          trustMaterialFile: destinationTrustMaterialFile,
           aggregateEndpoint:
             args.values["aggregate-ingestion-url"] ??
             process.env.ROLE_MODEL_AGGREGATE_INGESTION_URL ??
-            (runtimeChannel === "stage"
+            (runtimeChannel === "stage" && destinationTrustMaterialFile
               ? "https://ingest-stage.role-model.dev/contribution/aggregate"
               : undefined),
           aggregateScope:
             args.values["aggregate-scope"] ??
             process.env.ROLE_MODEL_AGGREGATE_SCOPE ??
-            (runtimeChannel === "stage" ? "standalone-runtime-stage" : undefined),
+            (runtimeChannel === "stage" && destinationTrustMaterialFile
+              ? "standalone-runtime-stage"
+              : undefined),
           ...(aggregateCorrelationReleaseId && aggregateCorrelationCohortId
             ? {
                 aggregateCorrelationReleaseId,

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -135,6 +135,12 @@ describe("production Track B composition", () => {
     expect(cliSource).toMatch(/standalone-runtime-stage/);
   });
 
+  test("does not enable the Stage aggregate destination unless external trust material is supplied", () => {
+    const cliSource = readFileSync(new URL("../src/cli.ts", import.meta.url), "utf8");
+    expect(cliSource).toMatch(/destinationTrustMaterialFile/);
+    expect(cliSource).toMatch(/runtimeChannel === "stage" && destinationTrustMaterialFile/);
+  });
+
   test("owns and supervises the private operations sidecar without URL injection", async () => {
     const stateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-track-b-runtime-"));
     roots.push(stateRoot);


### PR DESCRIPTION
Fixes the live Stage RC startup failure: the Stage aggregate destination and scope are now defaulted only when externally supplied destination trust material is present. Without material, contribution remains disabled instead of causing Track B sidecar startup to fail. Focused Track B composition coverage added.