### PR TITLE
fix(runtime): preserve graph key recovery boundary

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts
@@ -78,6 +78,18 @@ export interface ManagedArtifactKeyFiles {
   readonly artifactEncryptionKeyFile?: string;
 }
 
+function hasPersistedArtifactState(stateRoot: string): boolean {
+  const legacyFile = path.join(stateRoot, "artifact-store.json");
+  const roots = [path.join(stateRoot, "artifact-store"), `${legacyFile}.store`];
+  return (
+    existsSync(legacyFile) ||
+    roots.some(
+      (root) =>
+        existsSync(path.join(root, "metadata.sqlite")) || existsSync(path.join(root, "blobs")),
+    )
+  );
+}
+
 /**
  * Small local graph adapter for fixture and development runs that do not have
  * the private operations sidecar configured. Rich observations live in these
@@ -235,6 +247,15 @@ export async function resolveManagedArtifactKeyFiles(options: {
   };
 
   if (await pathExists(keyRoot)) return readPublishedPair();
+
+  // Generating a replacement pair for persisted ciphertext irreversibly makes
+  // the existing graph unreadable. Require recovery of the original pair
+  // instead; first install is the only safe time to provision keys.
+  if (hasPersistedArtifactState(stableStateRoot)) {
+    throw new Error(
+      "managed artifact keys are absent for existing artifact state; restore both Message Graph keys from backup instead of generating replacements",
+    );
+  }
 
   await mkdir(stableStateRoot, { recursive: true });
   const temporaryRoot = await mkdtemp(`${keyRoot}.tmp-`);

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -93,6 +93,26 @@ describe("production Track B composition", () => {
     await expect(
       resolveManagedArtifactKeyFiles({ channel: "production", stateRoot }),
     ).rejects.toThrow(/incomplete.*managed artifact key/i);
+  });
+
+  test("refuses to provision replacement Message Graph keys over persisted artifact state", async () => {
+    const stateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-missing-artifact-keys-"));
+    roots.push(stateRoot);
+    const runtimeModule = await import("../src/track-b-runtime.js");
+    const resolveManagedArtifactKeyFiles = Reflect.get(
+      runtimeModule,
+      "resolveManagedArtifactKeyFiles",
+    ) as (input: { channel: "stage"; stateRoot: string }) => Promise<unknown>;
+    await mkdir(path.join(stateRoot, "artifact-store"), { recursive: true });
+    await writeFile(
+      path.join(stateRoot, "artifact-store", "metadata.sqlite"),
+      "existing encrypted graph state",
+    );
+
+    await expect(resolveManagedArtifactKeyFiles({ channel: "stage", stateRoot })).rejects.toThrow(
+      /restore.*Message Graph keys|existing.*artifact/i,
+    );
+    expect(existsSync(path.join(stateRoot, "managed-keys"))).toBe(false);
   });
 
   test("provisions stage artifact keys under durable state instead of a release secrets directory", async () => {


### PR DESCRIPTION
## Summary\n- fail closed when managed Message Graph keys are missing over persisted artifact state\n- preserve existing ciphertext for key restoration rather than silently generating replacements\n\n## Verification\n- corepack pnpm --filter @role-model-router/runtime-host-bridge exec vitest run test/track-b-runtime-composition.test.ts --reporter=verbose\n- corepack pnpm exec biome check role-model-router/apps/runtime-host-bridge/src/track-b-runtime.ts role-model-router/apps/runtime-host-bridge/test/track-b-runtime-composition.test.ts