### PR TITLE
fix(runtime): extend bounded remote readiness probes

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/remote-health-probe.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/remote-health-probe.ts
@@ -61,6 +61,8 @@ export interface RemoteEndpointAdmissionProbeContext {
   readonly probeTimeoutMs?: number;
 }
 
+export const DEFAULT_REMOTE_PROBE_TIMEOUT_MS = 15_000;
+
 const COMPARABLE_MODEL_ID_ALIASES: Readonly<Record<string, readonly string[]>> = {
   "moonshot/kimi-k2.7-code": ["kimi-for-coding"],
   "kimi-k2.7-code": ["kimi-for-coding"],
@@ -195,7 +197,7 @@ async function probeTarget(
             ? resolvedAuthorization
             : `Bearer ${resolvedAuthorization}`,
         },
-        signal: AbortSignal.timeout(context.probeTimeoutMs ?? 5000),
+        signal: AbortSignal.timeout(context.probeTimeoutMs ?? DEFAULT_REMOTE_PROBE_TIMEOUT_MS),
       });
       return {
         response,
@@ -394,7 +396,7 @@ export async function probeRemoteEndpointAdmission(
         "content-type": "application/json",
         authorization: credential.startsWith("Bearer ") ? credential : `Bearer ${credential}`,
       },
-      signal: AbortSignal.timeout(context.probeTimeoutMs ?? 5_000),
+      signal: AbortSignal.timeout(context.probeTimeoutMs ?? DEFAULT_REMOTE_PROBE_TIMEOUT_MS),
       body: JSON.stringify(body),
     });
 

--- a/role-model-router/apps/runtime-host-bridge/test/remote-endpoint-admission-probe.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/remote-endpoint-admission-probe.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from "vitest";
 
-import { probeRemoteEndpointAdmission } from "../src/remote-health-probe.js";
+import {
+  DEFAULT_REMOTE_PROBE_TIMEOUT_MS,
+  probeRemoteEndpointAdmission,
+} from "../src/remote-health-probe.js";
 
 describe("remote endpoint admission probes", () => {
+  test("uses the 15-second bounded default for remote provider readiness", () => {
+    expect(DEFAULT_REMOTE_PROBE_TIMEOUT_MS).toBe(15_000);
+  });
+
   test("uses the configured effort in a bounded OpenAI-compatible readiness request", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
 


### PR DESCRIPTION
Raises the bounded default remote readiness timeout from five to fifteen seconds for startup and admission probes. Focused runtime-host tests pass.