### PR TITLE
release(stage): storage audit readiness RC

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -687,6 +687,23 @@ const privateRetentionRequest = async (
   return result;
 };
 
+const normalizeStorageAuditReadiness = (value: unknown) => {
+  const raw = recordValue(value);
+  if (raw.schemaVersion !== "role-model.storage-audit-readiness.v1")
+    return { storageAudit: value ?? null, storageAuditStatus: null };
+  const audit = recordValue(raw.audit);
+  return {
+    storageAudit: audit.schemaVersion === "role-model.storage-audit.v1" ? audit : null,
+    storageAuditStatus: {
+      schemaVersion: "role-model.storage-audit-readiness.v1",
+      status: typeof raw.status === "string" ? raw.status : "pending",
+      observedAt: typeof raw.observedAt === "string" ? raw.observedAt : null,
+      freshUntil: typeof raw.freshUntil === "string" ? raw.freshUntil : null,
+      reason: typeof raw.reason === "string" ? raw.reason : undefined,
+    },
+  };
+};
+
 function boundedIdentity(value: unknown, label: string): string {
   if (typeof value !== "string" || value.length < 1 || value.length > 1024)
     throw new Error(`${label} is required`);
@@ -1522,7 +1539,7 @@ export function createTrackBOperations({
       if (remote)
         return {
           ...normalizeStorageRetentionContract(remote),
-          storageAudit: storageAudit ?? null,
+          ...normalizeStorageAuditReadiness(storageAudit),
         };
       const state = await readState(statePath);
       const categories = state.storageServices.map((row) => ({

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -2003,6 +2003,64 @@ describe("Track B operations APIs", () => {
     }
   });
 
+  test("run95 preserves an asynchronous storage-audit readiness state without presenting it as a completed audit", async () => {
+    const operations = createServer((request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      if (request.url === "/storage-retention") {
+        response.end(
+          JSON.stringify({
+            revision: 7,
+            totalBytes: 140,
+            physicalResources: [],
+            logicalClasses: [],
+            policyState: { state: "absent", channel: "stage" },
+          }),
+        );
+        return;
+      }
+      if (request.url === "/storage-audit") {
+        response.end(
+          JSON.stringify({
+            schemaVersion: "role-model.storage-audit-readiness.v1",
+            status: "pending",
+            observedAt: null,
+            freshUntil: null,
+            reason: "Read-only storage audit is in progress",
+          }),
+        );
+        return;
+      }
+      response.writeHead(404).end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      operations.once("error", reject);
+      operations.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = operations.address();
+      if (!address || typeof address === "string")
+        throw new Error("operations server did not bind");
+      const api = createTrackBOperations({
+        statePath: path.join(os.tmpdir(), `run95-storage-audit-${Date.now()}.json`),
+        catalog: [],
+        operationsEndpoint: `http://127.0.0.1:${address.port}`,
+        operationsToken: "run95-storage-audit-token-0001",
+      });
+      await expect(api.readStorageRetention()).resolves.toMatchObject({
+        revision: 7,
+        storageAudit: null,
+        storageAuditStatus: {
+          schemaVersion: "role-model.storage-audit-readiness.v1",
+          status: "pending",
+        },
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        operations.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   test("run79 mutateExtension enables disables and sets mode with audit receipts", async () => {
     const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run79-mutate-${Date.now()}`);
     roots.push(runtimeStateRoot);

--- a/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
+++ b/role-model-router/apps/runtime-ui/app/lib/runtime-api.ts
@@ -1891,6 +1891,14 @@ export interface RuntimeStorageRetentionSummary {
     readonly graphEdges?: number;
     readonly measuredAt?: string;
   } | null;
+  /** Audit freshness is separate from completed physical accounting. */
+  readonly storageAuditStatus?: {
+    readonly schemaVersion: "role-model.storage-audit-readiness.v1";
+    readonly status: "pending" | "stale" | "ready" | string;
+    readonly observedAt?: string | null;
+    readonly freshUntil?: string | null;
+    readonly reason?: string;
+  } | null;
   readonly policyState?: {
     readonly channel: string;
     readonly state: string;

--- a/role-model-router/apps/runtime-ui/app/routes/storage-retention.tsx
+++ b/role-model-router/apps/runtime-ui/app/routes/storage-retention.tsx
@@ -186,6 +186,16 @@ export function StorageRetentionRouteView() {
           {summary.policyState?.state ?? "not reported"}
         </p>
       ) : null}
+      {summary?.storageAuditStatus ? (
+        <p className={supportingTextClassName}>
+          Storage audit: {summary.storageAuditStatus.status}
+          {summary.storageAuditStatus.observedAt
+            ? ` (observed ${summary.storageAuditStatus.observedAt})`
+            : summary.storageAuditStatus.reason
+              ? ` — ${summary.storageAuditStatus.reason}`
+              : ""}
+        </p>
+      ) : null}
       <p className={supportingTextClassName}>
         Unattributed physical bytes are measured physical allocation not mapped to logical storage
         classes; they are not service health.


### PR DESCRIPTION
Promotes the synchronized Run 95 public/private pair for a fresh Stage RC.\n\n- Public adapter unwraps async storage-audit readiness.\n- Private Track B sidecar performs storage audit asynchronously with bounded cached results.\n- Paired CircleCI contracts and packaged-runtime browser gate passed before promotion.