### PR TITLE
chore(release): promote Run 95 to stage candidate

### DIFF
--- a/docs/operations/02-ci-and-release-flow.md
+++ b/docs/operations/02-ci-and-release-flow.md
@@ -56,6 +56,10 @@ Reviewed `hotfix/* -> main` is the explicit emergency exception.
 packages are available by explicit manual dispatch. Every successful `stage` push publishes a GitHub prerelease with
 all four stage-channel archives and `SHA256SUMS.txt`; prereleases are never selected by the stable installers.
 
+An explicit `workflow_dispatch` build is useful for package diagnostics, but it does not publish or replace a Stage
+prerelease. To create a candidate for acceptance, promote a reviewed public change through `dev -> stage` so that a
+`stage` push produces a new immutable `stage-rc-<stage-sha>` identity.
+
 After testing, a maintainer runs `.github/workflows/accept-release-candidate.yml` with the exact prerelease tag and
 checks the explicit acceptance input. That workflow re-downloads the candidate, validates all checksums and stage
 manifests, and creates the immutable `rc-approved/<full-stage-sha>` receipt. Do not approve a candidate based only on


### PR DESCRIPTION
## Stage candidate promotion

Creates the source-bound Run 95 Stage candidate after reconciled branch history.

- Public dev commit: `39e92dac502dc4dc23a0395c59186e0d0f73b496`
- Paired private stage commit: `f5ebcf0fcd599dee1e7dfe873d8531f7bc193b1e`
- All reconciliation CI completed green before this promotion.