### PR TITLE
fix(release): bind Stage packaging to exact private head

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -327,8 +327,9 @@ jobs:
             exit 1
           fi
           git fetch --no-tags origin "+refs/heads/${REQUIRED_PRIVATE_BRANCH}:refs/remotes/origin/${REQUIRED_PRIVATE_BRANCH}"
-          if ! git merge-base --is-ancestor "$RELEASE_PRIVATE_SHA" "origin/$REQUIRED_PRIVATE_BRANCH"; then
-            echo "Private revision must be promoted through role-model-internal/$REQUIRED_PRIVATE_BRANCH before $ROLE_MODEL_BUILD_CHANNEL packaging."
+          required_private_head="$(git rev-parse "origin/$REQUIRED_PRIVATE_BRANCH")"
+          if [[ "$RELEASE_PRIVATE_SHA" != "$required_private_head" ]]; then
+            echo "Paired private revision must equal the current role-model-internal/$REQUIRED_PRIVATE_BRANCH head before $ROLE_MODEL_BUILD_CHANNEL packaging."
             exit 1
           fi
 

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -54,7 +54,8 @@ test("the public release orchestrator enforces paired private promotion", () => 
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /Verify private revision passed paired promotion branch/);
   assert.match(workflow, /REQUIRED_PRIVATE_BRANCH:[\s\S]*?'main'[\s\S]*?'stage'/);
-  assert.match(workflow, /git merge-base --is-ancestor/);
+  assert.match(workflow, /required_private_head="\$\(git rev-parse "origin\/\$REQUIRED_PRIVATE_BRANCH"\)"/);
+  assert.match(workflow, /\[\[ "\$RELEASE_PRIVATE_SHA" != "\$required_private_head" \]\]/);
 });
 
 test("paired private checkout never dirties the public package provenance worktree", () => {

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -54,7 +54,10 @@ test("the public release orchestrator enforces paired private promotion", () => 
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /Verify private revision passed paired promotion branch/);
   assert.match(workflow, /REQUIRED_PRIVATE_BRANCH:[\s\S]*?'main'[\s\S]*?'stage'/);
-  assert.match(workflow, /required_private_head="\$\(git rev-parse "origin\/\$REQUIRED_PRIVATE_BRANCH"\)"/);
+  assert.match(
+    workflow,
+    /required_private_head="\$\(git rev-parse "origin\/\$REQUIRED_PRIVATE_BRANCH"\)"/,
+  );
   assert.match(workflow, /\[\[ "\$RELEASE_PRIVATE_SHA" != "\$required_private_head" \]\]/);
 });
 


### PR DESCRIPTION
## Summary\n- reject a paired private revision that is merely an ancestor of the required promotion branch\n- require equality with the current paired private Stage/main head\n- add a repository-owned workflow contract regression\n\n## Verification\n- 
ode --test scripts/build-binaries-workflow.test.mjs\n\nThis fixes the provenance mismatch found in published Stage RC stage-rc-142dbfa35981.