### PR TITLE
fix(runtime): complete bounded Track B capture

### DIFF
--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -24178,10 +24178,9 @@ export async function createRuntimeBridgeBackend(
           capability: "runtime-observation-persist",
           reason:
             routeCaptureDegradationReason ??
-            String(error instanceof Error ? error.message : "runtime observation persist failed").slice(
-              0,
-              256,
-            ),
+            String(
+              error instanceof Error ? error.message : "runtime observation persist failed",
+            ).slice(0, 256),
           routingContinues: true,
           atMs: Date.now(),
         };

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -29210,10 +29210,6 @@ export function resolveBridgeServerOptions(input: {
   const packagedProfile = readPackagedRuntimeProfile(input.executablePath);
   const profile = packagedProfile ?? resolveRuntimeChannelProfile("production");
   const statePath = resolveBridgePathApi([input.localAppData], process.env.LOCALAPPDATA);
-  const runtimeStatePath = resolveBridgePathApi(
-    [input.runtimeStateRoot, input.localAppData],
-    process.env.LOCALAPPDATA,
-  );
   const inferredRepoRoot = input.executablePath
     ? (() => {
         const executableDir = repoPath.dirname(repoPath.resolve(input.executablePath));
@@ -29245,6 +29241,13 @@ export function resolveBridgeServerOptions(input: {
     statePath.join(os.homedir(), ".local", "state");
   const runtimeStateRoot =
     input.runtimeStateRoot?.trim() || statePath.join(platformStateBase, profile.state_root_name);
+  const explicitUnifiedRuntimeConfigPath = input.unifiedRuntimeConfigPath?.trim();
+  const stateRootUnifiedRuntimeConfigPath = statePath.join(runtimeStateRoot, "runtime-config.yaml");
+  const legacyUnifiedRuntimeConfigPath = statePath.join(
+    runtimeStateRoot,
+    "state",
+    "runtime-config.yaml",
+  );
 
   return {
     host: input.host?.trim() || profile.host,
@@ -29259,7 +29262,9 @@ export function resolveBridgeServerOptions(input: {
       preferRepoRootBuild: Boolean(input.repoRoot?.trim()) || Boolean(packagedProfile),
     }),
     unifiedRuntimeConfigPath:
-      input.unifiedRuntimeConfigPath?.trim() ||
-      runtimeStatePath.join(runtimeStateRoot, "state", "runtime-config.yaml"),
+      explicitUnifiedRuntimeConfigPath ||
+      (existsSync(stateRootUnifiedRuntimeConfigPath)
+        ? stateRootUnifiedRuntimeConfigPath
+        : legacyUnifiedRuntimeConfigPath),
   };
 }

--- a/role-model-router/apps/runtime-host-bridge/src/index.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/index.ts
@@ -24070,6 +24070,7 @@ export async function createRuntimeBridgeBackend(
         | { readonly scopeId: string; readonly artifactId: string; readonly contentHash: string }
         | undefined;
       let routeCapture: Record<string, unknown> | undefined;
+      let routeCaptureDegradationReason: string | undefined;
       try {
         if (localGraphStore) {
           const content = JSON.stringify(bundle);
@@ -24116,10 +24117,25 @@ export async function createRuntimeBridgeBackend(
             };
           }
         }
-      } catch {
+      } catch (error) {
         // Capture remains non-routing-critical before graph-primary cutover.
         // Run 94 (SP2): without a graph artifact reference the SQLite row must still be
         // bounded — persist the compact degradation stub instead of the full bundle.
+        // Keep the operator receipt actionable without copying a private-boundary
+        // message, which may include untrusted capture content.
+        const status =
+          error &&
+          typeof error === "object" &&
+          "status" in error &&
+          typeof error.status === "number" &&
+          Number.isInteger(error.status)
+            ? error.status
+            : undefined;
+        routeCaptureDegradationReason =
+          status && status >= 100 && status <= 599
+            ? `track-b-capture-boundary-http-${status}`
+            : "track-b-capture-boundary-unavailable";
+        console.error("Track B route capture failed", routeCaptureDegradationReason);
       }
       const graphEvidence = routeCapture
         ? {
@@ -24160,9 +24176,12 @@ export async function createRuntimeBridgeBackend(
           schemaVersion: "role-model.degradation-receipt.v1",
           degraded: true,
           capability: "runtime-observation-persist",
-          reason: String(
-            error instanceof Error ? error.message : "runtime observation persist failed",
-          ).slice(0, 256),
+          reason:
+            routeCaptureDegradationReason ??
+            String(error instanceof Error ? error.message : "runtime observation persist failed").slice(
+              0,
+              256,
+            ),
           routingContinues: true,
           atMs: Date.now(),
         };

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -1094,7 +1094,8 @@ export function createTrackBOperations({
   const requestPrivate = (
     route: string,
     init?: { readonly method?: string; readonly body?: Record<string, unknown> },
-  ) => privateRetentionRequest(operationsEndpoint, operationsToken, route, init, operationsTimeoutMs);
+  ) =>
+    privateRetentionRequest(operationsEndpoint, operationsToken, route, init, operationsTimeoutMs);
   return {
     async readGraphMigration(): Promise<unknown> {
       const remote = await requestPrivate("graph-migration");

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -661,7 +661,10 @@ const privateRetentionRequest = async (
   token: string | undefined,
   route: string,
   init: { readonly method?: string; readonly body?: Record<string, unknown> } = {},
-  timeoutMs = 5_000,
+  // Route captures may perform bounded durable CAS and SQLite commits after the
+  // provider response. Five seconds aborts healthy local captures on mature
+  // runtimes; retain a finite budget while allowing that proven completion path.
+  timeoutMs = 8_000,
 ): Promise<unknown | null> => {
   if (!endpoint) return null;
   if (!token || token.trim().length < 24) {
@@ -1073,7 +1076,7 @@ export function createTrackBOperations({
   runtimeChannel = "development",
   operationsEndpoint = process.env.ROLE_MODEL_TRACK_B_OPERATIONS_URL?.trim(),
   operationsToken = process.env.ROLE_MODEL_TRACK_B_OPERATIONS_TOKEN,
-  operationsTimeoutMs = 5_000,
+  operationsTimeoutMs = 8_000,
   extensionRuntime,
 }: {
   readonly statePath: string;

--- a/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
+++ b/role-model-router/apps/runtime-host-bridge/src/track-b-operations.ts
@@ -661,6 +661,7 @@ const privateRetentionRequest = async (
   token: string | undefined,
   route: string,
   init: { readonly method?: string; readonly body?: Record<string, unknown> } = {},
+  timeoutMs = 5_000,
 ): Promise<unknown | null> => {
   if (!endpoint) return null;
   if (!token || token.trim().length < 24) {
@@ -668,14 +669,26 @@ const privateRetentionRequest = async (
       "Track B private operations boundary requires a launcher-issued authentication token",
     );
   }
-  const response = await fetch(new URL(route, endpoint.endsWith("/") ? endpoint : `${endpoint}/`), {
-    method: init.method ?? "GET",
-    headers: {
-      ...(init.body ? { "content-type": "application/json" } : {}),
-      authorization: `Bearer ${token}`,
-    },
-    ...(init.body ? { body: JSON.stringify(init.body) } : {}),
-  });
+  let response: Response;
+  try {
+    response = await fetch(new URL(route, endpoint.endsWith("/") ? endpoint : `${endpoint}/`), {
+      method: init.method ?? "GET",
+      headers: {
+        ...(init.body ? { "content-type": "application/json" } : {}),
+        authorization: `Bearer ${token}`,
+      },
+      ...(init.body ? { body: JSON.stringify(init.body) } : {}),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new TrackBPrivateOperationError(
+        504,
+        `private Track B operation timed out after ${timeoutMs}ms`,
+      );
+    }
+    throw error;
+  }
   const result = (await response.json().catch(() => ({}))) as { readonly error?: unknown };
   if (!response.ok)
     throw new TrackBPrivateOperationError(
@@ -1060,6 +1073,7 @@ export function createTrackBOperations({
   runtimeChannel = "development",
   operationsEndpoint = process.env.ROLE_MODEL_TRACK_B_OPERATIONS_URL?.trim(),
   operationsToken = process.env.ROLE_MODEL_TRACK_B_OPERATIONS_TOKEN,
+  operationsTimeoutMs = 5_000,
   extensionRuntime,
 }: {
   readonly statePath: string;
@@ -1067,6 +1081,8 @@ export function createTrackBOperations({
   readonly runtimeChannel?: "development" | "stage" | "production";
   readonly operationsEndpoint?: string;
   readonly operationsToken?: string;
+  /** Bounds a private sidecar operation so a dashboard request cannot wait forever. */
+  readonly operationsTimeoutMs?: number;
   readonly extensionRuntime?: {
     listExtensions(): readonly unknown[] | Promise<readonly unknown[]>;
     mutateExtension(input: Record<string, unknown>): unknown | Promise<unknown>;
@@ -1075,7 +1091,7 @@ export function createTrackBOperations({
   const requestPrivate = (
     route: string,
     init?: { readonly method?: string; readonly body?: Record<string, unknown> },
-  ) => privateRetentionRequest(operationsEndpoint, operationsToken, route, init);
+  ) => privateRetentionRequest(operationsEndpoint, operationsToken, route, init, operationsTimeoutMs);
   return {
     async readGraphMigration(): Promise<unknown> {
       const remote = await requestPrivate("graph-migration");

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -23681,7 +23681,7 @@ describe("runtime-host-bridge", () => {
       scopeId: "standalone-runtime",
       staticRoot:
         "/home/runner/work/role-model/role-model/role-model-router/apps/runtime-ui/build/client",
-      unifiedRuntimeConfigPath: "C:\\runtime-state\\state\\runtime-config.yaml",
+      unifiedRuntimeConfigPath: path.join("C:\\runtime-state", "state", "runtime-config.yaml"),
     });
   });
 

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -23621,9 +23621,15 @@ describe("runtime-host-bridge", () => {
   });
 
   test("prefers an existing state-root runtime config when a packaged launch omits the flag", async () => {
-    const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-runtime-config-default-"));
+    const runtimeStateRoot = await mkdtemp(
+      path.join(os.tmpdir(), "role-model-runtime-config-default-"),
+    );
     try {
-      await writeFile(path.join(runtimeStateRoot, "runtime-config.yaml"), 'version: "1.0"\n', "utf8");
+      await writeFile(
+        path.join(runtimeStateRoot, "runtime-config.yaml"),
+        'version: "1.0"\n',
+        "utf8",
+      );
       const result = (
         bridge as {
           resolveBridgeServerOptions: (value: {
@@ -23633,7 +23639,9 @@ describe("runtime-host-bridge", () => {
         }
       ).resolveBridgeServerOptions({ repoRoot, runtimeStateRoot });
 
-      expect(result.unifiedRuntimeConfigPath).toBe(path.join(runtimeStateRoot, "runtime-config.yaml"));
+      expect(result.unifiedRuntimeConfigPath).toBe(
+        path.join(runtimeStateRoot, "runtime-config.yaml"),
+      );
     } finally {
       await rm(runtimeStateRoot, { recursive: true, force: true });
     }

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -23620,6 +23620,25 @@ describe("runtime-host-bridge", () => {
     });
   });
 
+  test("prefers an existing state-root runtime config when a packaged launch omits the flag", async () => {
+    const runtimeStateRoot = await mkdtemp(path.join(os.tmpdir(), "role-model-runtime-config-default-"));
+    try {
+      await writeFile(path.join(runtimeStateRoot, "runtime-config.yaml"), 'version: "1.0"\n', "utf8");
+      const result = (
+        bridge as {
+          resolveBridgeServerOptions: (value: {
+            repoRoot?: string;
+            runtimeStateRoot?: string;
+          }) => { unifiedRuntimeConfigPath: string };
+        }
+      ).resolveBridgeServerOptions({ repoRoot, runtimeStateRoot });
+
+      expect(result.unifiedRuntimeConfigPath).toBe(path.join(runtimeStateRoot, "runtime-config.yaml"));
+    } finally {
+      await rm(runtimeStateRoot, { recursive: true, force: true });
+    }
+  });
+
   test("keeps repoRoot-derived static paths stable when runtimeStateRoot uses a different path dialect", () => {
     const result = (
       bridge as {

--- a/role-model-router/apps/runtime-host-bridge/test/index.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/index.test.ts
@@ -23616,7 +23616,7 @@ describe("runtime-host-bridge", () => {
       runtimeStateRoot: "C:\\runtime-state",
       scopeId: "standalone-runtime",
       staticRoot: path.join(repoRoot, "role-model-router", "apps", "runtime-ui", "build", "client"),
-      unifiedRuntimeConfigPath: "C:\\runtime-state\\state\\runtime-config.yaml",
+      unifiedRuntimeConfigPath: path.join("C:\\runtime-state", "state", "runtime-config.yaml"),
     });
   });
 

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -2061,6 +2061,35 @@ describe("Track B operations APIs", () => {
     }
   });
 
+  test("run95 bounds a stalled private storage summary instead of leaving the operator read pending", async () => {
+    const operations = createServer((_request, _response) => {
+      // Deliberately never respond: this models a stalled private sidecar.
+    });
+    await new Promise<void>((resolve, reject) => {
+      operations.once("error", reject);
+      operations.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = operations.address();
+      if (!address || typeof address === "string")
+        throw new Error("operations server did not bind");
+      const api = createTrackBOperations({
+        statePath: path.join(os.tmpdir(), `run95-stalled-storage-${Date.now()}.json`),
+        catalog: [],
+        operationsEndpoint: `http://127.0.0.1:${address.port}`,
+        operationsToken: "run95-stalled-storage-token-0001",
+        operationsTimeoutMs: 25,
+      });
+      const startedAt = Date.now();
+      await expect(api.readStorageRetention()).rejects.toThrow(/timed out/i);
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        operations.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   test("run79 mutateExtension enables disables and sets mode with audit receipts", async () => {
     const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run79-mutate-${Date.now()}`);
     roots.push(runtimeStateRoot);

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -1249,7 +1249,11 @@ describe("Track B operations APIs", () => {
       });
       migration.backfill({ scopeId: `tenant:${scopeId}`, batchSize: 10 });
       migration.enterShadowMirror({ deadlineMs: Date.now() + 10_000 });
-      migration.verifyParity({ backupVerified: true, restoreVerified: true, consumersVerified: true });
+      migration.verifyParity({
+        backupVerified: true,
+        restoreVerified: true,
+        consumersVerified: true,
+      });
       migration.cutover();
 
       const result = await backend.executeChatCompletions(
@@ -1264,7 +1268,9 @@ describe("Track B operations APIs", () => {
         capability: "runtime-observation-persist",
         reason: "track-b-capture-boundary-http-503",
       });
-      expect(readRuntimeTelemetryRecord({ databasePath, requestId: "req-track-b-capture-failure-001" })).toBeNull();
+      expect(
+        readRuntimeTelemetryRecord({ databasePath, requestId: "req-track-b-capture-failure-001" }),
+      ).toBeNull();
     } finally {
       await backend.shutdown();
       await new Promise<void>((resolve, reject) =>
@@ -2189,9 +2195,10 @@ describe("Track B operations APIs", () => {
         operationsEndpoint: `http://127.0.0.1:${address.port}`,
         operationsToken: "run95-capture-budget-token-0001",
       });
-      await expect(
-        api.recordLocalRouteCapture({ requestId: "request-1" }),
-      ).resolves.toMatchObject({ status: "captured", rootArtifactId: "artifact:test" });
+      await expect(api.recordLocalRouteCapture({ requestId: "request-1" })).resolves.toMatchObject({
+        status: "captured",
+        rootArtifactId: "artifact:test",
+      });
     } finally {
       await new Promise<void>((resolve, reject) =>
         operations.close((error) => (error ? reject(error) : resolve())),

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -2158,6 +2158,47 @@ describe("Track B operations APIs", () => {
     }
   });
 
+  test("run95 allows a bounded local route capture to complete beyond the legacy five-second budget", async () => {
+    const operations = createServer((request, response) => {
+      if (request.method !== "POST" || request.url !== "/capture/route") {
+        response.writeHead(404).end();
+        return;
+      }
+      setTimeout(() => {
+        response.writeHead(200, { "content-type": "application/json" }).end(
+          JSON.stringify({
+            status: "captured",
+            scope: "runtime:test",
+            rootArtifactId: "artifact:test",
+            rootArtifactDigest: "sha256:test",
+          }),
+        );
+      }, 5_500);
+    });
+    await new Promise<void>((resolve, reject) => {
+      operations.once("error", reject);
+      operations.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = operations.address();
+      if (!address || typeof address === "string")
+        throw new Error("operations server did not bind");
+      const api = createTrackBOperations({
+        statePath: path.join(os.tmpdir(), `run95-capture-budget-${Date.now()}.json`),
+        catalog: [],
+        operationsEndpoint: `http://127.0.0.1:${address.port}`,
+        operationsToken: "run95-capture-budget-token-0001",
+      });
+      await expect(
+        api.recordLocalRouteCapture({ requestId: "request-1" }),
+      ).resolves.toMatchObject({ status: "captured", rootArtifactId: "artifact:test" });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        operations.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   test("run79 mutateExtension enables disables and sets mode with audit receipts", async () => {
     const runtimeStateRoot = path.join(os.tmpdir(), `track-b-run79-mutate-${Date.now()}`);
     roots.push(runtimeStateRoot);

--- a/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
+++ b/role-model-router/apps/runtime-host-bridge/test/track-b-operations-api.test.ts
@@ -1205,6 +1205,74 @@ describe("Track B operations APIs", () => {
     }
   });
 
+  test("reports a bounded private capture failure instead of masking it as a graph writer error", async () => {
+    const runtimeStateRoot = path.join(os.tmpdir(), `track-b-capture-failure-${Date.now()}`);
+    roots.push(runtimeStateRoot);
+    const scopeId = "track-b-capture-failure";
+    const operations = createServer(async (request, response) => {
+      for await (const _chunk of request) {
+        // Drain the request without retaining potentially rich capture content.
+      }
+      if (request.url === "/capture/route") {
+        response.writeHead(503, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "capture service unavailable" }));
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "accepted" }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      operations.once("error", reject);
+      operations.listen(0, "127.0.0.1", resolve);
+    });
+    const address = operations.address();
+    if (!address || typeof address === "string") throw new Error("operations server did not bind");
+    const backend = await createRuntimeBridgeBackend({
+      repoRoot,
+      fixtureRoot,
+      runtimeStateRoot,
+      scopeId,
+      trackBOperationsEndpoint: `http://127.0.0.1:${address.port}`,
+      trackBOperationsToken: "c".repeat(64),
+    });
+    try {
+      const databasePath = resolveSqliteMemoryLocation({ runtimeStateRoot, scopeId });
+      const migration = new LegacySqliteMigration({
+        databasePath,
+        backupPath: path.join(runtimeStateRoot, "legacy-backup.sqlite"),
+        artifactWriter: ({ contentHash }) => ({
+          artifactId: contentHash,
+          artifactPath: `artifact://${contentHash}`,
+          contentHash,
+        }),
+        routerRoot: path.join(repoRoot, "role-model-router"),
+      });
+      migration.backfill({ scopeId: `tenant:${scopeId}`, batchSize: 10 });
+      migration.enterShadowMirror({ deadlineMs: Date.now() + 10_000 });
+      migration.verifyParity({ backupVerified: true, restoreVerified: true, consumersVerified: true });
+      migration.cutover();
+
+      const result = await backend.executeChatCompletions(
+        {
+          model: "deepseek/chat-capture-v1",
+          messages: [{ role: "user", content: "verify bounded capture failure" }],
+        },
+        "req-track-b-capture-failure-001",
+      );
+
+      expect(result.persistenceDegradation).toMatchObject({
+        capability: "runtime-observation-persist",
+        reason: "track-b-capture-boundary-http-503",
+      });
+      expect(readRuntimeTelemetryRecord({ databasePath, requestId: "req-track-b-capture-failure-001" })).toBeNull();
+    } finally {
+      await backend.shutdown();
+      await new Promise<void>((resolve, reject) =>
+        operations.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   test("legacy failure recovery retries extension closure after graph commit and propagates sidecar auth failures", async () => {
     const runtimeStateRoot = path.join(os.tmpdir(), `track-b-recovery-retry-${Date.now()}`);
     roots.push(runtimeStateRoot);

--- a/role-model-router/packages/core/src/taxonomy/index.test.ts
+++ b/role-model-router/packages/core/src/taxonomy/index.test.ts
@@ -8,15 +8,7 @@ describe("taxonomyDataRootCandidates", () => {
     const executablePath = path.join("D:", "release", "role-model-dev.exe");
 
     expect(taxonomyDataRootCandidates(executablePath)).toContain(
-      path.join(
-        "D:",
-        "release",
-        "role-model-router",
-        "packages",
-        "core",
-        "data",
-        "taxonomy",
-      ),
+      path.join("D:", "release", "role-model-router", "packages", "core", "data", "taxonomy"),
     );
   });
 });

--- a/role-model-router/packages/core/src/taxonomy/index.test.ts
+++ b/role-model-router/packages/core/src/taxonomy/index.test.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { taxonomyDataRootCandidates } from "./index.js";
+
+describe("taxonomyDataRootCandidates", () => {
+  test("R95 resolves the taxonomy staged next to a packaged executable", () => {
+    const executablePath = path.join("D:", "release", "role-model-dev.exe");
+
+    expect(taxonomyDataRootCandidates(executablePath)).toContain(
+      path.join(
+        "D:",
+        "release",
+        "role-model-router",
+        "packages",
+        "core",
+        "data",
+        "taxonomy",
+      ),
+    );
+  });
+});

--- a/role-model-router/packages/core/src/taxonomy/index.ts
+++ b/role-model-router/packages/core/src/taxonomy/index.ts
@@ -152,11 +152,21 @@ function readArgValue(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-const taxonomyDataRootCandidates = (): string[] => {
+export const taxonomyDataRootCandidates = (executablePath = process.execPath): string[] => {
   const explicitRoot = process.env.ROLE_MODEL_TAXONOMY_DATA_ROOT;
   const repoRoot = readArgValue("--repo-root") ?? process.env.ROLE_MODEL_REPO_ROOT;
   return [
     ...(explicitRoot ? [explicitRoot] : []),
+    // A SEA executable has no source checkout to resolve from. Packaging stages this
+    // directory beside the executable, so prefer that self-contained release path.
+    path.join(
+      path.dirname(executablePath),
+      "role-model-router",
+      "packages",
+      "core",
+      "data",
+      "taxonomy",
+    ),
     ...(repoRoot
       ? [path.join(repoRoot, "role-model-router", "packages", "core", "data", "taxonomy")]
       : []),


### PR DESCRIPTION
## Summary
- Bound packaged Track B capture operations while preserving explicit degradation reasons.
- Resolve packaged runtime configuration and taxonomy strictly from the staged runtime tree.
- Pair with private Track B reconciliation work for the same release candidate.

## Verification
- Rebuilt exact development artifact on :3458.
- Pi CLI request through configured controller.remote-only alias linked to its telemetry and routing decision with the max variant identity.
- Durable readback verified every Track B extension and public runtime:test-critical passed locally.

Private companion: https://github.com/try-works/role-model-internal/pull/88.