### PR TITLE
chore(release): promote Run 95 candidate to stage

### DIFF
--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -56,6 +56,10 @@ Reviewed `hotfix/* -> main` is the explicit emergency exception.
 packages are available by explicit manual dispatch. Every successful `stage` push publishes a GitHub prerelease with
 all four stage-channel archives and `SHA256SUMS.txt`; prereleases are never selected by the stable installers.
 
+An explicit `workflow_dispatch` build is useful for package diagnostics, but it does not publish or replace a Stage
+prerelease. To create a candidate for acceptance, promote a reviewed public change through `dev -> stage` so that a
+`stage` push produces a new immutable `stage-rc-<stage-sha>` identity.
+
 After testing, a maintainer runs `.github/workflows/accept-release-candidate.yml` with the exact prerelease tag and
 checks the explicit acceptance input. That workflow re-downloads the candidate, validates all checksums and stage
 manifests, and creates the immutable `rc-approved/<full-stage-sha>` receipt. Do not approve a candidate based only on


### PR DESCRIPTION
## Stage promotion

Promotes the reviewed release-flow clarification and creates a new immutable Stage RC for Run 95 verification.

- Public dev commit: `ad8a874efbf4a5fd94ac95987403a0bf6544a6ee`
- Paired private Stage commit: `f5ebcf0fcd599dee1e7dfe873d8531f7bc193b1e`
- The previous manual packaging dispatch is diagnostic-only and did not publish an RC; this push-based promotion is the source-bound candidate path.